### PR TITLE
docs: fix LangGraph install command for 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,26 @@ pip install "arclith[duckdb]"
 pip install "arclith[mariadb]"
 pip install "arclith[fastapi]"
 pip install "arclith[mcp]"
-pip install "arclith[langgraph]"
 pip install "arclith[all]"
 ```
 
-`arclith[langgraph]` installe le socle local pour exposer un agent via LangGraph Studio et LangSmith.
-Le chemin standard est ensuite:
+`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Avec cette release,
+installer les dependances agent directement dans le projet applicatif:
 
 ```bash
+uv add \
+  "langgraph>=1.0.8" \
+  "langgraph-api>=0.11.0" \
+  "langgraph-cli[inmem]>=0.4.31" \
+  "langsmith>=0.4.0" \
+  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+Quand une release Arclith publie l'extra `langgraph`, la premiere commande pourra redevenir
+`uv add "arclith[langgraph]"` ou `pip install "arclith[langgraph]"`.
 
 Arclith genere `langgraph.json`, le point d'entree LangGraph et le cablage `Arclith.langgraph(...)`.
 Le code specifique du projet reste dans `src/<package>/adapters/inbound/langgraph/agent.py`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,11 +96,19 @@ src/<package>/infrastructure/containers/<entity>_container.py  # RepositoryRegis
 **LangGraph / LangSmith :**
 
 ```bash
-uv add "arclith[langgraph]"
+uv add \
+  "langgraph>=1.0.8" \
+  "langgraph-api>=0.11.0" \
+  "langgraph-cli[inmem]>=0.4.31" \
+  "langsmith>=0.4.0" \
+  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
+Arclith publie cet extra, la premiere commande pourra redevenir `uv add "arclith[langgraph]"`.
 
 L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet ne modifie ensuite que ce fichier pour

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -86,11 +86,19 @@ curl -fsS -X POST http://127.0.0.1:8100/v1/ingredients/ \
 
 ## 3. Ajouter LangGraph et LangSmith
 
-Installer l'extra agent dans le projet genere:
+Installer les dependances agent dans le projet genere:
 
 ```bash
-uv add "arclith[langgraph]"
+uv add \
+  "langgraph>=1.0.8" \
+  "langgraph-api>=0.11.0" \
+  "langgraph-cli[inmem]>=0.4.31" \
+  "langsmith>=0.4.0" \
+  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
 ```
+
+`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
+Arclith publie cet extra, cette etape pourra redevenir `uv add "arclith[langgraph]"`.
 
 Generer l'entrypoint LangGraph:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -241,11 +241,19 @@ Arclith ne genere pas d'UI dediee pour tester un agent. Le chemin standard est u
 `agent/langgraph` teste dans LangGraph Studio, avec les traces branchees sur LangSmith:
 
 ```bash
-uv add "arclith[langgraph]"
+uv add \
+  "langgraph>=1.0.8" \
+  "langgraph-api>=0.11.0" \
+  "langgraph-cli[inmem]>=0.4.31" \
+  "langsmith>=0.4.0" \
+  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
+Arclith publie cet extra, la premiere commande pourra redevenir `uv add "arclith[langgraph]"`.
 
 L'adapter `agent/langgraph` genere `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet n'a plus qu'a modifier ce fichier


### PR DESCRIPTION
## Summary
- Replace `uv add "arclith[langgraph]"` in the agent quickstart docs with direct LangGraph, LangSmith, and PydanticAI dependencies that work with published `arclith==0.11.0`.
- Note that the `langgraph` extra can be restored once a future Arclith release publishes it.

## Validation
- Verified PyPI metadata for `arclith==0.11.0`: extras are `agent`, `all`, `auth`, `cache`, `duckdb`, `fastapi`, `mariadb`, `mcp`, `mongodb`, `vault`; no `langgraph`.
- Updated `/Users/killian/Desktop/toto0/pantry-agent` dependency list and ran `uv lock` / `uv sync` without the invalid-extra warning.
- `uv run python` import check for `langgraph`, `langsmith`, `pydantic_ai`, and `arclith.infrastructure.lm.build_pydantic_ai_model`.
- `uv run langgraph --version` -> `LangGraph CLI, version 0.4.31`.
- `git diff --check`.
- `uv run --frozen --extra all python -m pytest tests/units/test_arclith_langgraph.py tests/units/infrastructure/test_lm.py`.
- `cd cli && uv run --frozen python -m pytest tests/test_add_adapter.py::test_add_langgraph_agent_adapter_generates_runtime_entrypoint tests/test_add_adapter.py::test_add_langsmith_observability_adapter_uses_catalog_params`.