### PR TITLE
fix(uvicorn): force ws=websockets-sansio to drop websockets.legacy import

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -551,3 +551,44 @@ make test
 ### Références
 
 - `_sample/adapters/input/` — implémentation de référence
+
+---
+
+## SK-F10 — Corriger un DeprecationWarning tiers
+
+**Contexte :** une dépendance (directe ou transitive) émet un `DeprecationWarning` visible dans les logs ou les tests.
+
+> ⚠️ **Règle absolue : on ne masque jamais un warning sans corriger sa cause racine.**
+> Utiliser `filterwarnings = ["ignore::DeprecationWarning:..."]` dans pytest ou `warnings.filterwarnings("ignore")`
+> est interdit. Cela cache la dette sans la réduire et peut dissimuler des régressions futures.
+
+### Protocole de diagnostic
+
+1. **Identifier la chaîne d'import** — lire le stacktrace complet du warning (ou lancer `python -W error::DeprecationWarning -c "import <suspect>"` pour forcer l'exception et obtenir la pile entière).
+2. **Localiser le fichier source** — le warning vient d'un `__init__.py` ou d'un module dans `.venv/lib/.../site-packages/`. Lire le fichier pour comprendre QUI l'importe.
+3. **Identifier l'entrée d'arclith** — remonter jusqu'au code d'`arclith` qui déclenche la chaîne (ex : paramètre de config d'un serveur tiers).
+4. **Corriger à la source** — modifier le code d'`arclith` pour éviter le chemin d'import incriminé (ex : passer `ws="websockets-sansio"` à uvicorn).
+
+### Règle : résoudre les versions avant de bumper
+
+Avant de modifier une contrainte de version dans `pyproject.toml` :
+
+1. **Vérifier quelle version exacte** corrige le comportement ciblé :
+   ```bash
+   # Vérifier le changelog / release notes du package sur PyPI
+   uv run --frozen python -c "import <pkg>; print(<pkg>.__version__)"
+   # Tester localement avec la version candidate
+   uv add <pkg>==<candidate> --dev  # dans une branche temporaire
+   make test  # confirmer la disparition du warning
+   ```
+2. **Documenter la version** dans l'ADR avant de committer le bump.
+3. **Ne jamais bumper en aveugle** avec `>=latest` sans avoir validé le comportement.
+
+### Validation
+
+```bash
+# Le warning ne doit plus apparaître
+uv run --frozen pytest -v -W error::DeprecationWarning
+# La suite de tests reste verte
+make test
+```

--- a/arclith/adapters/input/probes/server.py
+++ b/arclith/adapters/input/probes/server.py
@@ -101,6 +101,7 @@ class ProbeServer:
                 port=self._port,
                 log_config=None,
                 access_log=False,
+                ws="websockets-sansio",
             )
             server = uvicorn.Server(config)
             loop = asyncio.new_event_loop()

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -344,6 +344,7 @@ class Arclith:
             port=self.config.api.port,
             reload=self.config.api.reload if isinstance(app, str) and in_main_thread else False,
             log_config=_UVICORN_LOG_CONFIG,
+            ws="websockets-sansio",
         )
 
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -138,6 +138,37 @@ devrait être appliqué deux fois.
 - Tests du pipeline mutualisé : un seul fichier `tests/units/adapters/input/test_auth_pipeline.py` (à créer — SK-AUTH-01).
 
 
+---
+
+## ADR-009 — `ws="websockets-sansio"` imposé sur toutes les configs uvicorn
+
+**Date :** 2026-04-04
+
+**Contexte :** `uvicorn 0.41.0` sélectionne automatiquement `websockets_impl.py` (legacy) quand `websockets` est installé
+(via `fastmcp`). Ce module importe `websockets.legacy`, déprécié depuis `websockets 14.0`. `fastmcp/__init__` active
+globalement `warnings.simplefilter("default", DeprecationWarning)`, rendant le warning visible à chaque démarrage.
+
+**Décision :** Passer `ws="websockets-sansio"` explicitement à chaque construction de `uvicorn.Config` / `uvicorn.run()`
+dans `arclith`. L'implémentation `websockets_sansio_impl.py` n'utilise que la nouvelle API `websockets` (≥14.0), sans
+import `legacy`.
+
+**Pourquoi pas l'alternative évidente (supprimer le warning via `filterwarnings`) :**
+Masquer un avertissement sans corriger la cause racine est interdit : cela cache une dette technique et peut dissimuler
+des régressions futures. **Règle absolue : on ne masque jamais un warning sans corriger sa source.**
+
+**Pourquoi pas bump de `uvicorn` :**
+Avant tout bump de dépendance, il faut vérifier quelle version exacte corrige le comportement ciblé (règle SK-F10).
+Ici, `ws="websockets-sansio"` est disponible depuis uvicorn 0.20+, la correction est déterministe et ne nécessite
+aucun changement de contrainte dans `pyproject.toml`.
+
+**Conséquence sur le code :**
+
+- `Arclith.run_api()` — `uvicorn.run(..., ws="websockets-sansio")`
+- `ProbeServer.start_in_background()` — `uvicorn.Config(..., ws="websockets-sansio")`
+- `websockets_impl.py` (legacy) n'est jamais chargé par arclith.
+
+---
+
 **Contexte :** Exposer les services via le Model Context Protocol.
 
 **Décision :** `fastmcp>=3.1.0` avec trois transports : stdio, SSE, streamable-HTTP.


### PR DESCRIPTION
## Root cause

`uvicorn 0.41.0/protocols/websockets/auto.py` sélectionne `websockets_impl.py` (legacy) dès que `websockets` est installé (via `fastmcp`). Ce module importe `websockets.legacy`, déprécié depuis websockets 14.0. `fastmcp/__init__` active globalement `warnings.simplefilter("default", DeprecationWarning)`, rendant le warning visible à chaque démarrage.

**Chaîne complète :**
`fastmcp` (installé) → `fastmcp/__init__` active `DeprecationWarning` → uvicorn `Config.load()` → `auto.py` → `websockets_impl.py` → `import websockets.legacy.handshake` + `from websockets.legacy.server import HTTPResponse` → 💥 warning

## Fix

Passage de `ws="websockets-sansio"` sur les deux points d'entrée uvicorn d'arclith :

- `Arclith.run_api()` → `uvicorn.run(..., ws="websockets-sansio")`
- `ProbeServer.start_in_background()` → `uvicorn.Config(..., ws="websockets-sansio")`

`websockets_sansio_impl.py` n'utilise que la nouvelle API `websockets` (≥14.0), sans aucun import legacy. Disponible depuis uvicorn 0.20+, aucune contrainte de version à modifier.

## Docs

- **ADR-009** (`docs/decisions.md`) — décision + règle "ne jamais masquer sans corriger"
- **SK-F10** (`SKILLS.md`) — recette "Corriger un DeprecationWarning tiers" + règle "résoudre les versions avant de bumper"

## Validation

```
pytest -v                          → 205 passed, 2 skipped
pytest -W error::DeprecationWarning → 205 passed, 2 skipped, 0 warning
```