### PR TITLE
fix: désactiver reload uvicorn hors main thread (MODE=all)

### DIFF
--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -337,11 +337,12 @@ class Arclith:
 
     def run_api(self, app: "FastAPI | str") -> None:
         import uvicorn
+        in_main_thread = threading.current_thread() is threading.main_thread()
         uvicorn.run(
             app,  # type: ignore[arg-type]
             host=self.config.api.host,
             port=self.config.api.port,
-            reload=self.config.api.reload if isinstance(app, str) else False,
+            reload=self.config.api.reload if isinstance(app, str) and in_main_thread else False,
             log_config=_UVICORN_LOG_CONFIG,
         )
 


### PR DESCRIPTION
## Problème

En `MODE=all`, `run_with_probes` lance chaque runner dans un thread séparé. `run_api` passait `reload=True` à uvicorn même depuis ce thread secondaire.

`ChangeReload` (superviseur uvicorn) appelle `signal.signal()` qui lève :
```
ValueError: signal only works in main thread of the main interpreter
```

## Correction

`run_api` détecte maintenant si l'appel vient du main thread. Si non, `reload` est forcé à `False` indépendamment de la config.