### PR TITLE
Fix CI failures after arclith 0.10 release

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -14,51 +14,68 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.13"
+  ARCLITH_TEMPLATE_DIR: ${{ github.workspace }}/.templates/_sample
 
 jobs:
   e2e-scaffold:
     name: E2E — Scaffold & Validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
+      - uses: actions/checkout@v4
+        with:
+          repository: karned-rekipe/_sample
+          path: .templates/_sample
+
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-      
+
       - name: Install CLI dependencies
         working-directory: cli
         run: uv sync --group dev
-      
+
       - name: Install arclith-cli tool
         working-directory: cli
         run: uv tool install .
-      
+
       - name: Run E2E tests
         working-directory: cli
         run: uv run pytest tests/ -v --tb=short
-        
+
       - name: Quick smoke test — scaffold real project
         run: |
           cd /tmp
-          arclith-cli new TestEntity test-smoke --port 9999
+          arclith-cli new TestEntity test-smoke --port 9999 --template-dir "$ARCLITH_TEMPLATE_DIR"
           cd test-smoke
-          
+
           # Verify stable PyPI dependency
           if grep -q '\[tool\.uv\.sources\]' pyproject.toml; then
             echo "❌ Generated project contains [tool.uv.sources] — template is broken"
             exit 1
           fi
-          
+
           # Verify arclith version
           grep "arclith\[" pyproject.toml
-          
+
+          # Validate the current repository version without waiting for PyPI propagation.
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          pyproject = Path("pyproject.toml")
+          pyproject.write_text(
+              pyproject.read_text().rstrip()
+              + f'\n\n[tool.uv.sources]\narclith = {{ path = "{os.environ["GITHUB_WORKSPACE"]}", editable = true }}\n'
+          )
+          PY
+
           # Install and validate
           uv sync --no-dev
-          uv run python main.py --help
-          
-          echo "✅ Smoke test passed"
+          uv run python -c "import main; from test_smoke.adapters.input.fastapi.dependencies import require_auth; from test_smoke.adapters.input.fastmcp.dependencies import require_auth_mcp; print('imports ok')"
 
+          echo "✅ Smoke test passed"

--- a/arclith/adapters/input/fastapi/idempotency.py
+++ b/arclith/adapters/input/fastapi/idempotency.py
@@ -67,7 +67,7 @@ class IdempotencyMiddleware:
             return
 
         if len(idempotency_key) > 255:
-            await self._send_error(send, status = 400, message = "Idempotency-Key exceeds 255 characters")
+            await self._send_error(send, status=400, message="Idempotency-Key exceeds 255 characters")
             return
 
         path = scope.get("path", "")

--- a/arclith/adapters/input/fastapi/idempotency.py
+++ b/arclith/adapters/input/fastapi/idempotency.py
@@ -57,56 +57,67 @@ class IdempotencyMiddleware:
         self._methods = methods or {"POST"}
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
-        if scope["type"] != "http":
+        if not self._should_handle(scope):
             await self._app(scope, receive, send)
             return
 
-        method = scope.get("method", "")
-        if method not in self._methods:
-            await self._app(scope, receive, send)
-            return
-
-        # Extract Idempotency-Key from headers
-        headers_dict = {k.decode(): v.decode() for k, v in scope.get("headers", [])}
-        idempotency_key = headers_dict.get("idempotency-key") or headers_dict.get("Idempotency-Key")
-
+        idempotency_key = self._get_idempotency_key(scope)
         if not idempotency_key:
-            if self._required:
-                # Reject request
-                await self._send_error(
-                    send,
-                    status = 400,
-                    message = "Idempotency-Key header is required for POST requests",
-                )
-                return
-            # Optional mode: continue without idempotency
-            await self._app(scope, receive, send)
+            await self._handle_missing_key(scope, receive, send)
             return
 
-        # Validate key length
         if len(idempotency_key) > 255:
             await self._send_error(send, status = 400, message = "Idempotency-Key exceeds 255 characters")
             return
 
-        # Build cache key (namespace by path + tenant if available)
         path = scope.get("path", "")
         cache_key = f"idempotency:{path}:{idempotency_key}"
-
-        # Check cache
         cached = await self._cache.get(cache_key)
         if cached:
-            self._logger.info(
-                "🔁 Idempotent request (cache hit)",
-                key = idempotency_key,
-                path = path,
-            )
-            cached_data = json.loads(cached)
-            await self._send_cached_response(send, cached_data)
+            await self._send_cache_hit(send, cached, idempotency_key, path)
             return
 
-        # Cache miss → execute request and capture response
         response_data: dict[str, Any] = {"status": 500, "headers": [], "body": b""}
+        try:
+            await self._app(scope, receive, self._capture_response(response_data, send))
+        finally:
+            await self._cache_successful_response(cache_key, response_data, idempotency_key, path)
 
+    def _should_handle(self, scope: Any) -> bool:
+        return scope["type"] == "http" and scope.get("method", "") in self._methods
+
+    @staticmethod
+    def _get_idempotency_key(scope: Any) -> str | None:
+        for key, value in scope.get("headers", []):
+            if key.lower() == b"idempotency-key":
+                return value.decode()
+        return None
+
+    async def _handle_missing_key(self, scope: Any, receive: Any, send: Any) -> None:
+        if not self._required:
+            await self._app(scope, receive, send)
+            return
+        await self._send_error(
+            send,
+            status = 400,
+            message = "Idempotency-Key header is required for POST requests",
+        )
+
+    async def _send_cache_hit(
+            self,
+            send: Any,
+            cached: str,
+            idempotency_key: str,
+            path: str,
+    ) -> None:
+        self._logger.info(
+            "🔁 Idempotent request (cache hit)",
+            key = idempotency_key,
+            path = path,
+        )
+        await self._send_cached_response(send, json.loads(cached))
+
+    def _capture_response(self, response_data: dict[str, Any], send: Any) -> Any:
         async def _send_wrapper(message: Any) -> None:
             if message["type"] == "http.response.start":
                 response_data["status"] = message["status"]
@@ -115,30 +126,41 @@ class IdempotencyMiddleware:
                 response_data["body"] += message.get("body", b"")
             await send(message)
 
-        try:
-            await self._app(scope, receive, _send_wrapper)
-        finally:
-            # Cache successful responses only (2xx)
-            status = response_data["status"]
-            if 200 <= status < 300:
-                # Store response in cache
-                cache_value = json.dumps(
-                    {
-                        "status": status,
-                        "headers": [
-                            (k.decode() if isinstance(k, bytes) else k, v.decode() if isinstance(v, bytes) else v) for
-                            k, v in response_data["headers"]],
-                        "body": response_data["body"].decode("utf-8", errors = "replace"),
-                    }
-                )
-                await self._cache.set(cache_key, cache_value, ttl_s = self._ttl)
-                self._logger.info(
-                    "💾 Cached idempotent response",
-                    key = idempotency_key,
-                    path = path,
-                    status = status,
-                    ttl = self._ttl,
-                )
+        return _send_wrapper
+
+    async def _cache_successful_response(
+            self,
+            cache_key: str,
+            response_data: dict[str, Any],
+            idempotency_key: str,
+            path: str,
+    ) -> None:
+        status = response_data["status"]
+        if not 200 <= status < 300:
+            return
+        await self._cache.set(
+            cache_key,
+            json.dumps(self._cache_payload(status, response_data)),
+            ttl_s = self._ttl,
+        )
+        self._logger.info(
+            "💾 Cached idempotent response",
+            key = idempotency_key,
+            path = path,
+            status = status,
+            ttl = self._ttl,
+        )
+
+    @staticmethod
+    def _cache_payload(status: int, response_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "status": status,
+            "headers": [
+                (k.decode() if isinstance(k, bytes) else k, v.decode() if isinstance(v, bytes) else v)
+                for k, v in response_data["headers"]
+            ],
+            "body": response_data["body"].decode("utf-8", errors = "replace"),
+        }
 
     async def _send_cached_response(self, send: Any, cached_data: dict[str, Any]) -> None:
         """Replay cached response."""

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -71,38 +71,12 @@ class Arclith:
     def fastapi(self, **kwargs: Any) -> "FastAPI":
         from fastapi import FastAPI
 
-        # Inject title/version/description from config if not overridden
-        kwargs.setdefault("title", self.config.app.name)
-        kwargs.setdefault("version", self.config.app.version)
-        kwargs.setdefault("description", self.config.app.description)
-
-        # Pre-fill Swagger UI OAuth2 when Keycloak is configured
-        if self.config.keycloak:
-            if "swagger_ui_init_oauth" not in kwargs:
-                kc = self.config.keycloak
-                # Utiliser client_id si défini, sinon audience, sinon défaut
-                client_id = kc.client_id or kc.audience or "arclith-client"
-                kwargs["swagger_ui_init_oauth"] = {
-                    "clientId": client_id,
-                    "usePkceWithAuthorizationCodeGrant": True,
-                    "scopes": "openid profile",
-                    "additionalQueryStringParams": {"prompt": "login"},
-                }
-            # Définir explicitement l'URL de redirection OAuth2 pour Swagger UI
-            if "swagger_ui_oauth2_redirect_url" not in kwargs:
-                kwargs["swagger_ui_oauth2_redirect_url"] = "/docs/oauth2-redirect"
-            # Persister automatiquement l'autorisation OAuth2
-            if "swagger_ui_parameters" not in kwargs:
-                kwargs["swagger_ui_parameters"] = {
-                    "persistAuthorization": True,
-                }
-
+        self._configure_fastapi_kwargs(kwargs)
         user_lifespan = kwargs.pop("lifespan", None)
-        arclith_self = self
 
         @asynccontextmanager
         async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
-            arclith_self._setup_uvicorn_logging()
+            self._setup_uvicorn_logging()
             if user_lifespan is not None:
                 async with AsyncExitStack() as stack:
                     await stack.enter_async_context(user_lifespan(app))
@@ -111,7 +85,39 @@ class Arclith:
                 yield
 
         app = FastAPI(lifespan=_lifespan, **kwargs)
+        self._add_fastapi_observability(app)
+        self._add_fastapi_http_middlewares(app)
 
+        if self.config.keycloak:
+            self._patch_openapi_keycloak(app)
+
+        return app
+
+    def _configure_fastapi_kwargs(self, kwargs: dict[str, Any]) -> None:
+        kwargs.setdefault("title", self.config.app.name)
+        kwargs.setdefault("version", self.config.app.version)
+        kwargs.setdefault("description", self.config.app.description)
+        if self.config.keycloak:
+            self._configure_keycloak_swagger(kwargs)
+
+    def _configure_keycloak_swagger(self, kwargs: dict[str, Any]) -> None:
+        kc = self.config.keycloak
+        if kc is None:
+            return
+        client_id = kc.client_id or kc.audience or "arclith-client"
+        kwargs.setdefault(
+            "swagger_ui_init_oauth",
+            {
+                "clientId": client_id,
+                "usePkceWithAuthorizationCodeGrant": True,
+                "scopes": "openid profile",
+                "additionalQueryStringParams": {"prompt": "login"},
+            },
+        )
+        kwargs.setdefault("swagger_ui_oauth2_redirect_url", "/docs/oauth2-redirect")
+        kwargs.setdefault("swagger_ui_parameters", {"persistAuthorization": True})
+
+    def _add_fastapi_observability(self, app: "FastAPI") -> None:
         if self.config.probe.enabled:
             from arclith.adapters.input.probes.metrics import ApiMetricsCollector
             app.add_middleware(ApiMetricsCollector, registry=self._metrics_registry)
@@ -119,12 +125,11 @@ class Arclith:
                 ApiMetricsCollector(app=None, registry=self._metrics_registry)  # type: ignore[arg-type]
             )
 
-        # SOTA HTTP middlewares — order matters (outermost to innermost)
-        # TimingMiddleware wraps all others → measures total request time
+    def _add_fastapi_http_middlewares(self, app: "FastAPI") -> None:
+        # Order matters: Starlette applies the last registered middleware first.
         from arclith.adapters.input.fastapi.timing import TimingMiddleware
         app.add_middleware(TimingMiddleware, logger=self.logger)
 
-        # CacheControlMiddleware — inject Cache-Control headers
         from arclith.adapters.input.fastapi.cache_control import CacheControlMiddleware
         app.add_middleware(
             CacheControlMiddleware,
@@ -133,12 +138,10 @@ class Arclith:
             get_list_max_age = self.config.http.cache_control.get_list_max_age,
         )
 
-        # ETaggerMiddleware — manage ETag/If-Match for optimistic locking
         from arclith.adapters.input.fastapi.etag import ETaggerMiddleware
         if self.config.http.etag.enabled:
             app.add_middleware(ETaggerMiddleware, logger = self.logger)
 
-        # IdempotencyMiddleware — prevent duplicate POST requests (critical for e-commerce)
         from arclith.adapters.input.fastapi.idempotency import IdempotencyMiddleware
         if self.config.http.idempotency.enabled:
             app.add_middleware(
@@ -148,12 +151,6 @@ class Arclith:
                 ttl = self.config.http.idempotency.ttl_seconds,
                 required = self.config.http.idempotency.required,
             )
-
-        # Inject Keycloak OAuth2 PKCE security scheme into the OpenAPI spec
-        if self.config.keycloak:
-            self._patch_openapi_keycloak(app)
-
-        return app
 
     def _patch_openapi_keycloak(self, app: "FastAPI") -> None:
         """Inject Keycloak OAuth2 PKCE security scheme into the OpenAPI spec.

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -53,6 +53,10 @@ def new(
         str,
         typer.Option("--ref", help="Branche ou tag Git du template _sample"),
     ] = "main",
+    template_dir: Annotated[
+        Path | None,
+        typer.Option("--template-dir", help="Répertoire local du template _sample", hidden=True),
+    ] = None,
 ) -> None:
     """Créer un nouveau projet [bold]arclith[/bold] scaffoldé depuis le template officiel [dim]_sample[/dim]."""
     entity = entity or _prompt_entity()
@@ -77,9 +81,9 @@ def new(
         )
     )
 
-    with console.status("[bold]Téléchargement du template depuis GitHub…[/bold]"):
+    with console.status("[bold]Préparation du template…[/bold]"):
         try:
-            download_and_extract(target_dir, ref=repo_ref)
+            download_and_extract(target_dir, ref=repo_ref, template_dir=template_dir)
         except Exception as exc:
             console.print(f"[red]✗ Téléchargement échoué :[/red] {exc}")
             raise typer.Exit(1) from exc

--- a/cli/arclith_cli/scaffold.py
+++ b/cli/arclith_cli/scaffold.py
@@ -21,6 +21,7 @@ _DATA_FILES_TO_REMOVE = {"ingredient.csv"}
 
 def download_and_extract(target_dir: Path, *, ref: str = "main", template_dir: Path | None = None) -> None:
     if template_dir is not None:
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
         _copy_template(template_dir, target_dir)
         _cleanup(target_dir)
         return

--- a/cli/arclith_cli/scaffold.py
+++ b/cli/arclith_cli/scaffold.py
@@ -19,7 +19,12 @@ _FILES_TO_REMOVE = {
 _DATA_FILES_TO_REMOVE = {"ingredient.csv"}
 
 
-def download_and_extract(target_dir: Path, *, ref: str = "main") -> None:
+def download_and_extract(target_dir: Path, *, ref: str = "main", template_dir: Path | None = None) -> None:
+    if template_dir is not None:
+        _copy_template(template_dir, target_dir)
+        _cleanup(target_dir)
+        return
+
     url = _TEMPLATE_URL.format(ref=ref)
     response = httpx.get(url, follow_redirects=True, timeout=60)
     response.raise_for_status()
@@ -39,6 +44,16 @@ def download_and_extract(target_dir: Path, *, ref: str = "main") -> None:
                 dest.write_bytes(zf.read(member.filename))
 
     _cleanup(target_dir)
+
+
+def _copy_template(source_dir: Path, target_dir: Path) -> None:
+    if not source_dir.is_dir():
+        raise FileNotFoundError(f"Template directory not found: {source_dir}")
+    shutil.copytree(
+        source_dir,
+        target_dir,
+        ignore=shutil.ignore_patterns(*_DIRS_TO_REMOVE, *_FILES_TO_REMOVE),
+    )
 
 
 def _zip_root(zf: zipfile.ZipFile) -> str:
@@ -62,4 +77,3 @@ def _cleanup(target_dir: Path) -> None:
             data_dir.rmdir()  # only succeeds if empty
         except OSError:
             pass
-

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -18,13 +21,43 @@ def temp_workspace():
     shutil.rmtree(tmp, ignore_errors=True)
 
 
+def _template_args() -> list[str]:
+    template_dir = os.environ.get("ARCLITH_TEMPLATE_DIR")
+    if template_dir:
+        return ["--template-dir", template_dir]
+
+    sibling_template = Path(__file__).resolve().parents[3] / "_sample"
+    if sibling_template.is_dir():
+        return ["--template-dir", str(sibling_template)]
+
+    return []
+
+
+def _inject_local_arclith_source(project_dir: Path) -> None:
+    pyproject = project_dir / "pyproject.toml"
+    pyproject.write_text(
+        pyproject.read_text().rstrip()
+        + f'\n\n[tool.uv.sources]\narclith = {{ path = "{_REPO_ROOT.as_posix()}", editable = true }}\n'
+    )
+
+
 def test_scaffold_and_run(temp_workspace: Path):
     """Test that scaffolded project installs and runs successfully."""
     project_dir = temp_workspace / "test-plan-service"
     
     # Step 1 — scaffold via CLI (non-interactive)
     result = subprocess.run(
-        ["arclith-cli", "new", "Plan", "test-plan-service", "--dir", str(temp_workspace), "--port", "9000"],
+        [
+            "arclith-cli",
+            "new",
+            "Plan",
+            "test-plan-service",
+            "--dir",
+            str(temp_workspace),
+            "--port",
+            "9000",
+            *_template_args(),
+        ],
         capture_output=True,
         text=True,
         timeout=120,
@@ -43,6 +76,7 @@ def test_scaffold_and_run(temp_workspace: Path):
         "it should use stable PyPI arclith"
     )
     assert "arclith[" in pyproject_content, "arclith dependency missing"
+    _inject_local_arclith_source(project_dir)
     
     # Step 3 — uv sync
     result = subprocess.run(
@@ -103,7 +137,17 @@ def test_scaffold_with_custom_entity_formats(temp_workspace: Path):
         project_dir = temp_workspace / project_name
         
         result = subprocess.run(
-            ["arclith-cli", "new", entity_input, project_name, "--dir", str(temp_workspace), "--port", "9100"],
+            [
+                "arclith-cli",
+                "new",
+                entity_input,
+                project_name,
+                "--dir",
+                str(temp_workspace),
+                "--port",
+                "9100",
+                *_template_args(),
+            ],
             capture_output=True,
             text=True,
             timeout=120,
@@ -131,10 +175,19 @@ def test_scaffold_runs_tests(temp_workspace: Path):
     
     # Scaffold
     subprocess.run(
-        ["arclith-cli", "new", "Widget", "test-validated-service", "--dir", str(temp_workspace)],
+        [
+            "arclith-cli",
+            "new",
+            "Widget",
+            "test-validated-service",
+            "--dir",
+            str(temp_workspace),
+            *_template_args(),
+        ],
         check=True,
         timeout=120,
     )
+    _inject_local_arclith_source(project_dir)
     
     # Install deps
     subprocess.run(["uv", "sync", "--group", "dev"], cwd=project_dir, check=True, timeout=180)


### PR DESCRIPTION
## Summary
- refactor FastAPI setup and idempotency middleware to satisfy the strict radon complexity gate
- make CLI E2E deterministic by allowing a local _sample template source in CI
- keep generated projects publishable, then inject the local arclith source only during CI installation
- replace the smoke test server startup with import validation to avoid hanging the workflow

## Validation
- make quality
- cd cli && uv run ruff check arclith_cli tests
- cd cli && uv run pytest tests/ -v --tb=short
- parsed .github/workflows/*.yml with PyYAML
- local smoke equivalent: scaffold + no [tool.uv.sources] assertion + local arclith source injection + uv sync --no-dev + import validation