### PR TITLE
Add Todo tutorial and Pages docs

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,62 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install docs dependencies
+        run: uv sync --frozen --group docs
+
+      - name: Build MkDocs
+        run: uv run --frozen --group docs mkdocs build --strict
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ secrets.yaml
 # artefacts de test / qualité
 .coverage
 htmlcov/
+site/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint typecheck security complexity test coverage quality precommit setup
+.PHONY: lint typecheck security complexity test coverage docs docs-serve quality precommit setup
 
 SRC := arclith
 UV  := uv run --frozen
@@ -25,6 +25,12 @@ test:
 
 coverage:
 	uv run --frozen --extra all python -m pytest --cov --cov-report=term-missing --cov-report=html
+
+docs:
+	uv run --frozen --group docs mkdocs build --strict
+
+docs-serve:
+	uv run --group docs mkdocs serve
 
 quality: lint security complexity typecheck coverage
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Pour créer un projet concret avec la CLI, lancer API/MCP/probes, puis faire év
 Pour poser uniquement le cœur métier minimal après création d'un projet :
 
 ```bash
+arclith-cli init todo-list-service
+cd todo-list-service
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,6 +10,25 @@ uv tool install "git+https://github.com/karned-rekipe/arclith.git#subdirectory=c
 
 ## Commandes
 
+### `init` — Initialiser un projet minimal
+
+Crée un projet Arclith vide de métier, avec le layout canonique `src/<package>/...`, une
+configuration minimale et un `main.py` prêt à recevoir les adapters.
+
+```bash
+# Mode interactif
+arclith-cli init
+
+# Mode direct
+arclith-cli init todo-list-service
+arclith-cli init todo-list-service --dir ~/projects
+```
+
+Cette commande ne crée aucune entité, aucun CRUD et aucun endpoint métier. Elle sert quand on veut
+construire le projet étape par étape avec `add-entity`, `add-usecase`, puis `add-adapter`.
+
+---
+
 ### `new` — Créer un projet
 
 Scaffold un nouveau projet arclith depuis le template officiel `_sample`.

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.tree import Tree
+
+console = Console()
+
+_PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+
+def init_project_cmd(*, project_name: str, directory: Path | None = None) -> Path:
+    """Create a minimal Arclith project without a starter entity."""
+    project_name = project_name.strip()
+    _assert_valid_project_name(project_name)
+
+    parent_dir = (directory or Path(".")).resolve()
+    target_dir = parent_dir / project_name
+    if target_dir.exists():
+        console.print(f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]")
+        raise typer.Exit(1)
+
+    package_name = _to_package(project_name)
+    package_root = target_dir / "src" / package_name
+
+    _create_package_layout(package_root)
+    _write_project_files(target_dir, project_name, package_name)
+    _write_config(target_dir, project_name)
+    _write_tests(target_dir, package_name)
+
+    console.print(
+        Panel.fit(
+            f"[bold blue]arclith-cli[/bold blue]\n\n"
+            f"  Projet   [bold]{project_name}[/bold]\n"
+            f"  Package  [bold green]{package_name}[/bold green]\n"
+            f"  Cible    [dim]{target_dir}[/dim]\n"
+            f"  Métier   [dim]vide, à créer avec add-entity et add-usecase[/dim]",
+            border_style="blue",
+            title="[bold]Projet minimal[/bold]",
+        )
+    )
+    _print_tree(target_dir, project_name)
+    return target_dir
+
+
+def _assert_valid_project_name(project_name: str) -> None:
+    if _PROJECT_RE.match(project_name):
+        return
+    console.print(
+        f"[red]✗[/red] Nom de projet invalide : [bold]{project_name}[/bold]. "
+        "Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre."
+    )
+    raise typer.Exit(1)
+
+
+def _to_package(raw: str) -> str:
+    package = raw.replace("-", "_").lower()
+    package = re.sub(r"[^a-z0-9_]", "_", package)
+    package = re.sub(r"_+", "_", package).strip("_")
+    if not package or not package[0].isalpha():
+        console.print(f"[red]✗[/red] Nom de package Python invalide pour : [bold]{raw}[/bold].")
+        raise typer.Exit(1)
+    return package
+
+
+def _framework_version() -> str:
+    try:
+        return version("arclith")
+    except PackageNotFoundError:
+        return "0.13.0"
+
+
+def _create_package_layout(package_root: Path) -> None:
+    dirs = (
+        package_root,
+        package_root / "domain",
+        package_root / "domain" / "models",
+        package_root / "domain" / "ports",
+        package_root / "domain" / "ports" / "outbound",
+        package_root / "application",
+        package_root / "application" / "use_cases",
+        package_root / "application" / "planners",
+        package_root / "adapters",
+        package_root / "adapters" / "inbound",
+        package_root / "adapters" / "outbound",
+        package_root / "infrastructure",
+        package_root / "infrastructure" / "containers",
+    )
+    for directory in dirs:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "py.typed").write_text("", encoding="utf-8")
+
+
+def _write_project_files(target_dir: Path, project_name: str, package_name: str) -> None:
+    framework_version = _framework_version()
+    (target_dir / "pyproject.toml").write_text(
+        f"""[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{project_name}"
+version = "0.1.0"
+description = "Arclith service"
+requires-python = ">=3.13"
+dependencies = [
+    "arclith[fastapi,mcp]>={framework_version}",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{package_name}"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.0",
+    "pytest-asyncio>=1.3.0",
+    "httpx>=0.27.0",
+]
+""",
+        encoding="utf-8",
+    )
+    (target_dir / "README.md").write_text(
+        f"""# {project_name}
+
+Projet Arclith minimal.
+
+```bash
+uv sync
+uv run python -m pytest
+```
+""",
+        encoding="utf-8",
+    )
+    (target_dir / ".gitignore").write_text(
+        """__pycache__/
+*.pyc
+.venv/
+.env
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+*.egg-info/
+""",
+        encoding="utf-8",
+    )
+    (target_dir / "main.py").write_text(
+        f'''"""Application entrypoint for {project_name}."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from arclith import Arclith
+
+_CONFIG = Path(__file__).parent / "config"
+
+arclith = Arclith(_CONFIG)
+app = arclith.fastapi()
+
+
+def _run_api() -> None:
+    arclith.run_api("main:app")
+
+
+if __name__ == "__main__":
+    arclith.run_with_probes(_run_api, transports=["api"])
+''',
+        encoding="utf-8",
+    )
+
+
+def _write_config(target_dir: Path, project_name: str) -> None:
+    config_dir = target_dir / "config"
+    adapters_dir = config_dir / "adapters"
+    inbound_dir = adapters_dir / "inbound"
+    inbound_dir.mkdir(parents=True, exist_ok=True)
+    (adapters_dir / "outbound").mkdir(parents=True, exist_ok=True)
+
+    (config_dir / "app.yaml").write_text(
+        f'''name: {project_name}
+version: "0.1.0"
+description: "{project_name} — built with Arclith"
+''',
+        encoding="utf-8",
+    )
+    (adapters_dir / "adapters.yaml").write_text(
+        """logger: console
+repository: memory
+observability: none
+""",
+        encoding="utf-8",
+    )
+    (config_dir / "http.yaml").write_text(
+        """idempotency:
+  enabled: true
+  ttl_seconds: 86400
+  required: false
+
+etag:
+  enabled: true
+
+cache_control:
+  get_single_max_age: 300
+  get_list_max_age: 60
+""",
+        encoding="utf-8",
+    )
+    (config_dir / "soft_delete.yaml").write_text("retention_days: 30\n", encoding="utf-8")
+    (inbound_dir / "probe.yaml").write_text(
+        """host: 0.0.0.0
+port: 9000
+enabled: true
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_tests(target_dir: Path, package_name: str) -> None:
+    test_dir = target_dir / "tests"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    (test_dir / "__init__.py").write_text("", encoding="utf-8")
+    (test_dir / "test_project_bootstrap.py").write_text(
+        f"""from arclith import Arclith
+
+
+def test_project_config_loads() -> None:
+    app = Arclith("config")
+
+    assert app.config.app.name
+    assert app.config.adapters.repository == "memory"
+
+
+def test_package_imports() -> None:
+    import {package_name}
+
+    assert {package_name}.__name__ == "{package_name}"
+""",
+        encoding="utf-8",
+    )
+
+
+def _print_tree(target_dir: Path, project_name: str) -> None:
+    tree = Tree(f"[bold green]{project_name}/[/bold green]")
+    _build_tree(tree, target_dir, depth=0, max_depth=3)
+    console.print()
+    console.print(tree)
+    console.print(
+        Panel(
+            f"[bold cyan]cd[/bold cyan] {target_dir}\n"
+            f"[bold cyan]uv sync[/bold cyan]\n"
+            f"[bold cyan]arclith-cli add-entity[/bold cyan]\n"
+            f"[bold cyan]arclith-cli add-usecase[/bold cyan]",
+            title="[bold blue]Next steps[/bold blue]",
+            border_style="green",
+        )
+    )
+
+
+def _build_tree(node: Tree, path: Path, depth: int, max_depth: int) -> None:
+    if depth >= max_depth:
+        return
+    children = sorted(path.iterdir(), key=lambda p: (p.is_file(), p.name))
+    for child in children:
+        if child.name.startswith("."):
+            continue
+        label = f"[blue]{child.name}/[/blue]" if child.is_dir() else child.name
+        branch = node.add(label)
+        if child.is_dir():
+            _build_tree(branch, child, depth + 1, max_depth)

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -17,6 +17,7 @@ from .add_adapter import add_adapter_cmd
 from .capabilities import CAPABILITY_CATALOG, capability_catalog_as_dict
 from .core_scaffold import add_entity_cmd, add_planner_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
+from .init_project import init_project_cmd
 from .rename import EntityNames, apply_rename
 from .scaffold import download_and_extract
 from .updater import run_update
@@ -31,6 +32,21 @@ console = Console()
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+
+@app.command()
+def init(
+    project_name: Annotated[
+        str | None,
+        typer.Argument(help="Nom du répertoire du projet. Exemple : todo-list-service"),
+    ] = None,
+    directory: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Répertoire parent où le projet sera créé"),
+    ] = Path("."),
+) -> None:
+    """Initialiser un projet arclith minimal sans entité métier."""
+    init_project_cmd(project_name=project_name or _prompt_project(), directory=directory)
 
 
 @app.command()

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -4,6 +4,7 @@ import pytest
 import typer
 
 from arclith_cli.core_scaffold import add_entity_cmd, add_planner_cmd, add_usecase_cmd
+from arclith_cli.init_project import init_project_cmd
 
 
 def _src_project(tmp_path: Path, package_name: str = "demo_service") -> Path:
@@ -31,6 +32,33 @@ def test_add_entity_creates_minimal_entity_in_src_package(tmp_path: Path) -> Non
     assert (project_dir / "src" / "demo_service" / "domain" / "__init__.py").exists()
     assert (project_dir / "src" / "demo_service" / "domain" / "models" / "__init__.py").exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
+
+
+def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) -> None:
+    generated = init_project_cmd(project_name="todo-list-service", directory=tmp_path)
+
+    package_root = generated / "src" / "todo_list_service"
+    assert generated == tmp_path / "todo-list-service"
+    assert (generated / "pyproject.toml").exists()
+    assert (generated / "main.py").exists()
+    assert (generated / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8") == (
+        "logger: console\n"
+        "repository: memory\n"
+        "observability: none\n"
+    )
+    assert (package_root / "domain" / "models" / "__init__.py").exists()
+    assert (package_root / "application" / "use_cases" / "__init__.py").exists()
+    assert (package_root / "adapters" / "inbound" / "__init__.py").exists()
+    assert (package_root / "infrastructure" / "containers" / "__init__.py").exists()
+    assert sorted(path.name for path in (package_root / "domain" / "models").glob("*.py")) == ["__init__.py"]
+
+
+def test_init_project_refuses_existing_directory(tmp_path: Path) -> None:
+    project_dir = tmp_path / "todo-list-service"
+    project_dir.mkdir()
+
+    with pytest.raises(typer.Exit):
+        init_project_cmd(project_name="todo-list-service", directory=tmp_path)
 
 
 def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> None:

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -49,6 +49,52 @@ def _inject_local_arclith_source(project_dir: Path) -> None:
     )
 
 
+def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Path):
+    project_dir = temp_workspace / "todo-list-service"
+
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "init",
+            "todo-list-service",
+            "--dir",
+            str(temp_workspace),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"init failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert (project_dir / "src" / "todo_list_service" / "domain" / "models" / "__init__.py").exists()
+    assert not (project_dir / "src" / "todo_list_service" / "domain" / "models" / "todo.py").exists()
+    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        ["arclith-cli", "add-entity", "Todo"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    result = subprocess.run(
+        ["arclith-cli", "add-usecase", "CreateTodo"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-usecase failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert (project_dir / "src" / "todo_list_service" / "domain" / "models" / "todo.py").exists()
+    assert (
+        project_dir / "src" / "todo_list_service" / "application" / "use_cases" / "create_todo.py"
+    ).exists()
+
+
 def test_scaffold_and_run(temp_workspace: Path):
     """Test that scaffolded project installs and runs successfully."""
     project_dir = temp_workspace / "test-plan-service"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -125,6 +125,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.6" },
     { name = "types-pyyaml", specifier = "==6.0.12.20250516" },
 ]
+docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 
 [[package]]
 name = "arclith-cli"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -20,11 +20,13 @@ câblage, des ports, des schémas ou des adapters autour de ce cœur.
 
 ## Scaffold du cœur métier
 
-Les entités et les use cases ne sont pas des capacités du catalogue : ils appartiennent au cœur
+`arclith-cli init` initialise un projet vide de métier. Les entités et les use cases ne sont pas des capacités du catalogue : ils appartiennent au cœur
 métier. La CLI peut seulement poser les fichiers minimaux, sans CRUD par défaut et sans câblage
 automatique vers FastAPI, FastMCP, LangGraph ou un repository.
 
 ```bash
+arclith-cli init todo-list-service
+cd todo-list-service
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
 arclith-cli add-planner ShoppingIntent

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# Arclith
+
+Arclith est un framework Python 3.13 pour construire des microservices en architecture hexagonale.
+
+Le chemin recommandé pour découvrir le projet est le tutoriel Todo:
+
+- [Vue d'ensemble](tutorials/todo-list/index.md)
+- [Initialiser le projet](tutorials/todo-list/01-init-project.md)
+- [Créer l'entité](tutorials/todo-list/02-create-entity.md)
+- [Créer le use case](tutorials/todo-list/03-create-usecase.md)
+- [Exposer une API](tutorials/todo-list/04-api.md)
+- [Exposer un MCP](tutorials/todo-list/05-mcp.md)
+- [Ajouter un agent](tutorials/todo-list/06-agent.md)
+
+Les quickstarts existants restent disponibles:
+
+- [Quickstart Arclith](quickstart.md)
+- [Quickstart Agent](agent-quickstart.md)
+- [Capacités standardisées](capabilities.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,6 +23,16 @@ uv tool install "git+https://github.com/karned-rekipe/arclith.git#subdirectory=c
 arclith-cli version
 ```
 
+Pour partir d'un projet vide de métier, utiliser `init`, puis ajouter explicitement les fichiers
+du cœur:
+
+```bash
+arclith-cli init todo-list-service
+cd todo-list-service
+arclith-cli add-entity Todo
+arclith-cli add-usecase CreateTodo
+```
+
 Pour tester une branche de développement avant merge:
 
 ```bash

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -1,0 +1,77 @@
+# 1. Initialiser le projet
+
+Objectif: créer uniquement le projet Arclith minimal, sans entité métier et sans CRUD généré.
+
+![Capture interactive init](assets/01-init-project.svg)
+
+Depuis le dossier qui contiendra les projets de test:
+
+```bash
+mkdir -p ~/Perso/projets/demo-arclith
+cd ~/Perso/projets/demo-arclith
+
+arclith-cli init
+```
+
+Répondre au prompt:
+
+```text
+Projet (ex : my-recipe-service, meal-planner)
+  Nom du projet: todo-list-service
+```
+
+Entrer dans le projet et installer les dépendances:
+
+```bash
+cd todo-list-service
+uv sync
+```
+
+Le projet démarre avec `repository: memory`:
+
+```yaml
+# config/adapters/adapters.yaml
+logger: console
+repository: memory
+observability: none
+```
+
+La structure attendue est:
+
+```text
+todo-list-service/
+  config/
+  src/todo_list_service/
+    domain/
+    application/
+    adapters/
+    infrastructure/
+  tests/
+  main.py
+  pyproject.toml
+```
+
+## Tester
+
+Le scaffold minimal contient un test de bootstrap:
+
+```bash
+uv run python -m pytest
+```
+
+Résultat attendu:
+
+```text
+tests/test_project_bootstrap.py ..   [100%]
+```
+
+## Voie rapide
+
+```bash
+arclith-cli init todo-list-service
+cd todo-list-service
+uv sync
+uv run python -m pytest
+```
+
+Étape suivante: [créer l'entité Todo](02-create-entity.md).

--- a/docs/tutorials/todo-list/02-create-entity.md
+++ b/docs/tutorials/todo-list/02-create-entity.md
@@ -1,0 +1,129 @@
+# 2. Créer l'entité Todo
+
+Objectif: utiliser la CLI pour créer le fichier minimal, puis écrire le modèle métier.
+
+![Capture interactive add-entity](assets/02-create-entity.svg)
+
+Depuis la racine du projet:
+
+```bash
+arclith-cli add-entity
+```
+
+Répondre au prompt:
+
+```text
+Entité — utilisez le singulier (ex : Recipe, recipe_step, MealPlan)
+  Nom de l'entité: Todo
+```
+
+La CLI crée:
+
+```text
+src/todo_list_service/domain/models/todo.py
+```
+
+Remplacer le contenu par:
+
+```python
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import StrEnum
+
+from arclith.domain.models.entity import Entity
+from pydantic import Field, field_validator, model_validator
+
+
+class TodoStatus(StrEnum):
+    TODO = "todo"
+    WIP = "wip"
+    DONE = "done"
+
+
+class Todo(Entity):
+    title: str = Field(min_length=1, max_length=140)
+    description: str = Field(default="", max_length=4000)
+    due_date: date
+    completed_at: datetime | None = None
+    status: TodoStatus = TodoStatus.TODO
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("title ne peut pas être vide")
+        return normalized
+
+    @field_validator("description")
+    @classmethod
+    def normalize_description(cls, value: str) -> str:
+        return value.strip()
+
+    @model_validator(mode="after")
+    def validate_completion(self) -> "Todo":
+        if self.status == TodoStatus.DONE and self.completed_at is None:
+            raise ValueError("completed_at est requis quand status=done")
+        if self.status != TodoStatus.DONE and self.completed_at is not None:
+            raise ValueError("completed_at doit rester vide tant que la todo n'est pas done")
+        return self
+```
+
+Commentaires importants:
+
+- `Todo` hérite de `Entity`, donc Arclith fournit déjà `uuid`, `created_at`, `updated_at`,
+  `deleted_at` et `version`;
+- `TodoStatus` est une enum de chaîne pour produire des valeurs JSON lisibles;
+- les invariants métier restent dans le domaine, pas dans FastAPI, MCP ou LangGraph.
+
+## Tester
+
+Créer `tests/test_todo_entity.py`:
+
+```python
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from todo_list_service.domain.models.todo import Todo, TodoStatus
+
+
+def test_create_todo_with_required_fields() -> None:
+    todo = Todo(title="  Préparer la revue  ", due_date=date(2026, 8, 31))
+
+    assert todo.title == "Préparer la revue"
+    assert todo.description == ""
+    assert todo.status == TodoStatus.TODO
+    assert todo.completed_at is None
+
+
+def test_done_requires_completed_at() -> None:
+    with pytest.raises(ValidationError):
+        Todo(title="Publier", due_date=date(2026, 8, 31), status=TodoStatus.DONE)
+
+
+def test_completed_at_is_rejected_before_done() -> None:
+    with pytest.raises(ValidationError):
+        Todo(
+            title="Publier",
+            due_date=date(2026, 8, 31),
+            completed_at=datetime.now(timezone.utc),
+            status=TodoStatus.WIP,
+        )
+```
+
+Lancer:
+
+```bash
+uv run python -m pytest tests/test_todo_entity.py
+```
+
+## Voie rapide
+
+```bash
+arclith-cli add-entity Todo
+```
+
+Étape suivante: [créer le use case](03-create-usecase.md).

--- a/docs/tutorials/todo-list/03-create-usecase.md
+++ b/docs/tutorials/todo-list/03-create-usecase.md
@@ -1,0 +1,157 @@
+# 3. Créer le use case
+
+Objectif: utiliser la CLI pour créer le fichier minimal, puis écrire le cas d'usage qui enregistre
+une todo via un port repository.
+
+![Capture interactive add-usecase](assets/03-create-usecase.svg)
+
+Depuis la racine du projet:
+
+```bash
+arclith-cli add-usecase
+```
+
+Répondre au prompt:
+
+```text
+Cas d'usage (ex : PlanShoppingList, find_by_name)
+  Nom du cas d'usage: CreateTodo
+```
+
+La CLI crée:
+
+```text
+src/todo_list_service/application/use_cases/create_todo.py
+```
+
+Remplacer le contenu par:
+
+```python
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from arclith.domain.ports.outbound.repository import Repository
+from pydantic import BaseModel, Field
+
+from todo_list_service.domain.models.todo import Todo, TodoStatus
+
+
+class CreateTodoCommand(BaseModel):
+    title: str = Field(min_length=1, max_length=140)
+    description: str = Field(default="", max_length=4000)
+    due_date: date
+    status: TodoStatus = TodoStatus.TODO
+    completed_at: datetime | None = None
+
+
+class CreateTodoUseCase:
+    def __init__(self, repository: Repository[Todo]) -> None:
+        self._repository = repository
+
+    async def execute(self, command: CreateTodoCommand) -> Todo:
+        completed_at = command.completed_at
+        if command.status == TodoStatus.DONE and completed_at is None:
+            completed_at = datetime.now(timezone.utc)
+
+        todo = Todo(
+            title=command.title,
+            description=command.description,
+            due_date=command.due_date,
+            status=command.status,
+            completed_at=completed_at,
+        )
+        return await self._repository.create(todo)
+```
+
+Le use case dépend seulement de `Repository[Todo]`. Il ne connaît ni FastAPI, ni FastMCP, ni
+LangGraph, ni MongoDB.
+
+Créer ensuite le container applicatif `src/todo_list_service/infrastructure/containers/todo_container.py`:
+
+```python
+from __future__ import annotations
+
+from arclith import Arclith
+from arclith.domain.ports.outbound.repository import Repository
+
+from todo_list_service.application.use_cases.create_todo import CreateTodoUseCase
+from todo_list_service.domain.models.todo import Todo
+
+_repository: Repository[Todo] | None = None
+
+
+def build_todo_repository(app: Arclith) -> Repository[Todo]:
+    global _repository
+    if _repository is None:
+        _repository = app.repository(Todo)
+    return _repository
+
+
+def build_create_todo_use_case(app: Arclith) -> CreateTodoUseCase:
+    return CreateTodoUseCase(build_todo_repository(app))
+```
+
+Le cache module-level est volontaire pour le mode `memory`: tous les appels API/MCP du même
+processus partagent le même repository.
+
+## Tester
+
+Créer `tests/test_create_todo_usecase.py`:
+
+```python
+from datetime import date
+
+import pytest
+from arclith.adapters.outbound.memory.repository import InMemoryRepository
+
+from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
+from todo_list_service.domain.models.todo import Todo, TodoStatus
+
+
+@pytest.mark.asyncio
+async def test_create_todo_persists_entity() -> None:
+    repository = InMemoryRepository[Todo]()
+    use_case = CreateTodoUseCase(repository)
+
+    todo = await use_case.execute(
+        CreateTodoCommand(
+            title="Écrire le tutoriel",
+            description="Couvrir API, MCP et agent",
+            due_date=date(2026, 9, 1),
+        )
+    )
+
+    assert todo.status == TodoStatus.TODO
+    assert await repository.read(todo.uuid) == todo
+
+
+@pytest.mark.asyncio
+async def test_done_todo_gets_completion_date() -> None:
+    repository = InMemoryRepository[Todo]()
+    use_case = CreateTodoUseCase(repository)
+
+    todo = await use_case.execute(
+        CreateTodoCommand(
+            title="Publier",
+            due_date=date(2026, 9, 1),
+            status=TodoStatus.DONE,
+        )
+    )
+
+    assert todo.completed_at is not None
+```
+
+Lancer:
+
+```bash
+uv run python -m pytest tests/test_todo_entity.py tests/test_create_todo_usecase.py
+```
+
+## Voie rapide
+
+```bash
+arclith-cli add-usecase CreateTodo
+```
+
+Étape suivante: [exposer une API](04-api.md).

--- a/docs/tutorials/todo-list/04-api.md
+++ b/docs/tutorials/todo-list/04-api.md
@@ -1,0 +1,238 @@
+# 4. Exposer une API
+
+Objectif: générer la configuration FastAPI avec la CLI, puis exposer `CreateTodoUseCase` par HTTP.
+
+![Capture interactive FastAPI](assets/04-api.svg)
+
+Depuis la racine du projet:
+
+```bash
+arclith-cli add-adapter --capability api
+```
+
+Répondre aux prompts:
+
+```text
+① Type d'adapter
+   1  fastapi
+
+  Votre choix (numéro ou nom): 1
+
+③ Paramètres fastapi
+  Host FastAPI (0.0.0.0): 0.0.0.0
+  Port FastAPI (8000): 8120
+  Activer le reload FastAPI [y/n] (y): y
+
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La CLI crée:
+
+```text
+config/adapters/inbound/fastapi.yaml
+```
+
+## Schémas HTTP
+
+Créer `src/todo_list_service/adapters/inbound/schemas/todo_schema.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from todo_list_service.domain.models.todo import TodoStatus
+
+
+class TodoCreateSchema(BaseModel):
+    title: str = Field(min_length=1, max_length=140)
+    description: str = Field(default="", max_length=4000)
+    due_date: date
+    status: TodoStatus = TodoStatus.TODO
+    completed_at: datetime | None = None
+
+
+class TodoSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uuid: UUID
+    title: str
+    description: str
+    due_date: date
+    completed_at: datetime | None
+    status: TodoStatus
+    created_at: datetime
+    updated_at: datetime
+    version: int
+```
+
+Créer aussi le package:
+
+```bash
+mkdir -p src/todo_list_service/adapters/inbound/schemas
+touch src/todo_list_service/adapters/inbound/schemas/__init__.py
+```
+
+## Router FastAPI
+
+Créer `src/todo_list_service/adapters/inbound/fastapi/routers/todo_router.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, Response
+
+from arclith.domain.ports.outbound.repository import Repository
+from todo_list_service.adapters.inbound.schemas.todo_schema import TodoCreateSchema, TodoSchema
+from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
+from todo_list_service.domain.models.todo import Todo
+
+
+class TodoRouter:
+    def __init__(self, create_todo: CreateTodoUseCase, repository: Repository[Todo]) -> None:
+        self._create_todo = create_todo
+        self._repository = repository
+        self.router = APIRouter(prefix="/v1/todos", tags=["todos"])
+        self._register_routes()
+
+    def _register_routes(self) -> None:
+        self.router.add_api_route(
+            "/",
+            self.create_todo,
+            methods=["POST"],
+            response_model=TodoSchema,
+            status_code=201,
+            summary="Create todo",
+        )
+        self.router.add_api_route(
+            "/",
+            self.list_todos,
+            methods=["GET"],
+            response_model=list[TodoSchema],
+            summary="List todos",
+        )
+
+    async def create_todo(self, payload: TodoCreateSchema, response: Response, request: Request) -> TodoSchema:
+        todo = await self._create_todo.execute(
+            CreateTodoCommand(
+                title=payload.title,
+                description=payload.description,
+                due_date=payload.due_date,
+                status=payload.status,
+                completed_at=payload.completed_at,
+            )
+        )
+        response.headers["Location"] = f"{request.url.path.rstrip('/')}/{todo.uuid}"
+        return TodoSchema.model_validate(todo)
+
+    async def list_todos(self) -> list[TodoSchema]:
+        todos = await self._repository.find_all()
+        return [TodoSchema.model_validate(todo) for todo in todos]
+```
+
+Créer le package router:
+
+```bash
+mkdir -p src/todo_list_service/adapters/inbound/fastapi/routers
+touch src/todo_list_service/adapters/inbound/fastapi/routers/__init__.py
+```
+
+## Registration
+
+Créer `src/todo_list_service/adapters/inbound/fastapi/register.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from arclith import Arclith
+from todo_list_service.adapters.inbound.fastapi.routers.todo_router import TodoRouter
+from todo_list_service.infrastructure.containers.todo_container import (
+    build_create_todo_use_case,
+    build_todo_repository,
+)
+
+
+def register_routers(app: FastAPI, arclith: Arclith) -> None:
+    repository = build_todo_repository(arclith)
+    create_todo = build_create_todo_use_case(arclith)
+    app.include_router(TodoRouter(create_todo, repository).router)
+```
+
+Mettre à jour `main.py`:
+
+```python
+"""Application entrypoint for todo-list-service."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from arclith import Arclith
+from todo_list_service.adapters.inbound.fastapi.register import register_routers
+
+_CONFIG = Path(__file__).parent / "config"
+
+arclith = Arclith(_CONFIG)
+app = arclith.fastapi()
+register_routers(app, arclith)
+
+
+def _run_api() -> None:
+    arclith.run_api("main:app")
+
+
+if __name__ == "__main__":
+    arclith.run_with_probes(_run_api, transports=["api"])
+```
+
+## Tester
+
+Lancer les tests:
+
+```bash
+uv run python -m pytest
+```
+
+Lancer l'API:
+
+```bash
+uv run python main.py
+```
+
+Dans un autre terminal:
+
+```bash
+curl -fsS http://127.0.0.1:9000/health
+curl -fsS -X POST http://127.0.0.1:8120/v1/todos/ \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: todo-demo-1" \
+  -d '{
+    "title": "Écrire le tutoriel",
+    "description": "Couvrir API, MCP et agent",
+    "due_date": "2026-09-01",
+    "status": "todo"
+  }'
+
+curl -fsS http://127.0.0.1:8120/v1/todos/
+```
+
+La réponse `POST` doit contenir les champs de la todo créée, dont `uuid`, `title`, `due_date`,
+`status`, `created_at` et `version`.
+
+## Voie rapide
+
+```bash
+arclith-cli add-adapter \
+  --capability api \
+  --adapter fastapi \
+  --param host=0.0.0.0 \
+  --param port=8120 \
+  --param reload=true \
+  --yes
+```
+
+Étape suivante: [exposer un MCP](05-mcp.md).

--- a/docs/tutorials/todo-list/05-mcp.md
+++ b/docs/tutorials/todo-list/05-mcp.md
@@ -1,0 +1,240 @@
+# 5. Exposer un MCP
+
+Objectif: générer la configuration FastMCP avec la CLI, puis exposer les mêmes opérations métier via
+des tools MCP.
+
+![Capture interactive FastMCP](assets/05-mcp.svg)
+
+Depuis la racine du projet:
+
+```bash
+arclith-cli add-adapter --capability mcp
+```
+
+Répondre aux prompts:
+
+```text
+① Type d'adapter
+   1  fastmcp
+
+  Votre choix (numéro ou nom): 1
+
+③ Paramètres fastmcp
+  Host FastMCP (127.0.0.1): 127.0.0.1
+  Port FastMCP (8001): 8121
+
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La CLI crée:
+
+```text
+config/adapters/inbound/fastmcp.yaml
+```
+
+## Tools MCP
+
+Créer `src/todo_list_service/adapters/inbound/fastmcp/tools/todo_tools.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Annotated
+
+import fastmcp
+from pydantic import Field
+
+from arclith.domain.ports.outbound.repository import Repository
+from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
+from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
+from todo_list_service.domain.models.todo import Todo, TodoStatus
+
+
+class TodoMCP:
+    def __init__(
+        self,
+        create_todo: CreateTodoUseCase,
+        repository: Repository[Todo],
+        mcp: fastmcp.FastMCP,
+    ) -> None:
+        self._create_todo = create_todo
+        self._repository = repository
+        self._mcp = mcp
+        self._register_tools()
+
+    def _register_tools(self) -> None:
+        create_todo = self._create_todo
+        repository = self._repository
+
+        @self._mcp.tool
+        async def create_todo_item(
+            title: Annotated[str, Field(description="Titre court de la todo.")],
+            due_date: Annotated[date, Field(description="Date d'échéance ISO, ex. 2026-09-01.")],
+            description: Annotated[str, Field(description="Description détaillée.")] = "",
+            status: Annotated[TodoStatus, Field(description="todo, wip ou done.")] = TodoStatus.TODO,
+            completed_at: Annotated[datetime | None, Field(description="Date de réalisation si status=done.")] = None,
+        ) -> dict:
+            """Create a todo through the application use case."""
+            todo = await create_todo.execute(
+                CreateTodoCommand(
+                    title=title,
+                    description=description,
+                    due_date=due_date,
+                    status=status,
+                    completed_at=completed_at,
+                )
+            )
+            return TodoSchema.model_validate(todo).model_dump(mode="json")
+
+        @self._mcp.tool
+        async def list_todo_items() -> list[dict]:
+            """List todos currently available in the repository."""
+            todos = await repository.find_all()
+            return [TodoSchema.model_validate(todo).model_dump(mode="json") for todo in todos]
+```
+
+Créer `src/todo_list_service/adapters/inbound/fastmcp/tools/__init__.py`:
+
+```python
+from todo_list_service.adapters.inbound.fastmcp.tools.todo_tools import TodoMCP
+
+__all__ = ["TodoMCP"]
+```
+
+Créer `src/todo_list_service/adapters/inbound/fastmcp/register.py`:
+
+```python
+from __future__ import annotations
+
+import fastmcp
+
+from arclith import Arclith
+from todo_list_service.adapters.inbound.fastmcp.tools import TodoMCP
+from todo_list_service.infrastructure.containers.todo_container import (
+    build_create_todo_use_case,
+    build_todo_repository,
+)
+
+
+def register_tools(mcp: fastmcp.FastMCP, arclith: Arclith) -> None:
+    repository = build_todo_repository(arclith)
+    create_todo = build_create_todo_use_case(arclith)
+    TodoMCP(create_todo, repository, mcp)
+```
+
+## Entrypoint API + MCP
+
+Remplacer `main.py` par:
+
+```python
+"""Application entrypoint for todo-list-service."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import fastmcp
+from arclith import Arclith
+from todo_list_service.adapters.inbound.fastapi.register import register_routers
+from todo_list_service.adapters.inbound.fastmcp.register import register_tools
+
+_CONFIG = Path(__file__).parent / "config"
+_VALID_MODES = {"api", "mcp_http", "all"}
+
+MODE = os.getenv("MODE", "api")
+if MODE not in _VALID_MODES:
+    print(f"MODE invalide: {MODE!r}. Valeurs: {sorted(_VALID_MODES)}", file=sys.stderr)
+    sys.exit(1)
+
+arclith = Arclith(_CONFIG)
+
+app = arclith.fastapi()
+register_routers(app, arclith)
+
+
+def build_mcp() -> fastmcp.FastMCP:
+    mcp = arclith.fastmcp("Todo MCP")
+    register_tools(mcp, arclith)
+    arclith.instrument_mcp(mcp)
+    return mcp
+
+
+def _run_api() -> None:
+    arclith.run_api("main:app")
+
+
+def _run_mcp_http() -> None:
+    arclith.run_mcp_http(build_mcp())
+
+
+if __name__ == "__main__":
+    match MODE:
+        case "api":
+            arclith.run_with_probes(_run_api, transports=["api"])
+        case "mcp_http":
+            arclith.run_with_probes(_run_mcp_http, transports=["mcp_http"])
+        case "all":
+            arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])
+```
+
+## Tester sans client externe
+
+Créer `tests/test_todo_mcp.py`:
+
+```python
+import pytest
+from fastmcp import Client
+
+from main import build_mcp
+
+
+@pytest.mark.asyncio
+async def test_mcp_create_and_list_todos() -> None:
+    async with Client(build_mcp()) as client:
+        tools = await client.list_tools()
+        assert {tool.name for tool in tools} >= {"create_todo_item", "list_todo_items"}
+
+        result = await client.call_tool(
+            "create_todo_item",
+            {
+                "title": "Tester le MCP",
+                "description": "Appeler le même use case que l'API",
+                "due_date": "2026-09-01",
+                "status": "todo",
+            },
+        )
+
+        assert not result.is_error
+
+        listed = await client.call_tool("list_todo_items", {})
+        assert not listed.is_error
+```
+
+Lancer:
+
+```bash
+uv run python -m pytest tests/test_todo_mcp.py
+```
+
+Smoke HTTP MCP:
+
+```bash
+MODE=mcp_http uv run python main.py
+```
+
+Le serveur écoute sur `http://127.0.0.1:8121/mcp`.
+
+## Voie rapide
+
+```bash
+arclith-cli add-adapter \
+  --capability mcp \
+  --adapter fastmcp \
+  --param host=127.0.0.1 \
+  --param port=8121 \
+  --yes
+```
+
+Étape suivante: [ajouter un agent](06-agent.md).

--- a/docs/tutorials/todo-list/06-agent.md
+++ b/docs/tutorials/todo-list/06-agent.md
@@ -1,0 +1,376 @@
+# 6. Ajouter un agent
+
+Objectif: créer un agent LangGraph qui pose les questions manquantes, puis appelle
+`CreateTodoUseCase` avec les mêmes données que l'API et le MCP.
+
+![Capture interactive agent](assets/06-agent.svg)
+
+L'agent a deux responsabilités:
+
+- transformer la conversation en `TodoDraft`;
+- demander les champs manquants avant d'enregistrer.
+
+Il ne connaît pas la persistance. Il appelle le use case applicatif.
+
+## Installer les dépendances agent
+
+```bash
+uv add "arclith[langgraph]"
+```
+
+## Créer le planner
+
+Depuis la racine du projet:
+
+```bash
+arclith-cli add-planner
+```
+
+Répondre:
+
+```text
+Planner (ex : IngredientIntent, todo_planner)
+  Nom du planner: TodoConversation
+```
+
+Remplacer `src/todo_list_service/application/planners/todo_conversation.py` par:
+
+```python
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from arclith.domain.ports.outbound.llm import LLMPort
+from pydantic import BaseModel, Field
+
+from todo_list_service.domain.models.todo import TodoStatus
+
+
+class TodoDraft(BaseModel):
+    title: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    due_date: date | None = Field(default=None)
+    status: TodoStatus | None = Field(default=None)
+    completed_at: datetime | None = Field(default=None)
+
+
+class TodoConversationPlanner:
+    def __init__(self, llm: LLMPort) -> None:
+        self._llm = llm
+
+    async def extract(self, prompt: str, current: TodoDraft) -> TodoDraft:
+        return await self._llm.complete_structured(
+            prompt,
+            output_type=TodoDraft,
+            instructions=(
+                "Tu extrais les champs d'une todo à partir d'une conversation en français. "
+                "Retourne uniquement les champs explicitement présents ou clairement déduits. "
+                "Ne fabrique pas de titre, de description ou de date. "
+                f"Draft actuel: {current.model_dump_json(exclude_none=True)}"
+            ),
+        )
+```
+
+## Configurer LM Studio
+
+Démarrer LM Studio Local Server sur `http://127.0.0.1:1234/v1`, puis vérifier les modèles:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/models
+```
+
+Lancer le wizard LLM:
+
+```bash
+arclith-cli add-adapter --capability llm
+```
+
+Répondre:
+
+```text
+① Type d'adapter
+   1  lmstudio
+   2  openai
+   3  anthropic
+
+  Votre choix (numéro ou nom): 1
+
+③ Paramètres lmstudio
+  Model ID LM Studio: <model-id-lm-studio>
+  Endpoint OpenAI-compatible LM Studio (http://127.0.0.1:1234/v1):
+  API key LM Studio (lm-studio):
+
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La CLI crée:
+
+```text
+config/adapters/outbound/lm.yaml
+```
+
+## Configurer LangSmith
+
+LangSmith est optionnel pour exécuter localement, mais utile pour inspecter les runs.
+
+```bash
+arclith-cli add-adapter --capability observability
+```
+
+Répondre:
+
+```text
+① Type d'adapter
+   1  langsmith
+   2  opentelemetry
+
+  Votre choix (numéro ou nom): 1
+  Activer LANGSMITH_TRACING [y/n] (y): y
+  Projet LangSmith (todo-list-service): todo-list-service-dev
+  Endpoint LangSmith (https://api.smith.langchain.com):
+  LANGSMITH_API_KEY:
+  Activer langsmith maintenant ? [y/n] (y): y
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La clé reste dans `.env`, jamais dans Git.
+
+## Générer l'entrypoint LangGraph
+
+```bash
+arclith-cli add-adapter --capability agent
+```
+
+Répondre:
+
+```text
+① Type d'adapter
+   1  langgraph
+
+  Votre choix (numéro ou nom): 1
+  Nom du graphe LangGraph (agent): todo_agent
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La CLI crée:
+
+```text
+langgraph.json
+config/adapters/inbound/langgraph.yaml
+src/todo_list_service/adapters/inbound/langgraph/agent.py
+```
+
+## Code agent
+
+Remplacer `src/todo_list_service/adapters/inbound/langgraph/agent.py` par:
+
+```python
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, TypedDict
+
+from arclith import Arclith
+from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
+from langgraph.graph import END, START
+
+from todo_list_service.application.planners.todo_conversation import TodoConversationPlanner, TodoDraft
+from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
+from todo_list_service.domain.models.todo import TodoStatus
+from todo_list_service.infrastructure.containers.todo_container import build_create_todo_use_case
+
+
+class AgentState(TypedDict, total=False):
+    messages: list[dict[str, Any]]
+    draft: dict[str, Any]
+    answer: str
+
+
+arclith = Arclith("config")
+
+
+@lru_cache(maxsize=1)
+def _create_todo_use_case() -> CreateTodoUseCase:
+    return build_create_todo_use_case(arclith)
+
+
+@lru_cache(maxsize=1)
+def _planner() -> TodoConversationPlanner:
+    lm_settings = arclith.config.adapters.lm
+    if lm_settings is None:
+        raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour l'agent.")
+    return TodoConversationPlanner(PydanticAILLMAdapter(lm_settings))
+
+
+def _last_user_message(state: AgentState) -> str:
+    for message in reversed(state.get("messages", [])):
+        if message.get("role") in {"user", "human"}:
+            return str(message.get("content", ""))
+    return ""
+
+
+def _draft_from_state(state: AgentState) -> TodoDraft:
+    return TodoDraft.model_validate(state.get("draft", {}))
+
+
+def _missing_fields(draft: TodoDraft) -> list[str]:
+    missing: list[str] = []
+    if not draft.title:
+        missing.append("title")
+    if not draft.description:
+        missing.append("description")
+    if draft.due_date is None:
+        missing.append("due_date")
+    if draft.status is None:
+        missing.append("status")
+    if draft.status == TodoStatus.DONE and draft.completed_at is None:
+        missing.append("completed_at")
+    return missing
+
+
+def _question_for(field: str) -> str:
+    questions = {
+        "title": "Quel est le titre de la todo ?",
+        "description": "Quelle description veux-tu enregistrer ?",
+        "due_date": "Quelle est la date d'échéance ?",
+        "status": "Quel est le statut : todo, wip ou done ?",
+        "completed_at": "Quelle est la date de réalisation ?",
+    }
+    return questions[field]
+
+
+async def run_agent(state: AgentState) -> AgentState:
+    prompt = _last_user_message(state)
+    current = _draft_from_state(state)
+
+    if prompt:
+        extracted = await _planner().extract(prompt, current)
+        current = current.model_copy(update=extracted.model_dump(exclude_none=True))
+
+    missing = _missing_fields(current)
+    if missing:
+        answer = _question_for(missing[0])
+        messages = [*state.get("messages", []), {"role": "assistant", "content": answer}]
+        return {**state, "draft": current.model_dump(mode="json", exclude_none=True), "answer": answer, "messages": messages}
+
+    todo = await _create_todo_use_case().execute(
+        CreateTodoCommand(
+            title=current.title or "",
+            description=current.description or "",
+            due_date=current.due_date,
+            status=current.status or TodoStatus.TODO,
+            completed_at=current.completed_at,
+        )
+    )
+    answer = f"Todo créée: {todo.title} ({todo.uuid})."
+    messages = [*state.get("messages", []), {"role": "assistant", "content": answer}]
+    return {**state, "draft": {}, "answer": answer, "messages": messages}
+
+
+def register_agent(builder: Any, app: Arclith) -> None:
+    builder.add_node("agent", run_agent)
+    builder.add_edge(START, "agent")
+    builder.add_edge("agent", END)
+
+
+agent = arclith.langgraph(AgentState, register_agent, name="todo_agent")
+```
+
+## Tester l'agent
+
+Lancer LangGraph Studio:
+
+```bash
+uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
+Envoyer un état incomplet:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Ajoute une todo pour écrire la doc"
+    }
+  ]
+}
+```
+
+L'agent doit demander le premier champ manquant, par exemple la description ou la date d'échéance.
+
+Envoyer ensuite un état complet:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Crée une todo titre Écrire la doc, description couvrir API MCP agent, échéance 2026-09-01, statut todo"
+    }
+  ]
+}
+```
+
+Résultat attendu:
+
+```text
+Todo créée: Écrire la doc (<uuid>).
+```
+
+## Passer à MongoDB ensuite
+
+Avec `repository: memory`, l'API/MCP et LangGraph ne partagent les données que s'ils tournent dans le
+même processus. Pour partager entre processus, ajouter MongoDB.
+
+Installer l'extra:
+
+```bash
+uv add "arclith[mongodb]"
+```
+
+Lancer le wizard:
+
+```bash
+arclith-cli add-adapter --capability repository
+```
+
+Répondre:
+
+```text
+① Type d'adapter
+   1  memory
+   2  mongodb
+   3  duckdb
+   4  mariadb
+
+  Votre choix (numéro ou nom): 2
+
+③ Paramètres mongodb
+  db_name (todo-list-service): todo_list_service
+  multitenant [y/n] (n): n
+  Activer mongodb maintenant ? [y/n] (y): y
+  Confirmer la génération ? [y/n] (y): y
+```
+
+La CLI crée les fichiers repository MongoDB et active:
+
+```yaml
+repository: mongodb
+```
+
+Configurer l'URI MongoDB via le resolver de secrets local, puis relancer API, MCP et LangGraph.
+
+## Voie rapide
+
+```bash
+uv add "arclith[langgraph]"
+arclith-cli add-planner TodoConversation
+arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name="<model-id-lm-studio>" --yes
+arclith-cli add-adapter --capability observability --adapter langsmith
+arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=todo_agent --yes
+
+# Ensuite, pour partager les données entre processus:
+uv add "arclith[mongodb]"
+arclith-cli add-adapter --capability repository --adapter mongodb --entity Todo --db-name todo_list_service --yes
+```

--- a/docs/tutorials/todo-list/assets/01-init-project.svg
+++ b/docs/tutorials/todo-list/assets/01-init-project.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="420" viewBox="0 0 1120 420" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - arclith-cli init</title>
+  <desc id="desc">Initialisation interactive d'un projet Arclith minimal.</desc>
+  <rect width="1120" height="420" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli init</text>
+  <text x="24" y="112" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Projet (ex : my-recipe-service, meal-planner)</text>
+  <text x="24" y="146" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom du projet: todo-list-service</text>
+  <text x="24" y="198" fill="#93c5fd" font-family="Menlo, Consolas, monospace" font-size="18">Projet minimal</text>
+  <text x="24" y="236" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Projet   todo-list-service</text>
+  <text x="24" y="270" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Package  todo_list_service</text>
+  <text x="24" y="304" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Metier   vide, a creer avec add-entity et add-usecase</text>
+  <text x="24" y="358" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Next steps: uv sync, arclith-cli add-entity, arclith-cli add-usecase</text>
+</svg>

--- a/docs/tutorials/todo-list/assets/02-create-entity.svg
+++ b/docs/tutorials/todo-list/assets/02-create-entity.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="300" viewBox="0 0 1120 300" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - arclith-cli add-entity</title>
+  <desc id="desc">Création interactive de l'entité Todo.</desc>
+  <rect width="1120" height="300" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-entity</text>
+  <text x="24" y="118" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Entite - utilisez le singulier (ex : Recipe, recipe_step, MealPlan)</text>
+  <text x="24" y="154" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom de l'entite: Todo</text>
+  <text x="24" y="210" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Entite Todo creee : src/todo_list_service/domain/models/todo.py</text>
+</svg>

--- a/docs/tutorials/todo-list/assets/03-create-usecase.svg
+++ b/docs/tutorials/todo-list/assets/03-create-usecase.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="300" viewBox="0 0 1120 300" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - arclith-cli add-usecase</title>
+  <desc id="desc">Création interactive du use case CreateTodo.</desc>
+  <rect width="1120" height="300" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-usecase</text>
+  <text x="24" y="118" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Cas d'usage (ex : PlanShoppingList, find_by_name)</text>
+  <text x="24" y="154" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom du cas d'usage: CreateTodo</text>
+  <text x="24" y="210" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Cas d'usage CreateTodoUseCase cree : src/.../application/use_cases/create_todo.py</text>
+</svg>

--- a/docs/tutorials/todo-list/assets/04-api.svg
+++ b/docs/tutorials/todo-list/assets/04-api.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="360" viewBox="0 0 1120 360" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - FastAPI adapter</title>
+  <desc id="desc">Génération interactive de la configuration FastAPI.</desc>
+  <rect width="1120" height="360" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-adapter --capability api</text>
+  <text x="24" y="114" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">① Type d'adapter</text>
+  <text x="48" y="148" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">1  fastapi</text>
+  <text x="24" y="186" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1</text>
+  <text x="24" y="224" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Host FastAPI: 0.0.0.0    Port FastAPI: 8120    reload: yes</text>
+  <text x="24" y="280" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ config/adapters/inbound/fastapi.yaml</text>
+  <text x="24" y="316" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastapi scaffolde avec succes.</text>
+</svg>

--- a/docs/tutorials/todo-list/assets/05-mcp.svg
+++ b/docs/tutorials/todo-list/assets/05-mcp.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="340" viewBox="0 0 1120 340" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - FastMCP adapter</title>
+  <desc id="desc">Génération interactive de la configuration FastMCP.</desc>
+  <rect width="1120" height="340" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-adapter --capability mcp</text>
+  <text x="24" y="114" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">① Type d'adapter</text>
+  <text x="48" y="148" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">1  fastmcp</text>
+  <text x="24" y="186" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1</text>
+  <text x="24" y="224" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Host FastMCP: 127.0.0.1    Port FastMCP: 8121</text>
+  <text x="24" y="280" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastmcp scaffolde avec succes.</text>
+</svg>

--- a/docs/tutorials/todo-list/assets/06-agent.svg
+++ b/docs/tutorials/todo-list/assets/06-agent.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="420" viewBox="0 0 1120 420" role="img" aria-labelledby="title desc">
+  <title id="title">Capture terminal - LangGraph agent</title>
+  <desc id="desc">Génération interactive des adapters LLM, LangSmith et LangGraph.</desc>
+  <rect width="1120" height="420" rx="8" fill="#1f2933"/>
+  <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
+  <circle cx="22" cy="18" r="6" fill="#f87171"/>
+  <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
+  <circle cx="66" cy="18" r="6" fill="#34d399"/>
+  <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-adapter --capability llm</text>
+  <text x="24" y="112" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">1 lmstudio  2 openai  3 anthropic</text>
+  <text x="24" y="150" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1  Model ID: &lt;model-id-lm-studio&gt;</text>
+  <text x="24" y="206" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-adapter --capability agent</text>
+  <text x="24" y="244" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1  Nom du graphe LangGraph: todo_agent</text>
+  <text x="24" y="300" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ uv run langgraph dev --no-browser --allow-blocking --port 2024</text>
+  <text x="24" y="354" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Agent: Je peux enregistrer la todo. Quelle est sa date d'echeance ?</text>
+</svg>

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -1,0 +1,68 @@
+# Tutoriel Todo List
+
+Ce tutoriel part de zéro et construit une todo list Arclith étape par étape.
+
+Le fil conducteur est volontairement simple:
+
+- une entité `Todo`;
+- un use case `CreateTodoUseCase` pour enregistrer une todo;
+- une API FastAPI;
+- un serveur MCP FastMCP;
+- un agent LangGraph qui collecte les champs manquants avant d'appeler le même use case.
+
+Le chemin principal utilise `repository: memory`. À la fin, on ajoute MongoDB pour partager les
+données entre l'API, le MCP et l'agent quand ils tournent dans des processus différents.
+
+## Modèle cible
+
+Une todo contient:
+
+| Champ | Type | Règle |
+| --- | --- | --- |
+| `title` | `str` | obligatoire, non vide |
+| `description` | `str` | optionnel côté API, stocké comme chaîne |
+| `due_date` | `date` | obligatoire |
+| `completed_at` | `datetime | None` | renseigné seulement si le statut est `done` |
+| `status` | `todo | wip | done` | `todo` par défaut |
+
+## Architecture
+
+```text
+Client HTTP / Client MCP / LangGraph
+  -> adapter inbound
+  -> CreateTodoUseCase
+  -> Repository[Todo]
+  -> memory, puis MongoDB
+```
+
+L'agent ne persiste jamais directement. Il transforme une conversation en commande structurée puis
+appelle `CreateTodoUseCase`, exactement comme l'API et le MCP.
+
+## Étapes
+
+1. [Initialiser le projet](01-init-project.md)
+2. [Créer l'entité Todo](02-create-entity.md)
+3. [Créer le use case d'enregistrement](03-create-usecase.md)
+4. [Exposer une API FastAPI](04-api.md)
+5. [Exposer un MCP FastMCP](05-mcp.md)
+6. [Ajouter un agent LangGraph](06-agent.md)
+
+Chaque page montre le mode interactif de la CLI. La voie rapide non interactive est donnée en fin de
+page pour les scripts et les reprises.
+
+## Prérequis
+
+- Python 3.13;
+- `uv`;
+- `git`;
+- LM Studio seulement pour la dernière étape agent;
+- une clé LangSmith seulement si vous voulez tracer l'agent dans LangSmith.
+
+Installer la CLI depuis le repository pour utiliser les dernières commandes:
+
+```bash
+uv tool install --force "git+https://github.com/karned-rekipe/arclith.git#subdirectory=cli"
+arclith-cli version
+```
+
+Le tutoriel utilise ensuite un projet local `todo-list-service`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: Arclith
+site_description: Documentation Arclith pour construire des services hexagonaux Python.
+site_url: https://karned-rekipe.github.io/arclith/
+repo_url: https://github.com/karned-rekipe/arclith
+repo_name: karned-rekipe/arclith
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: mkdocs
+  locale: fr
+
+nav:
+  - Accueil: index.md
+  - Quickstarts:
+      - Quickstart Arclith: quickstart.md
+      - Quickstart Agent: agent-quickstart.md
+      - Capacités: capabilities.md
+  - Tutoriel Todo:
+      - Vue d'ensemble: tutorials/todo-list/index.md
+      - 1. Initialiser le projet: tutorials/todo-list/01-init-project.md
+      - 2. Créer l'entité: tutorials/todo-list/02-create-entity.md
+      - 3. Créer le use case: tutorials/todo-list/03-create-usecase.md
+      - 4. Exposer une API: tutorials/todo-list/04-api.md
+      - 5. Exposer un MCP: tutorials/todo-list/05-mcp.md
+      - 6. Ajouter un agent: tutorials/todo-list/06-agent.md
+  - Référence:
+      - Auth: auth.md
+      - HTTP: http-conventions.md
+      - Idempotence: idempotency.md
+      - Multitenant: multitenant.md
+      - Cache: caching.md
+      - Décisions: decisions.md
+      - Release: release.md
+      - OAuth2 Troubleshooting: oauth2-troubleshooting.md
+
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,6 @@ dev = [
     "langgraph-api>=0.11.0",
     "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0",
 ]
+docs = [
+    "mkdocs>=1.6.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,9 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
+docs = [
+    { name = "mkdocs" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -230,6 +233,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.6" },
     { name = "types-pyyaml", specifier = "==6.0.12.20250516" },
 ]
+docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 
 [[package]]
 name = "asgiref"
@@ -777,6 +781,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,6 +1129,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -1575,6 +1603,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1584,6 +1621,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1618,6 +1707,53 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
 ]
 
 [[package]]
@@ -2419,6 +2555,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
 name = "radon"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3007,6 +3155,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `arclith-cli init` to create a minimal Arclith project without a starter entity.
- Add MkDocs configuration and a GitHub Pages deployment workflow.
- Add a step-by-step Todo tutorial: init, entity, use case, FastAPI, FastMCP, LangGraph agent, then MongoDB.
- Add terminal-style screenshots and docs navigation.

## Validation

- `make quality`
- `make docs`
- `cd cli && uv run pytest && uv run ruff check arclith_cli tests`
- Replayed the documented init/entity/usecase/api/mcp flow in a temporary generated project; use case and FastMCP smoke tests passed.
