### PR TITLE
chore: update MCP transport and enhance configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# arclith — Copilot Instructions
+
+Lib PyPI `arclith` v0.2.1 : framework hexagonal réutilisable (domain/ports/adapters/infra). Lire `AGENTS.md` local.
+
+## Règles spécifiques à ce repo
+
+- Ce repo est une **lib publiée sur PyPI** — tout import applicatif (recette, ingrédient…) est interdit dans `arclith/`.
+- `domain/` doit rester pur : zéro import externe hormis `pydantic` et `uuid6`.
+- Tout ajout d'adaptateur doit être référencé dans `build_repository()` (`infrastructure/repository_factory.py`).
+- Couverture de tests : **≥ 90 %** — vérifier avec `make coverage`.
+- Optional-deps groupés : `mongodb`, `duckdb`, `fastapi`, `mcp`, `all` — ne pas ajouter de dépendances au groupe de
+  base.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md — framework (`arclith`)
+
+## Contexte global
+
+`arclith` est le framework hexagonal partagé par tous les repos de Rekipe. Il est publié sur PyPI (`arclith>=0.2.0`) et
+ne doit contenir aucune logique métier. Les repos consommateurs (`recipe/`, `_sample/`) l'importent en dépendance.
+
+## Rôle
+
+Fournir les primitives réutilisables pour construire des services en architecture hexagonale :
+
+- Modèle de base `Entity` (UUIDv7, audit, soft-delete, optimistic locking)
+- Port `Repository[T]` (CRUD async + `find_deleted` + `duplicate`)
+- `BaseService[T]` qui câble les use cases standards
+- `Arclith` : bootstrap, config, FastAPI, FastMCP, Uvicorn
+- Trois implémentations de `Repository` : memory, MongoDB (motor), DuckDB
+
+## Règles de développement
+
+- **Pas d'import applicatif** dans `arclith/` — zéro référence à un domaine métier.
+- `domain/` n'importe que `pydantic` et `uuid6`.
+- Tout nouveau adaptateur doit être branché dans `build_repository()`.
+- Dépendances groupées : installer uniquement ce qui est nécessaire (`[mongodb]`, `[duckdb]`, `[fastapi]`, `[mcp]`,
+  `[all]`).
+- Coverage **≥ 90 %** : `make coverage`.
+- Pre-commit gate : `make precommit` (lint + typecheck + security).
+
+## Architecture
+
+```
+arclith/
+  domain/
+    models/entity.py          # Entity (UUIDv7, audit, soft-delete, version)
+    ports/repository.py       # Repository[T] (ABC, CRUD + find_deleted + duplicate)
+    ports/logger.py           # Logger (ABC)
+  application/
+    use_cases/                # CreateUseCase, ReadUseCase, UpdateUseCase, DeleteUseCase,
+                              # FindAllUseCase, DuplicateUseCase, PurgeUseCase
+    services/base_service.py  # BaseService[T] — câble les 7 use cases
+  adapters/
+    context.py                # set_tenant_uri / get_tenant_uri (ContextVar multitenant)
+    input/fastmcp/dependencies.py  # make_inject_tenant_uri()
+    output/
+      memory/repository.py    # InMemoryRepository[T]
+      mongodb/repository.py   # MongoDBRepository[T] (motor)
+      mongodb/config.py       # MongoDBConfig
+      duckdb/repository.py    # DuckDBRepository[T]
+      console/logger.py       # ConsoleLogger (loguru)
+  infrastructure/
+    config.py                 # AppConfig + load_config() — valide config.yaml
+    repository_factory.py     # build_repository(config, entity_class, logger)
+  arclith.py                  # Arclith — point d'entrée unique
+```
+
+### Flux de données
+
+```
+config.yaml → load_config() → AppConfig
+Arclith.__init__(config_path)
+  └─ .repository(entity_class) → build_repository() → InMemory|MongoDB|DuckDB Repository
+  └─ .fastapi(**kwargs) → FastAPI avec lifespan
+  └─ .fastmcp(name) → FastMCP
+  └─ .run_api() / .run_mcp_sse() / .run_mcp_stdio() / .run_mcp_http()
+```
+
+## Primitives détaillées
+
+### `Entity` (`domain/models/entity.py`)
+
+| Champ                       | Type               | Description                        |
+|-----------------------------|--------------------|------------------------------------|
+| `uuid`                      | `UUID` (v7)        | ID time-ordered, auto-généré       |
+| `created_at` / `updated_at` | `datetime` UTC     | Audit temporel                     |
+| `created_by` / `updated_by` | `str \| None`      | Audit acteur                       |
+| `deleted_at` / `deleted_by` | `datetime \| None` | Soft-delete                        |
+| `version`                   | `int` (défaut 1)   | Optimistic locking                 |
+| `is_deleted`                | property           | `True` si `deleted_at is not None` |
+
+### `Repository[T]` (`domain/ports/repository.py`)
+
+Méthodes abstraites : `create`, `read`, `update`, `delete`, `find_all`, `find_deleted`, `duplicate`.
+
+### `BaseService[T]` (`application/services/base_service.py`)
+
+Constructeur : `__init__(repository, logger, retention_days=None)`.  
+Méthodes publiques : `create`, `read`, `update`, `delete`, `find_all`, `duplicate`, `purge`.
+
+### `Arclith` (`arclith.py`)
+
+| Méthode                     | Retour          | Usage                              |
+|-----------------------------|-----------------|------------------------------------|
+| `.repository(entity_class)` | `Repository[T]` | Instancie via `build_repository()` |
+| `.fastapi(**kwargs)`        | `FastAPI`       | Crée l'app avec lifespan           |
+| `.fastmcp(name)`            | `FastMCP`       | Crée le serveur MCP                |
+| `.run_api(app)`             | —               | Lance Uvicorn (config `api:`)      |
+| `.run_mcp_stdio(mcp)`       | —               | Transport stdio                    |
+| `.run_mcp_sse(mcp)`         | —               | Transport SSE (config `mcp:`)      |
+| `.run_mcp_http(mcp)`        | —               | Transport streamable-HTTP          |
+
+### `AppConfig` (`infrastructure/config.py`)
+
+Sections validées depuis `config.yaml` :
+
+| Section       | Clés notables                                                                                        |
+|---------------|------------------------------------------------------------------------------------------------------|
+| `adapters`    | `repository` (memory/mongodb/duckdb), `multitenant`, `mongodb.uri`, `mongodb.db_name`, `duckdb.path` |
+| `api`         | `host`, `port`, `reload`                                                                             |
+| `mcp`         | `host`, `port`                                                                                       |
+| `soft_delete` | `retention_days` (None = ∞, 0 = immédiat)                                                            |
+
+## Conventions
+
+- Nommage adaptateurs output : `InMemory<Entity>Repository`, `MongoDB<Entity>Repository`, `DuckDB<Entity>Repository`.
+- Logger injecté partout — jamais `print()` ni `logging` directement dans les use cases.
+- `PurgeUseCase` : supprime physiquement les entités dont `deleted_at` est dépassé de `retention_days` jours.
+
+## Commandes utiles
+
+```bash
+make setup       # uv sync --group dev --extra all
+make precommit   # lint + typecheck + security
+make quality     # lint + security + complexity + typecheck + coverage (≥90 %)
+make test        # pytest -v
+```
+
+## Fichiers à lire en premier
+
+1. `arclith/domain/models/entity.py` — comprendre la base de toute entité
+2. `arclith/domain/ports/repository.py` — le contrat de persistance
+3. `arclith/application/services/base_service.py` — les use cases câblés
+4. `arclith/infrastructure/config.py` — la config validée
+5. `arclith/infrastructure/repository_factory.py` — le routage des implémentations
+

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,105 @@
+# SKILLS.md — framework (`arclith`)
+
+## SK-F01 — Ajouter un adaptateur de persistance
+
+**Contexte :** implémenter un nouveau backend de stockage (ex. Redis, PostgreSQL).
+
+### Étapes
+
+1. **Créer** `arclith/adapters/output/<backend>/repository.py`
+    - Sous-classer `Repository[T]` (ou `InMemoryRepository` pour partir d'une base)
+    - Implémenter les 7 méthodes abstraites : `create`, `read`, `update`, `delete`, `find_all`, `find_deleted`,
+      `duplicate`
+
+2. **Brancher** dans `arclith/infrastructure/repository_factory.py`
+   ```python
+   case "<backend>":
+       from arclith.adapters.output.<backend>.repository import <Backend>Repository
+       return <Backend>Repository(...)
+   ```
+
+3. **Config** — ajouter la nouvelle valeur dans le `Literal` de `AdaptersSettings.repository` (
+   `infrastructure/config.py`)
+
+4. **Optional-dep** — ajouter le groupe dans `pyproject.toml` :
+   ```toml
+   [project.optional-dependencies]
+   <backend> = ["<package>==x.y.z"]
+   ```
+
+5. **Tests** — `tests/units/adapters/output/<backend>/test_repository.py` : coverage ≥ 90 %
+
+### Validation
+
+```bash
+make coverage
+```
+
+---
+
+## SK-F02 — Étendre `Entity` avec un nouveau champ commun
+
+**Contexte :** ajouter un champ partagé par toutes les entités (ex. `tenant_id`).
+
+### Étapes
+
+1. `arclith/domain/models/entity.py` — ajouter le champ avec valeur par défaut
+2. Vérifier que tous les adaptateurs existants (MongoDB, DuckDB, memory) gèrent le champ
+3. Mettre à jour les tests unitaires de `Entity`
+4. Bump de version mineure dans `pyproject.toml`
+
+### Validation
+
+```bash
+make test
+make coverage
+```
+
+---
+
+## SK-F03 — Ajouter une méthode de requête au port `Repository`
+
+**Contexte :** ajouter une méthode de recherche (ex. `find_by_name`) au contrat de base.
+
+### Étapes
+
+1. `arclith/domain/ports/repository.py` — déclarer la méthode abstraite
+2. Implémenter dans **chacun** des adaptateurs : `InMemoryRepository`, `MongoDBRepository`, `DuckDBRepository`
+3. Ajouter dans `BaseService` si elle doit être exposée comme use case standard
+4. Mettre à jour les tests de chaque adaptateur
+
+> ⚠️ Un ajout au port de base est un **breaking change** : tous les sous-classeurs existants doivent l'implémenter.
+> Préférer un port spécialisé dans le repo consommateur si la méthode n'est pas universelle.
+
+### Validation
+
+```bash
+make test
+make typecheck
+```
+
+---
+
+## SK-F04 — Configurer le mode multitenant
+
+**Contexte :** permettre l'isolation par tenant via `ContextVar`.
+
+### Étapes côté framework (déjà implémenté)
+
+- `arclith/adapters/context.py` : `set_tenant_uri(uri)` / `get_tenant_uri()`
+- `arclith/adapters/input/fastmcp/dependencies.py` : `make_inject_tenant_uri(config)`
+
+### Étapes côté implémenteur
+
+1. `config.yaml` : `adapters.multitenant: true`
+2. Dans l'adapter d'entrée, avant chaque appel :
+   ```python
+   from arclith.adapters.context import set_tenant_uri
+   set_tenant_uri(uri_resolved_from_request)
+   ```
+3. `MongoDBRepository` appelle `get_tenant_uri()` automatiquement si `multitenant=true`.
+
+### Validation
+
+- Test unitaire avec deux URIs distinctes : vérifier que les collections MongoDB ciblées sont différentes.
+

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,109 @@
+# docs/decisions.md — framework (`arclith`)
+
+## ADR-001 — UUIDv7 comme identifiant d'entité
+
+**Contexte :** Choix de l'algorithme d'ID pour les entités.
+
+**Décision :** UUIDv7 via la bibliothèque `uuid6`.
+
+**Pourquoi pas l'alternative évidente (UUIDv4) :**
+UUIDv4 est aléatoire — pas d'ordre temporel, ce qui dégrade les index B-tree (MongoDB, DuckDB) et rend le tri par ID
+impossible. UUIDv7 est ordonné par le temps à la milliseconde, combine les avantages d'un ULID et d'un UUID standard.
+
+**Conséquence sur le code :**
+
+- `Entity.uuid` est de type `uuid6.UUID`, pas `uuid.UUID` stdlib.
+- Les adaptateurs MongoDB stockent l'UUID en string pour compatibilité.
+- `@field_validator("uuid", mode="before")` sur `Entity` coerce automatiquement les strings en `UUID`.
+
+---
+
+## ADR-002 — Pydantic v2 comme système de modèles
+
+**Contexte :** Validation et sérialisation des entités et de la config.
+
+**Décision :** Pydantic v2 (`pydantic==2.x`), `BaseModel` avec `ConfigDict`.
+
+**Pourquoi pas l'alternative évidente (dataclasses stdlib) :**
+Les dataclasses n'ont pas de validation automatique des types à l'instanciation, pas de sérialisation JSON intégrée, pas
+de `field_validator`. Pydantic v2 offre la validation au runtime et est le standard de l'écosystème FastAPI.
+
+**Conséquence sur le code :**
+
+- `Entity` étend `BaseModel`, pas `dataclass`.
+- `model_config = ConfigDict(arbitrary_types_allowed=True)` pour accepter `uuid6.UUID`.
+- Les `@field_validator` utilisent `mode="before"` pour la coercion.
+
+---
+
+## ADR-003 — Soft-delete par champ `deleted_at`
+
+**Contexte :** Suppression logique des entités sans perte de données.
+
+**Décision :** Champ `deleted_at: datetime | None` sur `Entity`. Suppression physique différée via `PurgeUseCase` selon
+`retention_days`.
+
+**Pourquoi pas l'alternative évidente (champ booléen `is_deleted`) :**
+Un booléen ne porte pas d'information temporelle. `deleted_at` permet de calculer le délai de rétention sans champ
+supplémentaire et de trier les suppressions par date.
+
+**Conséquence sur le code :**
+
+- `find_all()` filtre automatiquement les entités où `deleted_at is not None`.
+- `find_deleted()` retourne uniquement les supprimées.
+- `PurgeUseCase` supprime physiquement celles dont `deleted_at + retention_days < now`.
+- `retention_days: null` = conservation infinie ; `0` = suppression immédiate (pas de soft-delete).
+
+---
+
+## ADR-004 — Optimistic locking via champ `version`
+
+**Contexte :** Prévenir les écritures concurrentes conflictuelles.
+
+**Décision :** Champ `version: int = 1` incrémenté à chaque `update`.
+
+**Pourquoi pas l'alternative évidente (pessimistic locking / transactions) :**
+Les transactions MongoDB ont un surcoût significatif. L'optimistic locking est suffisant pour les volumes cibles et
+évite les deadlocks dans un contexte async.
+
+**Conséquence sur le code :**
+
+- Les adaptateurs `update()` doivent incrémenter `version` avant persistance.
+- Les clients qui soumettent une version obsolète recevront un conflit (à implémenter dans les use cases si nécessaire).
+
+---
+
+## ADR-005 — DuckDB comme adaptateur fichier plutôt que SQLite
+
+**Contexte :** Persistance légère sans serveur pour le dev et les sandboxes.
+
+**Décision :** DuckDB via `duckdb==1.5.0`, formats supportés : `.csv`, `.parquet`, `.json`, `.arrow`.
+
+**Pourquoi pas l'alternative évidente (SQLite) :**
+DuckDB est orienté analytique et supporte nativement Parquet, Arrow et CSV sans ORM. Il est plus adapté à des exports de
+données et à la lecture de fichiers plats. SQLite nécessiterait un ORM ou du SQL manuel.
+
+**Conséquence sur le code :**
+
+- `DuckDBSettings.path` valide l'extension : seuls `.csv`, `.parquet`, `.json`, `.arrow` sont acceptés (ou un dossier).
+- `DuckDBRepository[T]` reconstruit les entités depuis les colonnes du fichier.
+- Pas de migrations : le schéma est inféré depuis le modèle Pydantic.
+
+---
+
+## ADR-006 — FastMCP comme couche MCP plutôt qu'une implémentation manuelle
+
+**Contexte :** Exposer les services via le Model Context Protocol.
+
+**Décision :** `fastmcp>=3.1.0` avec trois transports : stdio, SSE, streamable-HTTP.
+
+**Pourquoi pas l'alternative évidente (implémentation MCP manuelle) :**
+FastMCP gère la sérialisation, le routing et les transports. Une implémentation manuelle serait fragile et ne suivrait
+pas les évolutions du spec MCP.
+
+**Conséquence sur le code :**
+
+- `Arclith.fastmcp(name)` retourne un `FastMCP` instance.
+- Les tools sont enregistrés via `@mcp.tool` (décorateur) à l'intérieur des classes `*MCP`.
+- `run_mcp_sse()` et `run_mcp_http()` lisent `config.mcp.host` / `config.mcp.port`.
+


### PR DESCRIPTION
- Changed MCP transport from "streamable_http" to "http" for better compatibility.
- Updated the URL in the configuration to reflect the new MCP service endpoint.
- Added a .dockerignore file to exclude unnecessary files from the Docker build context.
- Introduced new documentation files for better guidance on usage and development practices. These changes aim to streamline the development process and improve the overall architecture.