### PR TITLE
Restore langgraph extra docs for Arclith 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,26 +60,18 @@ pip install "arclith[duckdb]"
 pip install "arclith[mariadb]"
 pip install "arclith[fastapi]"
 pip install "arclith[mcp]"
+pip install "arclith[langgraph]"
 pip install "arclith[all]"
 ```
 
-`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Avec cette release,
-installer les dependances agent directement dans le projet applicatif:
+Pour ajouter LangGraph et LangSmith à un projet généré:
 
 ```bash
-uv add \
-  "langgraph>=1.0.8" \
-  "langgraph-api>=0.11.0" \
-  "langgraph-cli[inmem]>=0.4.31" \
-  "langsmith>=0.4.0" \
-  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
+uv add "arclith[langgraph]"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
-
-Quand une release Arclith publie l'extra `langgraph`, la premiere commande pourra redevenir
-`uv add "arclith[langgraph]"` ou `pip install "arclith[langgraph]"`.
 
 Arclith genere `langgraph.json`, le point d'entree LangGraph et le cablage `Arclith.langgraph(...)`.
 Le code specifique du projet reste dans `src/<package>/adapters/inbound/langgraph/agent.py`.

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,19 +96,11 @@ src/<package>/infrastructure/containers/<entity>_container.py  # RepositoryRegis
 **LangGraph / LangSmith :**
 
 ```bash
-uv add \
-  "langgraph>=1.0.8" \
-  "langgraph-api>=0.11.0" \
-  "langgraph-cli[inmem]>=0.4.31" \
-  "langsmith>=0.4.0" \
-  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
+uv add "arclith[langgraph]"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
-
-`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
-Arclith publie cet extra, la premiere commande pourra redevenir `uv add "arclith[langgraph]"`.
 
 L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet ne modifie ensuite que ce fichier pour

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -86,19 +86,11 @@ curl -fsS -X POST http://127.0.0.1:8100/v1/ingredients/ \
 
 ## 3. Ajouter LangGraph et LangSmith
 
-Installer les dependances agent dans le projet genere:
+Installer les dépendances agent dans le projet généré:
 
 ```bash
-uv add \
-  "langgraph>=1.0.8" \
-  "langgraph-api>=0.11.0" \
-  "langgraph-cli[inmem]>=0.4.31" \
-  "langsmith>=0.4.0" \
-  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
+uv add "arclith[langgraph]"
 ```
-
-`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
-Arclith publie cet extra, cette etape pourra redevenir `uv add "arclith[langgraph]"`.
 
 Generer l'entrypoint LangGraph:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -241,19 +241,11 @@ Arclith ne genere pas d'UI dediee pour tester un agent. Le chemin standard est u
 `agent/langgraph` teste dans LangGraph Studio, avec les traces branchees sur LangSmith:
 
 ```bash
-uv add \
-  "langgraph>=1.0.8" \
-  "langgraph-api>=0.11.0" \
-  "langgraph-cli[inmem]>=0.4.31" \
-  "langsmith>=0.4.0" \
-  "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"
+uv add "arclith[langgraph]"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
-
-`arclith==0.11.0` publie sur PyPI ne declare pas encore l'extra `langgraph`. Quand une release
-Arclith publie cet extra, la premiere commande pourra redevenir `uv add "arclith[langgraph]"`.
 
 L'adapter `agent/langgraph` genere `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet n'a plus qu'a modifier ce fichier


### PR DESCRIPTION
## Summary
- replace temporary pre-0.12 LangGraph dependency instructions with `uv add "arclith[langgraph]"`
- add `pip install "arclith[langgraph]"` to the optional dependency list
- remove stale notes saying the extra will become available in a future release

## Context
PR #35 landed after the 0.12 release PR and reintroduced the temporary install workaround for `arclith==0.11.0`. This PR restores the canonical 0.12 command before tagging/publishing.

## Validation
- `rg -n "0\\.11\\.0.*langgraph|ne declare pas encore|premiere commande pourra|pydantic-ai-slim\\[anthropic,openai\\]|langgraph-api>=|langgraph-cli\\[inmem\\]" README.md cli/README.md docs` returns no matches
- `git diff --check`
