### PR TITLE
feat: HTTP conventions, MCP organization, app.description + bump to v0.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,6 @@ Lib PyPI `arclith` v0.2.1 : framework hexagonal réutilisable (domain/ports/adap
 - `domain/` doit rester pur : zéro import externe hormis `pydantic` et `uuid6`.
 - Tout ajout d'adaptateur doit être référencé dans `build_repository()` (`infrastructure/repository_factory.py`).
 - Couverture de tests : **≥ 90 %** — vérifier avec `make coverage`.
-- Optional-deps groupés : `mongodb`, `duckdb`, `fastapi`, `mcp`, `all` — ne pas ajouter de dépendances au groupe de
-  base.
+- Optional-deps groupés : `mongodb`, `duckdb`, `fastapi`, `mcp`, `all` — ne pas ajouter de dépendances au groupe de base.
+- **HTTP Status Codes** : toujours déclarer explicitement `status_code` et `responses` dans FastAPI. Voir `docs/http-conventions.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Fournir les primitives réutilisables pour construire des services en architectu
   `[all]`).
 - Coverage **≥ 90 %** : `make coverage`.
 - Pre-commit gate : `make precommit` (lint + typecheck + security).
+- **HTTP Status Codes** : toujours déclarer explicitement `status_code` et `responses` dans FastAPI. Voir `docs/http-conventions.md`.
 
 ## Architecture
 
@@ -130,4 +131,5 @@ make test        # pytest -v
 3. `arclith/application/services/base_service.py` — les use cases câblés
 4. `arclith/infrastructure/config.py` — la config validée
 5. `arclith/infrastructure/repository_factory.py` — le routage des implémentations
+6. `docs/http-conventions.md` — status codes HTTP/REST SOTA
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.1] — 2026-03-27
+
+### Added
+
+- **AppSettings.description** — New optional field in `app:` section of `config.yaml` for API description. Automatically injected into FastAPI Swagger/OpenAPI documentation via `arclith.fastapi()`. Default: `"API service built with arclith framework"`.
+
+### Changed
+
+- **FastAPI metadata injection** — `arclith.fastapi()` now automatically injects `title`, `version`, and `description` from `config.app.*` if not explicitly provided in kwargs. This enables centralized API metadata management through config.yaml.
+
+---
+
 ## [0.6.0] — 2026-03-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.0] — 2026-03-27
+
+### Changed
+
+- **request_id uses UUIDv7** — `ResponseMetadata.request_id` now uses UUIDv7 (time-ordered) instead of UUIDv4 for better traceability and chronological sorting. This aligns with the framework's `Entity.uuid` convention.
+
+---
+
 ## [0.4.0] — 2026-03-26
 
 ### Added

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -261,9 +261,17 @@ adapters/
         recipe_tools.py
         ...
       tools.py                   # Register tools (point d'entrée)
+      prompts/
+        __init__.py              # Export tous les prompts
+        ingredient_prompts.py
+        recipe_prompts.py
+        ...
+      resources/
+        __init__.py              # Export toutes les resources
+        ingredient_resources.py
+        recipe_resources.py
+        ...
       dependencies.py
-      prompts.py                 # Prompts MCP (optionnel)
-      resources.py               # Resources MCP (optionnel)
 ```
 
 ### Étapes de migration
@@ -272,12 +280,17 @@ adapters/
    ```bash
    mkdir -p adapters/input/fastapi/routers
    mkdir -p adapters/input/fastmcp/tools
+   mkdir -p adapters/input/fastmcp/prompts
+   mkdir -p adapters/input/fastmcp/resources
    ```
 
 2. **Déplacer les fichiers** :
    ```bash
    mv adapters/input/fastapi/*_router.py adapters/input/fastapi/routers/
    mv adapters/input/fastmcp/*_tools.py adapters/input/fastmcp/tools/
+   # Renommer et déplacer les fichiers prompts et resources
+   mv adapters/input/fastmcp/prompts.py adapters/input/fastmcp/prompts/ingredient_prompts.py
+   mv adapters/input/fastmcp/resources.py adapters/input/fastmcp/resources/ingredient_resources.py
    ```
 
 3. **Créer les `__init__.py`** :
@@ -296,14 +309,36 @@ adapters/
    
    __all__ = ["IngredientMCP", "RecipeMCP"]
    ```
+   
+   ```python
+   # adapters/input/fastmcp/prompts/__init__.py
+   from adapters.input.fastmcp.prompts.ingredient_prompts import IngredientPrompts
+   from adapters.input.fastmcp.prompts.recipe_prompts import RecipePrompts
+   
+   __all__ = ["IngredientPrompts", "RecipePrompts"]
+   ```
+   
+   ```python
+   # adapters/input/fastmcp/resources/__init__.py
+   from adapters.input.fastmcp.resources.ingredient_resources import IngredientResources
+   from adapters.input.fastmcp.resources.recipe_resources import RecipeResources
+   
+   __all__ = ["IngredientResources", "RecipeResources"]
+   ```
 
-4. **Mettre à jour les imports** dans `router.py` et `tools.py` :
+4. **Mettre à jour les imports** dans `router.py`, `tools.py`, `main.py`, etc. :
    ```python
    # Avant
    from adapters.input.fastapi.ingredient_router import IngredientRouter
+   from adapters.input.fastmcp.ingredient_tools import IngredientMCP
+   from adapters.input.fastmcp.prompts import IngredientPrompts
+   from adapters.input.fastmcp.resources import IngredientResources
    
    # Après
    from adapters.input.fastapi.routers import IngredientRouter
+   from adapters.input.fastmcp.tools import IngredientMCP
+   from adapters.input.fastmcp.prompts import IngredientPrompts
+   from adapters.input.fastmcp.resources import IngredientResources
    ```
 
 5. **Mettre à jour les tests** qui importent ces modules :

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -113,7 +113,7 @@ make typecheck
 
 1. **Lire** `docs/http-conventions.md` — connaître les status codes standards
 
-2. **Créer** `adapters/input/fastapi/<entity>_router.py` :
+2. **Créer** `adapters/input/fastapi/routers/<entity>_router.py` :
    ```python
    class <Entity>Router:
        def __init__(self, service: <Entity>Service, logger: Logger) -> None:
@@ -201,9 +201,25 @@ make typecheck
            )
    ```
 
-3. **Handlers** — lever `HTTPException(status_code=404, detail="...")` si `service.read()` retourne `None`
+3. **Export** — ajouter dans `adapters/input/fastapi/routers/__init__.py` :
+   ```python
+   from adapters.input.fastapi.routers.<entity>_router import <Entity>Router
+   
+   __all__ = ["<Entity>Router", ...]
+   ```
 
-4. **Validation** — tester avec `pytest` + `TestClient` :
+4. **Register** — importer et enregistrer dans `adapters/input/fastapi/router.py` :
+   ```python
+   from adapters.input.fastapi.routers import <Entity>Router
+   
+   def register_routers(app: FastAPI, arclith: Arclith) -> None:
+       service, logger = build_<entity>_service(arclith)
+       app.include_router(<Entity>Router(service, logger).router)
+   ```
+
+5. **Handlers** — lever `HTTPException(status_code=404, detail="...")` si `service.read()` retourne `None`
+
+6. **Validation** — tester avec `pytest` + `TestClient` :
    - Vérifier chaque status code (201, 200, 204, 404, 400)
    - Vérifier que PUT/PATCH/DELETE retournent body vide (`None`)
    - Vérifier que GET list retourne 200 + `[]` si vide (pas 404)
@@ -217,4 +233,110 @@ make test
 ### Références
 
 - `docs/http-conventions.md` — conventions complètes
-- `_sample/adapters/input/fastapi/ingredient_router.py` — exemple de référence
+- `_sample/adapters/input/fastapi/routers/ingredient_router.py` — exemple de référence
+
+---
+
+## SK-F06 — Organiser routers FastAPI et tools MCP en sous-dossiers
+
+**Contexte :** structurer les adapters d'entrée pour gérer plusieurs entités proprement.
+
+### Structure recommandée
+
+```
+adapters/
+  input/
+    fastapi/
+      routers/
+        __init__.py              # Export tous les routers
+        ingredient_router.py
+        recipe_router.py
+        ...
+      router.py                  # Register routers (point d'entrée)
+      dependencies.py
+    fastmcp/
+      tools/
+        __init__.py              # Export tous les tools
+        ingredient_tools.py
+        recipe_tools.py
+        ...
+      tools.py                   # Register tools (point d'entrée)
+      dependencies.py
+      prompts.py                 # Prompts MCP (optionnel)
+      resources.py               # Resources MCP (optionnel)
+```
+
+### Étapes de migration
+
+1. **Créer les sous-dossiers** :
+   ```bash
+   mkdir -p adapters/input/fastapi/routers
+   mkdir -p adapters/input/fastmcp/tools
+   ```
+
+2. **Déplacer les fichiers** :
+   ```bash
+   mv adapters/input/fastapi/*_router.py adapters/input/fastapi/routers/
+   mv adapters/input/fastmcp/*_tools.py adapters/input/fastmcp/tools/
+   ```
+
+3. **Créer les `__init__.py`** :
+   ```python
+   # adapters/input/fastapi/routers/__init__.py
+   from adapters.input.fastapi.routers.ingredient_router import IngredientRouter
+   from adapters.input.fastapi.routers.recipe_router import RecipeRouter
+   
+   __all__ = ["IngredientRouter", "RecipeRouter"]
+   ```
+   
+   ```python
+   # adapters/input/fastmcp/tools/__init__.py
+   from adapters.input.fastmcp.tools.ingredient_tools import IngredientMCP
+   from adapters.input.fastmcp.tools.recipe_tools import RecipeMCP
+   
+   __all__ = ["IngredientMCP", "RecipeMCP"]
+   ```
+
+4. **Mettre à jour les imports** dans `router.py` et `tools.py` :
+   ```python
+   # Avant
+   from adapters.input.fastapi.ingredient_router import IngredientRouter
+   
+   # Après
+   from adapters.input.fastapi.routers import IngredientRouter
+   ```
+
+5. **Mettre à jour les tests** qui importent ces modules :
+   ```python
+   # Avant
+   from adapters.input.fastapi.ingredient_router import IngredientRouter
+   
+   # Après
+   from adapters.input.fastapi.routers import IngredientRouter
+   ```
+
+6. **Corriger les `patch()` dans les tests MCP** :
+   ```python
+   # Avant
+   patch("adapters.input.fastmcp.ingredient_tools.inject_tenant_uri")
+   
+   # Après
+   patch("adapters.input.fastmcp.tools.ingredient_tools.inject_tenant_uri")
+   ```
+
+### Validation
+
+```bash
+make test
+```
+
+### Avantages
+
+- ✅ Scalable : ajouter de nouvelles entités n'encombre pas le dossier parent
+- ✅ Cohérent : même structure pour FastAPI et FastMCP
+- ✅ Explicite : les `__init__.py` documentent ce qui est public
+- ✅ Standard : pattern courant dans les projets Python
+
+### Références
+
+- `_sample/adapters/input/` — implémentation de référence

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -266,11 +266,13 @@ adapters/
         ingredient_prompts.py
         recipe_prompts.py
         ...
+      prompts.py                 # Register prompts (point d'entrée)
       resources/
         __init__.py              # Export toutes les resources
         ingredient_resources.py
         recipe_resources.py
         ...
+      resources.py               # Register resources (point d'entrée)
       dependencies.py
 ```
 
@@ -359,6 +361,45 @@ adapters/
    patch("adapters.input.fastmcp.tools.ingredient_tools.inject_tenant_uri")
    ```
 
+7. **Créer les fichiers register pour prompts et resources** :
+   ```python
+   # adapters/input/fastmcp/prompts.py
+   import fastmcp
+   from arclith import Arclith
+   from adapters.input.fastmcp.prompts import IngredientPrompts
+   from infrastructure.ingredient_container import build_ingredient_service
+   
+   def register_prompts(mcp: fastmcp.FastMCP, arclith: Arclith) -> None:
+       service, logger = build_ingredient_service(arclith)
+       IngredientPrompts(service, logger, mcp)
+   ```
+   
+   ```python
+   # adapters/input/fastmcp/resources.py
+   import fastmcp
+   from arclith import Arclith
+   from adapters.input.fastmcp.resources import IngredientResources
+   from infrastructure.ingredient_container import build_ingredient_service
+   
+   def register_resources(mcp: fastmcp.FastMCP, arclith: Arclith) -> None:
+       service, logger = build_ingredient_service(arclith)
+       IngredientResources(service, logger, mcp)
+   ```
+
+8. **Mettre à jour main.py** :
+   ```python
+   # Imports
+   from adapters.input.fastmcp.tools import register_tools
+   from adapters.input.fastmcp.prompts import register_prompts
+   from adapters.input.fastmcp.resources import register_resources
+   
+   # Dans la fonction MCP runner
+   mcp = arclith.fastmcp("MyApp")
+   register_tools(mcp, arclith)
+   register_prompts(mcp, arclith)
+   register_resources(mcp, arclith)
+   ```
+
 ### Validation
 
 ```bash
@@ -368,8 +409,8 @@ make test
 ### Avantages
 
 - ✅ Scalable : ajouter de nouvelles entités n'encombre pas le dossier parent
-- ✅ Cohérent : même structure pour FastAPI et FastMCP
-- ✅ Explicite : les `__init__.py` documentent ce qui est public
+- ✅ Cohérent : même structure pour FastAPI et FastMCP (router.py ↔ tools.py/prompts.py/resources.py)
+- ✅ Explicite : les `__init__.py` documentent ce qui est public, les register_*() centralisent l'enregistrement
 - ✅ Standard : pattern courant dans les projets Python
 
 ### Références

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -103,3 +103,118 @@ make typecheck
 
 - Test unitaire avec deux URIs distinctes : vérifier que les collections MongoDB ciblées sont différentes.
 
+---
+
+## SK-F05 — Créer un router FastAPI conforme aux conventions HTTP
+
+**Contexte :** exposer une nouvelle entité via REST avec les status codes SOTA.
+
+### Étapes
+
+1. **Lire** `docs/http-conventions.md` — connaître les status codes standards
+
+2. **Créer** `adapters/input/fastapi/<entity>_router.py` :
+   ```python
+   class <Entity>Router:
+       def __init__(self, service: <Entity>Service, logger: Logger) -> None:
+           self._service = service
+           self._logger = logger
+           self.router = APIRouter(prefix="/v1/<entities>", tags=["<entities>"])
+           self._register_routes()
+
+       def _register_routes(self) -> None:
+           # POST — Create (201)
+           self.router.add_api_route(
+               methods=["POST"],
+               path="/",
+               endpoint=self.create_<entity>,
+               summary="Create <entity>",
+               response_model=<Entity>CreatedSchema,
+               status_code=201,  # ✅ Explicite
+               responses={
+                   400: {"description": "Invalid payload"},
+                   409: {"description": "<Entity> already exists"},
+               },
+           )
+           # GET — Read One (200 / 404)
+           self.router.add_api_route(
+               methods=["GET"],
+               path="/{uuid}",
+               endpoint=self.get_<entity>,
+               summary="Get <entity>",
+               response_model=<Entity>Schema,
+               status_code=200,  # ✅ Explicite
+               responses={404: {"description": "<Entity> not found"}},
+           )
+           # GET — List (200)
+           self.router.add_api_route(
+               methods=["GET"],
+               path="/",
+               endpoint=self.list_<entities>,
+               summary="List <entities>",
+               response_model=list[<Entity>Schema],
+               status_code=200,  # ✅ Explicite
+           )
+           # PUT — Replace (204 / 404)
+           self.router.add_api_route(
+               methods=["PUT"],
+               path="/{uuid}",
+               endpoint=self.update_<entity>,
+               summary="Replace <entity>",
+               status_code=204,  # ✅ No Content
+               responses={404: {"description": "<Entity> not found"}},
+           )
+           # PATCH — Partial Update (204 / 404)
+           self.router.add_api_route(
+               methods=["PATCH"],
+               path="/{uuid}",
+               endpoint=self.patch_<entity>,
+               summary="Partially update <entity>",
+               status_code=204,  # ✅ No Content
+               responses={404: {"description": "<Entity> not found"}},
+           )
+           # DELETE — Soft Delete (204)
+           self.router.add_api_route(
+               methods=["DELETE"],
+               path="/{uuid}",
+               endpoint=self.delete_<entity>,
+               summary="Delete <entity>",
+               status_code=204,  # ✅ No Content
+           )
+           # DELETE — Purge (200)
+           self.router.add_api_route(
+               methods=["DELETE"],
+               path="/purge",
+               endpoint=self.purge_<entities>,
+               summary="Purge soft-deleted <entities>",
+               status_code=200,  # ✅ OK + body { purged: N }
+           )
+           # POST — Duplicate (201 / 404)
+           self.router.add_api_route(
+               methods=["POST"],
+               path="/{uuid}/duplicate",
+               endpoint=self.duplicate_<entity>,
+               summary="Duplicate <entity>",
+               response_model=<Entity>CreatedSchema,
+               status_code=201,  # ✅ Created
+               responses={404: {"description": "<Entity> not found"}},
+           )
+   ```
+
+3. **Handlers** — lever `HTTPException(status_code=404, detail="...")` si `service.read()` retourne `None`
+
+4. **Validation** — tester avec `pytest` + `TestClient` :
+   - Vérifier chaque status code (201, 200, 204, 404, 400)
+   - Vérifier que PUT/PATCH/DELETE retournent body vide (`None`)
+   - Vérifier que GET list retourne 200 + `[]` si vide (pas 404)
+
+### Validation
+
+```bash
+make test
+```
+
+### Références
+
+- `docs/http-conventions.md` — conventions complètes
+- `_sample/adapters/input/fastapi/ingredient_router.py` — exemple de référence

--- a/arclith/adapters/input/schemas/response_wrapper.py
+++ b/arclith/adapters/input/schemas/response_wrapper.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 from typing import Generic, TypeVar
-from uuid import uuid4
 
 from pydantic import BaseModel, Field
+from uuid6 import uuid7
 
 
 T = TypeVar("T")
@@ -12,9 +12,9 @@ class ResponseMetadata(BaseModel):
     """Métadonnées de réponse API (niveau 3 Richardson - liens HATEOAS optionnels)."""
 
     request_id: str = Field(
-        default_factory=lambda: str(uuid4()),
-        description="Identifiant unique de la requête pour le traçage.",
-        examples=["550e8400-e29b-41d4-a716-446655440000"],
+        default_factory=lambda: str(uuid7()),
+        description="Identifiant unique de la requête pour le traçage (UUIDv7 time-ordered).",
+        examples=["01951234-5678-7abc-def0-123456789abc"],
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -63,6 +63,15 @@ class Arclith:
         return build_repository(self.config, entity_class, self.logger)
     def fastapi(self, **kwargs: Any) -> "FastAPI":
         from fastapi import FastAPI
+        
+        # Injecter title, version et description depuis la config si non fournis
+        if "title" not in kwargs:
+            kwargs["title"] = self.config.app.name
+        if "version" not in kwargs:
+            kwargs["version"] = self.config.app.version
+        if "description" not in kwargs:
+            kwargs["description"] = self.config.app.description
+        
         user_lifespan = kwargs.pop("lifespan", None)
         arclith_self = self
 

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -81,6 +81,7 @@ class ProbeSettings(BaseModel):
 class AppSettings(BaseModel):
     name: str = "arclith-service"
     version: str = "0.0.0"
+    description: str = "API service built with arclith framework"
 
 
 class AppConfig(BaseModel):

--- a/docs/http-conventions.md
+++ b/docs/http-conventions.md
@@ -1,0 +1,178 @@
+# HTTP Conventions — REST & MCP
+
+## Status Codes (SOTA)
+
+Tous les endpoints FastAPI DOIVENT déclarer explicitement leur `status_code` et `responses` si applicable.
+
+### POST — Create
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `POST /v1/resources` | **201 Created** | `{ uuid, ...metadata }` | Succès création |
+| | **400 Bad Request** | `{ detail }` | Validation payload échouée |
+| | **409 Conflict** | `{ detail }` | Conflit (ex. doublon contrainte unique) |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur inattendue |
+
+**Convention :** retourner 201 + body minimal avec UUID de la ressource créée.  
+Exposer `Location` header si pertinent (optionnel dans notre stack).
+
+### GET — Read
+
+#### GET Single Resource
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `GET /v1/resources/{uuid}` | **200 OK** | `{ uuid, fields... }` | Ressource trouvée |
+| | **404 Not Found** | `{ detail }` | Ressource inexistante ou soft-deleted |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** retourner 200 + body complet. 404 si non trouvée.
+
+#### GET List
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `GET /v1/resources` | **200 OK** | `[]` ou `[{ uuid, ... }]` | Liste vide = 200 OK avec `[]` |
+| | **400 Bad Request** | `{ detail }` | Paramètres query invalides |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** toujours 200 OK même si liste vide. Pas de 404 pour liste vide.
+
+### PUT — Replace
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `PUT /v1/resources/{uuid}` | **204 No Content** | ∅ | Succès remplacement complet |
+| | **404 Not Found** | `{ detail }` | Ressource inexistante |
+| | **400 Bad Request** | `{ detail }` | Payload invalide |
+| | **409 Conflict** | `{ detail }` | Optimistic lock failure (version mismatch) |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** 204 + body vide. Client doit re-fetch avec GET s'il veut l'état final.
+
+### PATCH — Partial Update
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `PATCH /v1/resources/{uuid}` | **204 No Content** | ∅ | Succès mise à jour partielle |
+| | **404 Not Found** | `{ detail }` | Ressource inexistante |
+| | **400 Bad Request** | `{ detail }` | Payload invalide |
+| | **409 Conflict** | `{ detail }` | Optimistic lock failure |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** identique à PUT — 204 + body vide.
+
+### DELETE — Soft Delete
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `DELETE /v1/resources/{uuid}` | **204 No Content** | ∅ | Succès soft-delete |
+| | **404 Not Found** | `{ detail }` | Ressource déjà supprimée ou inexistante |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** 204 + body vide. Idempotent — DELETE sur ressource déjà deleted = 204 (pas 404).
+
+### DELETE — Purge (batch)
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `DELETE /v1/resources/purge` | **200 OK** | `{ purged: <count> }` | Succès suppression physique |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** 200 + body JSON avec compteur. Jamais 204 car on retourne une métrique.
+
+### POST — Actions / Special Endpoints
+
+| Endpoint | Status | Response Body | Cas |
+|---|---|---|---|
+| `POST /v1/resources/{uuid}/duplicate` | **201 Created** | `{ uuid }` | Succès duplication |
+| | **404 Not Found** | `{ detail }` | Ressource source inexistante |
+| | **500 Internal Server Error** | `{ detail }` | Erreur serveur |
+
+**Convention :** 201 si création d'une nouvelle ressource. 200 si action ne créant pas de ressource.
+
+---
+
+## Déclaration dans FastAPI
+
+### ✅ Bon — Déclaration explicite
+
+```python
+self.router.add_api_route(
+    methods=["POST"],
+    path="/",
+    endpoint=self.create_resource,
+    summary="Create resource",
+    response_model=ResourceCreatedSchema,
+    status_code=201,  # ✅ Explicite
+    responses={
+        400: {"description": "Invalid payload"},
+        409: {"description": "Resource already exists"},
+    },
+)
+```
+
+### ❌ Mauvais — Status code implicite
+
+```python
+self.router.add_api_route(
+    methods=["POST"],
+    path="/",
+    endpoint=self.create_resource,
+    # ❌ Pas de status_code — FastAPI défaut = 200
+)
+```
+
+---
+
+## MCP Tools — Retours
+
+Les MCP tools ne retournent **pas** de status codes HTTP — ils retournent des objets JSON ou `None`.
+
+### Convention MCP
+
+| Opération | Retour | Erreur |
+|---|---|---|
+| Create | `dict` (objet complet) | Exception levée |
+| Read | `dict \| None` | `None` si non trouvé (pas d'exception) |
+| Update | `dict` (objet mis à jour) ou `None` | Exception si non trouvé |
+| Delete | `None` ou `{ deleted: true }` | Exception si non trouvé |
+| List | `list[dict]` | Toujours `[]` si vide, jamais `None` |
+
+**Règle :** les MCP tools **ne lèvent pas** HTTPException. Ils retournent `None` ou une liste vide. Les erreurs métier génèrent des exceptions Python classiques (ValueError, RuntimeError).
+
+---
+
+## Résumé SOTA
+
+| Verbe | Action | Status Success | Body Success | Status Error |
+|---|---|---|---|---|
+| POST | Create | 201 | `{ uuid, ... }` | 400, 409, 500 |
+| POST | Duplicate | 201 | `{ uuid }` | 404, 500 |
+| GET | Read One | 200 | `{ uuid, ... }` | 404, 500 |
+| GET | List | 200 | `[]` ou `[...]` | 400, 500 |
+| PUT | Replace | 204 | ∅ | 400, 404, 409, 500 |
+| PATCH | Partial | 204 | ∅ | 400, 404, 409, 500 |
+| DELETE | Soft | 204 | ∅ | 404, 500 |
+| DELETE | Purge | 200 | `{ purged: N }` | 500 |
+
+---
+
+## Principes
+
+1. **Explicite > Implicite** : toujours déclarer `status_code` dans `add_api_route`.
+2. **204 = No Content** : PUT/PATCH/DELETE ne retournent rien en cas de succès.
+3. **201 = Created** : POST qui crée une ressource retourne 201 + UUID.
+4. **200 = OK** : GET (list ou single) + actions retournant un body.
+5. **404 = Not Found** : déclarer dans `responses={}` pour tout endpoint avec `{uuid}` path param.
+6. **Liste vide ≠ 404** : `GET /v1/resources` retourne toujours 200 OK, même si `[]`.
+7. **MCP tools ≠ HTTP** : pas de status codes, retour `None` ou `dict` direct.
+
+---
+
+## Références
+
+- [RFC 9110 — HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html)
+- [REST API Design Rulebook (O'Reilly)](https://www.oreilly.com/library/view/rest-api-design/9781449317904/)
+- [FastAPI Response Status Code](https://fastapi.tiangolo.com/tutorial/response-status-code/)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arclith"
-version = "0.5.0"
+version = "0.6.0"
 description = "Hexagonal architecture framework — domain, use cases, repositories, adapters"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arclith"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hexagonal architecture framework — domain, use cases, repositories, adapters"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 📋 Résumé

Cette PR regroupe plusieurs améliorations documentaires, organisationnelles et fonctionnelles pour le framework `arclith`.

## ✨ Nouveautés

### Configuration API
- **feat**: Ajout du champ `app.description` dans la config avec injection automatique dans FastAPI Swagger/OpenAPI
  - Permet de centraliser les métadonnées API (title, version, description) dans `config.yaml`
  - Valeur par défaut : `"API service built with arclith framework"`

### Documentation
- **docs**: Ajout de `docs/http-conventions.md` - conventions HTTP/REST SOTA complètes
  - Status codes explicites pour tous les endpoints (200, 201, 204, 404...)
  - Patterns de réponses standardisés
- **docs**: SK-F06 - Organisation recommandée des routers/tools en sous-dossiers
  - Structure `routers/`, `tools/`, `prompts/`, `resources/` avec fichiers d'entrée
  - Pattern de registration centralisé (`register_routers()`, `register_tools()`, etc.)
  - Procédure de migration depuis structure plate
- **docs**: SK-F05 - Pattern de création de router FastAPI conforme aux conventions HTTP

### Breaking Changes
- **chore**: Bump à v0.6.0 - Migration de `request_id` vers UUIDv7

## 📝 Commits

6 commits de `bricoles` vers `main` :
- 977b664 - feat: add app.description field and inject FastAPI metadata from config
- ad37724 - chore: bump to v0.6.0 - migrate request_id to UUIDv7  
- 0ebfbf5 - docs: add register functions pattern to SK-F06
- d4d9806 - docs: extend SK-F06 with prompts and resources organization
- 7d8b114 - docs: add SK-F06 for routers/tools subdirectory organization
- cf9191a - docs: add HTTP/REST conventions (SOTA status codes)

## ✅ Checklist

- [x] Documentation complète (HTTP conventions, organization patterns)
- [x] Version bump (v0.6.0)
- [x] Metadata injection FastAPI depuis config
- [x] Tous les tests passent
- [x] Copilot instructions mises à jour