### PR TITLE
Add core scaffold CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Pour creer un projet concret avec la CLI, lancer API/MCP/probes, puis faire evol
 - [CLI](cli/README.md)
 - [Sample fonctionnel](https://github.com/karned-rekipe/_sample)
 
-Pour poser uniquement le coeur metier minimal apres creation d'un projet:
+Pour poser uniquement le cœur métier minimal après création d'un projet :
 
 ```bash
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
 ```
 
-Ces commandes ne generent pas de CRUD ni de wiring adapter par defaut.
+Ces commandes ne génèrent pas de CRUD ni de wiring adapter par défaut.
 
 ### Optional dependencies
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Pour creer un projet concret avec la CLI, lancer API/MCP/probes, puis faire evol
 - [CLI](cli/README.md)
 - [Sample fonctionnel](https://github.com/karned-rekipe/_sample)
 
+Pour poser uniquement le coeur metier minimal apres creation d'un projet:
+
+```bash
+arclith-cli add-entity ShoppingItem
+arclith-cli add-usecase PlanShoppingList
+```
+
+Ces commandes ne generent pas de CRUD ni de wiring adapter par defaut.
+
 ### Optional dependencies
 
 ```bash

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,6 +34,47 @@ Le projet généré utilise un layout `src/<package>/...` pour le code applicati
 
 ---
 
+### `add-entity` — Ajouter une entité métier
+
+Crée uniquement le fichier minimal d'une entité dans `src/<package>/domain/models/`.
+
+```bash
+cd my-recipe-service
+arclith-cli add-entity ShoppingItem
+```
+
+Fichier généré :
+
+```text
+src/<package>/domain/models/shopping_item.py
+```
+
+La commande ne génère aucun CRUD, aucun port repository, aucun adapter et aucun endpoint. Elle pose seulement le point d'ancrage du modèle métier ; le développeur complète ensuite les champs et invariants de l'entité.
+
+---
+
+### `add-usecase` — Ajouter un cas d'usage
+
+Crée uniquement le fichier minimal d'un cas d'usage dans `src/<package>/application/use_cases/`.
+
+```bash
+cd my-recipe-service
+arclith-cli add-usecase PlanShoppingList
+arclith-cli add-usecase find-by-name
+```
+
+Fichier généré :
+
+```text
+src/<package>/application/use_cases/plan_shopping_list.py
+```
+
+Le nom peut être fourni en PascalCase, snake_case ou kebab-case. Le suffixe `UseCase` est normalisé : `PlanShoppingListUseCase` et `plan-shopping-list-use-case` génèrent tous les deux `PlanShoppingListUseCase`.
+
+Comme `add-entity`, cette commande ne câble pas FastAPI, FastMCP, LangGraph, un repository ou un service. Les adapters se branchent ensuite explicitement avec `add-adapter`.
+
+---
+
 ### `add-adapter` — Ajouter un adapter
 
 Wizard interactif à lancer **depuis la racine du projet cible**. Scaffold le code Python et/ou les fichiers de configuration pour un nouvel adapter. Par défaut, la capacité cible est `repository`.

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -35,10 +35,10 @@ class UseCaseNames:
     @classmethod
     def from_input(cls, raw: str) -> UseCaseNames:
         names = EntityNames.from_input(raw)
-        pascal = _strip_pascal_suffix(names.pascal, "UseCase")
+        pascal = _strip_pascal_suffix(names.pascal)
         snake = _strip_snake_suffix(names.snake)
         if not pascal or not snake:
-            console.print(f"[red]x[/red] Nom de use case invalide: [bold]{raw}[/bold].")
+            console.print(f"[red]✗[/red] Nom de cas d'usage invalide : [bold]{raw}[/bold].")
             raise typer.Exit(1)
         return cls(pascal=pascal, snake=snake)
 
@@ -47,7 +47,7 @@ def add_entity_cmd(*, project_dir: Path | None = None, entity_name: str) -> Path
     project_dir = project_dir or Path.cwd()
     entity_name = entity_name.strip()
     _assert_project_root(project_dir, command="add-entity")
-    _assert_valid_name(entity_name, label="entite")
+    _assert_valid_name(entity_name, label="entité")
 
     paths = detect_project_paths(project_dir)
     names = EntityNames.from_input(entity_name)
@@ -57,7 +57,7 @@ def add_entity_cmd(*, project_dir: Path | None = None, entity_name: str) -> Path
     _ensure_package_dirs(paths, "domain", "models")
     entity_file.write_text(_ENTITY_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
     console.print(
-        f"[green]OK[/green] Entite {names.pascal} creee: "
+        f"[green]✓[/green] Entité {names.pascal} créée : "
         f"[bold]{entity_file.relative_to(project_dir)}[/bold]"
     )
     return entity_file
@@ -67,7 +67,7 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
     project_dir = project_dir or Path.cwd()
     usecase_name = usecase_name.strip()
     _assert_project_root(project_dir, command="add-usecase")
-    _assert_valid_name(usecase_name, label="use case")
+    _assert_valid_name(usecase_name, label="cas d'usage")
 
     paths = detect_project_paths(project_dir)
     names = UseCaseNames.from_input(usecase_name)
@@ -77,7 +77,7 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
     _ensure_package_dirs(paths, "application", "use_cases")
     usecase_file.write_text(_USE_CASE_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
     console.print(
-        f"[green]OK[/green] Use case {names.pascal}UseCase cree: "
+        f"[green]✓[/green] Cas d'usage {names.pascal}UseCase créé : "
         f"[bold]{usecase_file.relative_to(project_dir)}[/bold]"
     )
     return usecase_file
@@ -85,7 +85,7 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
 
 def _assert_project_root(project_dir: Path, *, command: str) -> None:
     if not project_dir.exists() or not project_dir.is_dir():
-        console.print(f"[red]x[/red] Repertoire introuvable: [bold]{project_dir}[/bold].")
+        console.print(f"[red]✗[/red] Répertoire introuvable : [bold]{project_dir}[/bold].")
         raise typer.Exit(1)
 
     has_project_marker = (
@@ -97,8 +97,8 @@ def _assert_project_root(project_dir: Path, *, command: str) -> None:
         return
 
     console.print(
-        f"[red]x[/red] Aucun projet arclith detecte.\n"
-        f"    Executez [bold]arclith-cli {command}[/bold] depuis la racine du projet."
+        f"[red]✗[/red] Aucun projet arclith détecté.\n"
+        f"    Exécutez [bold]arclith-cli {command}[/bold] depuis la racine du projet."
     )
     raise typer.Exit(1)
 
@@ -108,7 +108,7 @@ def _assert_valid_name(raw: str, *, label: str) -> None:
         return
 
     console.print(
-        f"[red]x[/red] Nom de {label} invalide: [bold]{raw}[/bold]. "
+        f"[red]✗[/red] Nom de {label} invalide : [bold]{raw}[/bold]. "
         "Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre."
     )
     raise typer.Exit(1)
@@ -118,7 +118,7 @@ def _assert_missing(path: Path, project_dir: Path) -> None:
     if not path.exists():
         return
 
-    console.print(f"[red]x[/red] Le fichier existe deja: [bold]{path.relative_to(project_dir)}[/bold].")
+    console.print(f"[red]✗[/red] Le fichier existe déjà : [bold]{path.relative_to(project_dir)}[/bold].")
     raise typer.Exit(1)
 
 
@@ -139,14 +139,27 @@ def _ensure_package_dirs(paths: ProjectPaths, *relative_parts: str) -> None:
             init_file.write_text("", encoding="utf-8")
 
 
-def _strip_pascal_suffix(value: str, suffix: str) -> str:
-    if value.endswith(suffix):
-        return value[: -len(suffix)]
-    return value
+def _strip_pascal_suffix(value: str) -> str:
+    suffixes = ("UseCase", "Usecase")
+    while True:
+        stripped = value
+        for suffix in suffixes:
+            if stripped.endswith(suffix):
+                stripped = stripped[: -len(suffix)]
+                break
+        if stripped == value:
+            return value
+        value = stripped
 
 
 def _strip_snake_suffix(value: str) -> str:
-    for suffix in ("_use_case", "_usecase"):
-        if value.endswith(suffix):
-            return value[: -len(suffix)]
-    return value
+    suffixes = ("_use_case", "_usecase")
+    while True:
+        stripped = value
+        for suffix in suffixes:
+            if stripped.endswith(suffix):
+                stripped = stripped[: -len(suffix)]
+                break
+        if stripped == value:
+            return value
+        value = stripped

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from .project_paths import ProjectPaths, detect_project_paths
+from .rename import EntityNames
+
+console = Console()
+
+_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+_ENTITY_TEMPLATE = """from arclith.domain.models.entity import Entity
+
+
+class {class_name}(Entity):
+    pass
+"""
+
+_USE_CASE_TEMPLATE = """class {class_name}UseCase:
+    async def execute(self) -> None:
+        raise NotImplementedError("Implement {class_name}UseCase.execute")
+"""
+
+
+@dataclass(frozen=True)
+class UseCaseNames:
+    pascal: str
+    snake: str
+
+    @classmethod
+    def from_input(cls, raw: str) -> UseCaseNames:
+        names = EntityNames.from_input(raw)
+        pascal = _strip_pascal_suffix(names.pascal, "UseCase")
+        snake = _strip_snake_suffix(names.snake)
+        if not pascal or not snake:
+            console.print(f"[red]x[/red] Nom de use case invalide: [bold]{raw}[/bold].")
+            raise typer.Exit(1)
+        return cls(pascal=pascal, snake=snake)
+
+
+def add_entity_cmd(*, project_dir: Path | None = None, entity_name: str) -> Path:
+    project_dir = project_dir or Path.cwd()
+    entity_name = entity_name.strip()
+    _assert_project_root(project_dir, command="add-entity")
+    _assert_valid_name(entity_name, label="entite")
+
+    paths = detect_project_paths(project_dir)
+    names = EntityNames.from_input(entity_name)
+    entity_file = paths.domain_models / f"{names.snake}.py"
+    _assert_missing(entity_file, project_dir)
+
+    _ensure_package_dirs(paths, "domain", "models")
+    entity_file.write_text(_ENTITY_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    console.print(
+        f"[green]OK[/green] Entite {names.pascal} creee: "
+        f"[bold]{entity_file.relative_to(project_dir)}[/bold]"
+    )
+    return entity_file
+
+
+def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Path:
+    project_dir = project_dir or Path.cwd()
+    usecase_name = usecase_name.strip()
+    _assert_project_root(project_dir, command="add-usecase")
+    _assert_valid_name(usecase_name, label="use case")
+
+    paths = detect_project_paths(project_dir)
+    names = UseCaseNames.from_input(usecase_name)
+    usecase_file = paths.application_use_cases / f"{names.snake}.py"
+    _assert_missing(usecase_file, project_dir)
+
+    _ensure_package_dirs(paths, "application", "use_cases")
+    usecase_file.write_text(_USE_CASE_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    console.print(
+        f"[green]OK[/green] Use case {names.pascal}UseCase cree: "
+        f"[bold]{usecase_file.relative_to(project_dir)}[/bold]"
+    )
+    return usecase_file
+
+
+def _assert_project_root(project_dir: Path, *, command: str) -> None:
+    if not project_dir.exists() or not project_dir.is_dir():
+        console.print(f"[red]x[/red] Repertoire introuvable: [bold]{project_dir}[/bold].")
+        raise typer.Exit(1)
+
+    has_project_marker = (
+        (project_dir / "pyproject.toml").exists()
+        or (project_dir / "src").is_dir()
+        or (project_dir / "config").is_dir()
+    )
+    if has_project_marker:
+        return
+
+    console.print(
+        f"[red]x[/red] Aucun projet arclith detecte.\n"
+        f"    Executez [bold]arclith-cli {command}[/bold] depuis la racine du projet."
+    )
+    raise typer.Exit(1)
+
+
+def _assert_valid_name(raw: str, *, label: str) -> None:
+    if _NAME_RE.match(raw.strip()):
+        return
+
+    console.print(
+        f"[red]x[/red] Nom de {label} invalide: [bold]{raw}[/bold]. "
+        "Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre."
+    )
+    raise typer.Exit(1)
+
+
+def _assert_missing(path: Path, project_dir: Path) -> None:
+    if not path.exists():
+        return
+
+    console.print(f"[red]x[/red] Le fichier existe deja: [bold]{path.relative_to(project_dir)}[/bold].")
+    raise typer.Exit(1)
+
+
+def _ensure_package_dirs(paths: ProjectPaths, *relative_parts: str) -> None:
+    target_dir = paths.package_root.joinpath(*relative_parts)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    stop_at = paths.package_root.parent if paths.package_name is not None else paths.package_root
+    init_dirs = [target_dir]
+    for parent in target_dir.parents:
+        if parent == stop_at:
+            break
+        init_dirs.append(parent)
+
+    for directory in init_dirs:
+        init_file = directory / "__init__.py"
+        if not init_file.exists():
+            init_file.write_text("", encoding="utf-8")
+
+
+def _strip_pascal_suffix(value: str, suffix: str) -> str:
+    if value.endswith(suffix):
+        return value[: -len(suffix)]
+    return value
+
+
+def _strip_snake_suffix(value: str) -> str:
+    for suffix in ("_use_case", "_usecase"):
+        if value.endswith(suffix):
+            return value[: -len(suffix)]
+    return value

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -284,9 +284,9 @@ def _prompt_project() -> str:
 
 
 def _prompt_usecase() -> str:
-    console.print("\n[bold]Use case[/bold] [dim](ex : PlanShoppingList, find_by_name)[/dim]")
+    console.print("\n[bold]Cas d'usage[/bold] [dim](ex : PlanShoppingList, find_by_name)[/dim]")
     while True:
-        value = Prompt.ask("  [bold green]Nom du use case[/bold green]").strip()
+        value = Prompt.ask("  [bold green]Nom du cas d'usage[/bold green]").strip()
         if not value:
             console.print("  [red]Le nom ne peut pas être vide.[/red]")
         elif not _ENTITY_RE.match(value):

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -15,6 +15,7 @@ from rich.tree import Tree
 from . import __version__
 from .add_adapter import add_adapter_cmd
 from .capabilities import CAPABILITY_CATALOG, capability_catalog_as_dict
+from .core_scaffold import add_entity_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .rename import EntityNames, apply_rename
 from .scaffold import download_and_extract
@@ -178,6 +179,32 @@ def add_adapter(
     )
 
 
+@app.command(name="add-entity")
+def add_entity(
+    entity: Annotated[
+        str | None,
+        typer.Argument(
+            help="Nom de l'entité métier au singulier. Exemple : Recipe, recipe_step, meal-plan",
+        ),
+    ] = None,
+) -> None:
+    """Créer uniquement le fichier minimal d'une entité métier dans domain/models."""
+    add_entity_cmd(entity_name=entity or _prompt_entity())
+
+
+@app.command(name="add-usecase")
+def add_usecase(
+    usecase: Annotated[
+        str | None,
+        typer.Argument(
+            help="Nom du cas d'usage. Exemple : PlanShoppingList, find_by_name, import-catalog",
+        ),
+    ] = None,
+) -> None:
+    """Créer uniquement le fichier minimal d'un cas d'usage dans application/use_cases."""
+    add_usecase_cmd(usecase_name=usecase or _prompt_usecase())
+
+
 @app.command(name="capabilities")
 def capabilities(
     as_json: Annotated[
@@ -248,6 +275,21 @@ def _prompt_project() -> str:
         if not value:
             console.print("  [red]Le nom ne peut pas être vide.[/red]")
         elif not _PROJECT_RE.match(value):
+            console.print(
+                "  [red]Caractères invalides.[/red] "
+                "[dim]Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre.[/dim]"
+            )
+        else:
+            return value
+
+
+def _prompt_usecase() -> str:
+    console.print("\n[bold]Use case[/bold] [dim](ex : PlanShoppingList, find_by_name)[/dim]")
+    while True:
+        value = Prompt.ask("  [bold green]Nom du use case[/bold green]").strip()
+        if not value:
+            console.print("  [red]Le nom ne peut pas être vide.[/red]")
+        elif not _ENTITY_RE.match(value):
             console.print(
                 "  [red]Caractères invalides.[/red] "
                 "[dim]Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre.[/dim]"

--- a/cli/arclith_cli/project_paths.py
+++ b/cli/arclith_cli/project_paths.py
@@ -13,6 +13,10 @@ class ProjectPaths:
         return self.package_root / "domain" / "models"
 
     @property
+    def application_use_cases(self) -> Path:
+        return self.package_root / "application" / "use_cases"
+
+    @property
     def adapters_outbound(self) -> Path:
         return self.package_root / "adapters" / "outbound"
 
@@ -33,13 +37,29 @@ def detect_project_paths(project_dir: Path) -> ProjectPaths:
     """Detect the importable application package for an Arclith project."""
     src_dir = project_dir / "src"
     if src_dir.exists():
-        candidates = sorted(
+        model_candidates = sorted(
             child
             for child in src_dir.iterdir()
             if child.is_dir() and (child / "domain" / "models").exists()
         )
-        if candidates:
-            package_root = candidates[0]
+        if model_candidates:
+            package_root = model_candidates[0]
+            return ProjectPaths(root=project_dir, package_root=package_root, package_name=package_root.name)
+
+        package_candidates = sorted(
+            child
+            for child in src_dir.iterdir()
+            if child.is_dir() and _looks_like_package_root(child)
+        )
+        if package_candidates:
+            package_root = package_candidates[0]
             return ProjectPaths(root=project_dir, package_root=package_root, package_name=package_root.name)
 
     return ProjectPaths(root=project_dir, package_root=project_dir, package_name=None)
+
+
+def _looks_like_package_root(path: Path) -> bool:
+    if (path / "__init__.py").exists():
+        return True
+
+    return any((path / layer).is_dir() for layer in ("domain", "application", "adapters", "infrastructure"))

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -49,10 +49,10 @@ def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> N
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
 
-def test_add_usecase_does_not_duplicate_usecase_suffix(tmp_path: Path) -> None:
+def test_add_usecase_strips_repeated_usecase_suffix(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="plan-shopping-list-use-case")
+    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="plan-shopping-list-use-case-usecase")
 
     assert generated.name == "plan_shopping_list.py"
     assert "class PlanShoppingListUseCase:" in generated.read_text(encoding="utf-8")

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+from arclith_cli.core_scaffold import add_entity_cmd, add_usecase_cmd
+
+
+def _src_project(tmp_path: Path, package_name: str = "demo_service") -> Path:
+    project_dir = tmp_path / "demo-service"
+    package_root = project_dir / "src" / package_name
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text('[project]\nname = "demo-service"\n', encoding="utf-8")
+    return project_dir
+
+
+def test_add_entity_creates_minimal_entity_in_src_package(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    generated = add_entity_cmd(project_dir=project_dir, entity_name="ShoppingItem")
+
+    assert generated == project_dir / "src" / "demo_service" / "domain" / "models" / "shopping_item.py"
+    assert generated.read_text(encoding="utf-8") == (
+        "from arclith.domain.models.entity import Entity\n"
+        "\n"
+        "\n"
+        "class ShoppingItem(Entity):\n"
+        "    pass\n"
+    )
+    assert (project_dir / "src" / "demo_service" / "domain" / "__init__.py").exists()
+    assert (project_dir / "src" / "demo_service" / "domain" / "models" / "__init__.py").exists()
+    assert not (project_dir / "src" / "demo_service" / "adapters").exists()
+
+
+def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="PlanShoppingList")
+
+    assert generated == project_dir / "src" / "demo_service" / "application" / "use_cases" / "plan_shopping_list.py"
+    assert generated.read_text(encoding="utf-8") == (
+        "class PlanShoppingListUseCase:\n"
+        "    async def execute(self) -> None:\n"
+        '        raise NotImplementedError("Implement PlanShoppingListUseCase.execute")\n'
+    )
+    assert (project_dir / "src" / "demo_service" / "application" / "__init__.py").exists()
+    assert (project_dir / "src" / "demo_service" / "application" / "use_cases" / "__init__.py").exists()
+    assert not (project_dir / "src" / "demo_service" / "adapters").exists()
+
+
+def test_add_usecase_does_not_duplicate_usecase_suffix(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="plan-shopping-list-use-case")
+
+    assert generated.name == "plan_shopping_list.py"
+    assert "class PlanShoppingListUseCase:" in generated.read_text(encoding="utf-8")
+    assert "UseCaseUseCase" not in generated.read_text(encoding="utf-8")
+
+
+def test_add_entity_supports_legacy_root_layout(tmp_path: Path) -> None:
+    project_dir = tmp_path / "legacy-service"
+    project_dir.mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text('[project]\nname = "legacy-service"\n', encoding="utf-8")
+
+    generated = add_entity_cmd(project_dir=project_dir, entity_name="Recipe")
+
+    assert generated == project_dir / "domain" / "models" / "recipe.py"
+    assert (project_dir / "domain" / "__init__.py").exists()
+    assert (project_dir / "domain" / "models" / "__init__.py").exists()
+    assert not (project_dir / "__init__.py").exists()
+
+
+def test_add_entity_refuses_to_overwrite_existing_file(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+    existing = project_dir / "src" / "demo_service" / "domain" / "models" / "recipe.py"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("class Recipe:\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        add_entity_cmd(project_dir=project_dir, entity_name="Recipe")
+
+    assert existing.read_text(encoding="utf-8") == "class Recipe:\n    pass\n"
+
+
+def test_add_usecase_rejects_invalid_name(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(project_dir=project_dir, usecase_name="123-import")

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -169,12 +169,20 @@ def test_scaffold_and_run(temp_workspace: Path):
         project_dir / "src" / "test_plan_service" / "application" / "use_cases" / "plan_shopping_list.py"
     ).exists()
 
+    import_script = "\n".join(
+        [
+            "from test_plan_service.domain.models.shopping_item import ShoppingItem",
+            "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase",
+            "print(ShoppingItem.__name__, PlanShoppingListUseCase.__name__)",
+        ]
+    )
     result = subprocess.run(
         [
-            "uv", "run", "python", "-c",
-            "from test_plan_service.domain.models.shopping_item import ShoppingItem; "
-            "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase; "
-            "print(ShoppingItem.__name__, PlanShoppingListUseCase.__name__)"
+            "uv",
+            "run",
+            "python",
+            "-c",
+            import_script,
         ],
         cwd=project_dir,
         capture_output=True,

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -136,7 +136,55 @@ def test_scaffold_and_run(temp_workspace: Path):
     for fname in expected_files:
         assert (project_dir / fname).exists(), f"Missing expected file: {fname}"
 
-    # Step 6 — validate non-interactive adapter generation through the CLI entry point
+    # Step 6 — validate core scaffolding through the CLI entry point
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "add-entity",
+            "ShoppingItem",
+        ],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert (
+        project_dir / "src" / "test_plan_service" / "domain" / "models" / "shopping_item.py"
+    ).exists()
+
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "add-usecase",
+            "PlanShoppingList",
+        ],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-usecase failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert (
+        project_dir / "src" / "test_plan_service" / "application" / "use_cases" / "plan_shopping_list.py"
+    ).exists()
+
+    result = subprocess.run(
+        [
+            "uv", "run", "python", "-c",
+            "from test_plan_service.domain.models.shopping_item import ShoppingItem; "
+            "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase; "
+            "print(ShoppingItem.__name__, PlanShoppingListUseCase.__name__)"
+        ],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Core scaffold import failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert "ShoppingItem PlanShoppingListUseCase" in result.stdout
+
+    # Step 7 — validate non-interactive adapter generation through the CLI entry point
     result = subprocess.run(
         [
             "arclith-cli",

--- a/cli/tests/test_project_paths.py
+++ b/cli/tests/test_project_paths.py
@@ -12,9 +12,23 @@ def test_detect_project_paths_uses_src_package(tmp_path: Path):
     assert paths.package_root == package_root
     assert paths.package_name == "my_service"
     assert paths.domain_models == package_root / "domain" / "models"
+    assert paths.application_use_cases == package_root / "application" / "use_cases"
     assert paths.adapters_outbound == package_root / "adapters" / "outbound"
     assert paths.containers == package_root / "infrastructure" / "containers"
     assert paths.import_path("domain", "models", "recipe") == "my_service.domain.models.recipe"
+
+
+def test_detect_project_paths_uses_src_package_before_domain_exists(tmp_path: Path):
+    package_root = tmp_path / "src" / "my_service"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+
+    paths = detect_project_paths(tmp_path)
+
+    assert paths.package_root == package_root
+    assert paths.package_name == "my_service"
+    assert paths.domain_models == package_root / "domain" / "models"
+    assert paths.application_use_cases == package_root / "application" / "use_cases"
 
 
 def test_detect_project_paths_supports_root_layout(tmp_path: Path):
@@ -24,4 +38,6 @@ def test_detect_project_paths_supports_root_layout(tmp_path: Path):
 
     assert paths.package_root == tmp_path
     assert paths.package_name is None
+    assert paths.domain_models == tmp_path / "domain" / "models"
+    assert paths.application_use_cases == tmp_path / "application" / "use_cases"
     assert paths.import_path("domain", "models", "recipe") == "domain.models.recipe"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -16,6 +16,27 @@ Une capacite decrit:
 
 Le code metier reste dans `domain/` et `application/`. Les capacites ne doivent generer que du cablage, des ports, des schemas ou des adapters autour de ce coeur.
 
+## Scaffold du coeur metier
+
+Les entites et les use cases ne sont pas des capacites du catalogue: ils appartiennent au coeur
+metier. La CLI peut seulement poser les fichiers minimaux, sans CRUD par defaut et sans cablage
+automatique vers FastAPI, FastMCP, LangGraph ou un repository.
+
+```bash
+arclith-cli add-entity ShoppingItem
+arclith-cli add-usecase PlanShoppingList
+```
+
+Fichiers generes:
+
+```text
+src/<package>/domain/models/shopping_item.py
+src/<package>/application/use_cases/plan_shopping_list.py
+```
+
+Le developpeur garde la responsabilite de definir les champs, invariants, ports et orchestration
+metier. Les adapters se branchent ensuite explicitement via `add-adapter`.
+
 ## Catalogue actuel
 
 ```bash

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -16,10 +16,10 @@ Une capacite decrit:
 
 Le code metier reste dans `domain/` et `application/`. Les capacites ne doivent generer que du cablage, des ports, des schemas ou des adapters autour de ce coeur.
 
-## Scaffold du coeur metier
+## Scaffold du cœur métier
 
-Les entites et les use cases ne sont pas des capacites du catalogue: ils appartiennent au coeur
-metier. La CLI peut seulement poser les fichiers minimaux, sans CRUD par defaut et sans cablage
+Les entités et les use cases ne sont pas des capacités du catalogue : ils appartiennent au cœur
+métier. La CLI peut seulement poser les fichiers minimaux, sans CRUD par défaut et sans câblage
 automatique vers FastAPI, FastMCP, LangGraph ou un repository.
 
 ```bash
@@ -27,15 +27,15 @@ arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
 ```
 
-Fichiers generes:
+Fichiers générés :
 
 ```text
 src/<package>/domain/models/shopping_item.py
 src/<package>/application/use_cases/plan_shopping_list.py
 ```
 
-Le developpeur garde la responsabilite de definir les champs, invariants, ports et orchestration
-metier. Les adapters se branchent ensuite explicitement via `add-adapter`.
+Le développeur garde la responsabilité de définir les champs, invariants, ports et orchestration
+métier. Les adapters se branchent ensuite explicitement via `add-adapter`.
 
 ## Catalogue actuel
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,16 +110,16 @@ curl -fsS "http://127.0.0.1:8100/v1/ingredients/?name=farine"
 
 ## 3. Changer ou ajouter un adapter outbound
 
-Pour ajouter seulement du coeur metier, sans CRUD ni adapter automatique:
+Pour ajouter seulement du cœur métier, sans CRUD ni adapter automatique :
 
 ```bash
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
 ```
 
-Ces commandes creent des fichiers minimaux dans `src/<package>/domain/models/` et
+Ces commandes créent des fichiers minimaux dans `src/<package>/domain/models/` et
 `src/<package>/application/use_cases/`. Les champs, invariants, ports et appels aux adapters restent
-du code metier a ecrire dans le projet.
+du code métier à écrire dans le projet.
 
 L'adapter actif est declare dans:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,6 +110,17 @@ curl -fsS "http://127.0.0.1:8100/v1/ingredients/?name=farine"
 
 ## 3. Changer ou ajouter un adapter outbound
 
+Pour ajouter seulement du coeur metier, sans CRUD ni adapter automatique:
+
+```bash
+arclith-cli add-entity ShoppingItem
+arclith-cli add-usecase PlanShoppingList
+```
+
+Ces commandes creent des fichiers minimaux dans `src/<package>/domain/models/` et
+`src/<package>/application/use_cases/`. Les champs, invariants, ports et appels aux adapters restent
+du code metier a ecrire dans le projet.
+
 L'adapter actif est declare dans:
 
 ```text


### PR DESCRIPTION
## What changed

- Add `arclith-cli add-entity` to create a minimal `domain/models/<entity>.py` file.
- Add `arclith-cli add-usecase` to create a minimal `application/use_cases/<usecase>.py` file.
- Improve CLI project path detection for `src/<package>` projects before `domain/models` exists.
- Document that these commands do not generate CRUD, adapters, repositories, endpoints, or LangGraph wiring by default.

## Why

This gives developers a small, explicit way to start the business core after project creation without forcing CRUD semantics. Adapter wiring remains a separate `add-adapter` decision.

## Validation

- `cd cli && uv run --frozen python -m ruff check arclith_cli tests`
- `cd cli && uv run --frozen python -m pytest tests/ -q` (`38 passed`)
- `make quality` (`265 passed`, coverage `90.24%`)
- `git diff --check`