### PR TITLE
Generate inbound ports for use cases

### DIFF
--- a/arclith/docs/architecture.md
+++ b/arclith/docs/architecture.md
@@ -64,18 +64,18 @@ class Ingredient(Entity):
 
 ### `domain/ports/inbound/`
 
-Les ports offerts par le coeur. Ils décrivent les capacités appelables par les adapters entrants
+Les ports offerts par le cœur. Ils décrivent les capacités appelables par les adapters entrants
 sans exposer FastAPI, FastMCP, LangGraph, Pydantic AI ou un autre framework.
 
 Exemples:
 
-- `CreateIngredientUseCasePort`
+- `CreateIngredientPort`
 - `ChatAgentPort`
 - `RunWorkflowPort`
 
 ### `domain/ports/outbound/`
 
-Les interfaces que le coeur consomme pour parler au monde extérieur.
+Les interfaces que le cœur consomme pour parler au monde extérieur.
 
 - `Repository[T]` — contrat de persistance (create, read, update, delete, find_all…)
 - `Logger` — contrat de logging

--- a/cli/README.md
+++ b/cli/README.md
@@ -74,7 +74,8 @@ La commande ne génère aucun CRUD, aucun port repository, aucun adapter et aucu
 
 ### `add-usecase` — Ajouter un cas d'usage
 
-Crée uniquement le fichier minimal d'un cas d'usage dans `src/<package>/application/use_cases/`.
+Crée le port inbound minimal dans `src/<package>/domain/ports/inbound/`, puis le fichier minimal du
+cas d'usage dans `src/<package>/application/use_cases/`.
 
 ```bash
 cd my-recipe-service
@@ -85,12 +86,13 @@ arclith-cli add-usecase find-by-name
 Fichier généré :
 
 ```text
+src/<package>/domain/ports/inbound/plan_shopping_list.py
 src/<package>/application/use_cases/plan_shopping_list.py
 ```
 
 Le nom peut être fourni en PascalCase, snake_case ou kebab-case. Le suffixe `UseCase` est normalisé : `PlanShoppingListUseCase` et `plan-shopping-list-use-case` génèrent tous les deux `PlanShoppingListUseCase`.
 
-Comme `add-entity`, cette commande ne câble pas FastAPI, FastMCP, LangGraph, un repository ou un service. Les adapters se branchent ensuite explicitement avec `add-adapter`.
+Comme `add-entity`, cette commande ne câble pas FastAPI, FastMCP, LangGraph, un repository ou un service. Les adapters se branchent ensuite explicitement avec `add-adapter` et devraient dépendre du port inbound généré.
 
 ---
 

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -21,7 +21,19 @@ class {class_name}(Entity):
     pass
 """
 
-_USE_CASE_TEMPLATE = """class {class_name}UseCase:
+_INBOUND_PORT_TEMPLATE = """from abc import ABC, abstractmethod
+
+
+class {class_name}Port(ABC):
+    @abstractmethod
+    async def execute(self) -> None:
+        raise NotImplementedError
+"""
+
+_USE_CASE_TEMPLATE = """from {inbound_port_module} import {class_name}Port
+
+
+class {class_name}UseCase({class_name}Port):
     async def execute(self) -> None:
         raise NotImplementedError("Implement {class_name}UseCase.execute")
 """
@@ -93,10 +105,24 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
     paths = detect_project_paths(project_dir)
     names = UseCaseNames.from_input(usecase_name)
     usecase_file = paths.application_use_cases / f"{names.snake}.py"
+    inbound_port_file = paths.inbound_ports / f"{names.snake}.py"
     _assert_missing(usecase_file, project_dir)
+    _assert_missing(inbound_port_file, project_dir)
 
+    _ensure_package_dirs(paths, "domain", "ports", "inbound")
     _ensure_package_dirs(paths, "application", "use_cases")
-    usecase_file.write_text(_USE_CASE_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    inbound_port_file.write_text(_INBOUND_PORT_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    usecase_file.write_text(
+        _USE_CASE_TEMPLATE.format(
+            class_name=names.pascal,
+            inbound_port_module=paths.import_path("domain", "ports", "inbound", names.snake),
+        ),
+        encoding="utf-8",
+    )
+    console.print(
+        f"[green]✓[/green] Port inbound {names.pascal}Port créé : "
+        f"[bold]{inbound_port_file.relative_to(project_dir)}[/bold]"
+    )
     console.print(
         f"[green]✓[/green] Cas d'usage {names.pascal}UseCase créé : "
         f"[bold]{usecase_file.relative_to(project_dir)}[/bold]"

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -81,6 +81,7 @@ def _create_package_layout(package_root: Path) -> None:
         package_root / "domain",
         package_root / "domain" / "models",
         package_root / "domain" / "ports",
+        package_root / "domain" / "ports" / "inbound",
         package_root / "domain" / "ports" / "outbound",
         package_root / "application",
         package_root / "application" / "use_cases",

--- a/cli/arclith_cli/project_paths.py
+++ b/cli/arclith_cli/project_paths.py
@@ -17,6 +17,10 @@ class ProjectPaths:
         return self.package_root / "application" / "use_cases"
 
     @property
+    def inbound_ports(self) -> Path:
+        return self.package_root / "domain" / "ports" / "inbound"
+
+    @property
     def application_planners(self) -> Path:
         return self.package_root / "application" / "planners"
 

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -47,6 +47,8 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
         "observability: none\n"
     )
     assert (package_root / "domain" / "models" / "__init__.py").exists()
+    assert (package_root / "domain" / "ports" / "inbound" / "__init__.py").exists()
+    assert (package_root / "domain" / "ports" / "outbound" / "__init__.py").exists()
     assert (package_root / "application" / "use_cases" / "__init__.py").exists()
     assert (package_root / "adapters" / "inbound" / "__init__.py").exists()
     assert (package_root / "infrastructure" / "containers" / "__init__.py").exists()
@@ -67,11 +69,27 @@ def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> N
     generated = add_usecase_cmd(project_dir=project_dir, usecase_name="PlanShoppingList")
 
     assert generated == project_dir / "src" / "demo_service" / "application" / "use_cases" / "plan_shopping_list.py"
+    inbound_port = project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "plan_shopping_list.py"
+    assert inbound_port.read_text(encoding="utf-8") == (
+        "from abc import ABC, abstractmethod\n"
+        "\n"
+        "\n"
+        "class PlanShoppingListPort(ABC):\n"
+        "    @abstractmethod\n"
+        "    async def execute(self) -> None:\n"
+        "        raise NotImplementedError\n"
+    )
     assert generated.read_text(encoding="utf-8") == (
-        "class PlanShoppingListUseCase:\n"
+        "from demo_service.domain.ports.inbound.plan_shopping_list import PlanShoppingListPort\n"
+        "\n"
+        "\n"
+        "class PlanShoppingListUseCase(PlanShoppingListPort):\n"
         "    async def execute(self) -> None:\n"
         '        raise NotImplementedError("Implement PlanShoppingListUseCase.execute")\n'
     )
+    assert (project_dir / "src" / "demo_service" / "domain" / "__init__.py").exists()
+    assert (project_dir / "src" / "demo_service" / "domain" / "ports" / "__init__.py").exists()
+    assert (project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "__init__.py").exists()
     assert (project_dir / "src" / "demo_service" / "application" / "__init__.py").exists()
     assert (project_dir / "src" / "demo_service" / "application" / "use_cases" / "__init__.py").exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
@@ -99,7 +117,13 @@ def test_add_usecase_strips_repeated_usecase_suffix(tmp_path: Path) -> None:
     generated = add_usecase_cmd(project_dir=project_dir, usecase_name="plan-shopping-list-use-case-usecase")
 
     assert generated.name == "plan_shopping_list.py"
-    assert "class PlanShoppingListUseCase:" in generated.read_text(encoding="utf-8")
+    assert "class PlanShoppingListUseCase(PlanShoppingListPort):" in generated.read_text(encoding="utf-8")
+    assert (
+        "class PlanShoppingListPort(ABC):"
+        in (
+            project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "plan_shopping_list.py"
+        ).read_text(encoding="utf-8")
+    )
     assert "UseCaseUseCase" not in generated.read_text(encoding="utf-8")
 
 
@@ -126,6 +150,23 @@ def test_add_entity_supports_legacy_root_layout(tmp_path: Path) -> None:
     assert not (project_dir / "__init__.py").exists()
 
 
+def test_add_usecase_supports_legacy_root_layout(tmp_path: Path) -> None:
+    project_dir = tmp_path / "legacy-service"
+    project_dir.mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text('[project]\nname = "legacy-service"\n', encoding="utf-8")
+
+    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="CreateRecipe")
+
+    assert generated == project_dir / "application" / "use_cases" / "create_recipe.py"
+    assert (
+        "from domain.ports.inbound.create_recipe import CreateRecipePort\n"
+        in generated.read_text(encoding="utf-8")
+    )
+    assert (project_dir / "domain" / "ports" / "inbound" / "create_recipe.py").exists()
+    assert (project_dir / "domain" / "ports" / "inbound" / "__init__.py").exists()
+    assert not (project_dir / "__init__.py").exists()
+
+
 def test_add_entity_refuses_to_overwrite_existing_file(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
     existing = project_dir / "src" / "demo_service" / "domain" / "models" / "recipe.py"
@@ -143,6 +184,19 @@ def test_add_usecase_rejects_invalid_name(tmp_path: Path) -> None:
 
     with pytest.raises(typer.Exit):
         add_usecase_cmd(project_dir=project_dir, usecase_name="123-import")
+
+
+def test_add_usecase_refuses_to_overwrite_existing_inbound_port(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+    existing = project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "recipe.py"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("class RecipePort:\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(project_dir=project_dir, usecase_name="Recipe")
+
+    assert existing.read_text(encoding="utf-8") == "class RecipePort:\n    pass\n"
+    assert not (project_dir / "src" / "demo_service" / "application" / "use_cases" / "recipe.py").exists()
 
 
 def test_add_planner_rejects_invalid_name(tmp_path: Path) -> None:

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -67,6 +67,7 @@ def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Pat
 
     assert result.returncode == 0, f"init failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     assert (project_dir / "src" / "todo_list_service" / "domain" / "models" / "__init__.py").exists()
+    assert (project_dir / "src" / "todo_list_service" / "domain" / "ports" / "inbound" / "__init__.py").exists()
     assert not (project_dir / "src" / "todo_list_service" / "domain" / "models" / "todo.py").exists()
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
@@ -92,6 +93,9 @@ def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Pat
     assert (project_dir / "src" / "todo_list_service" / "domain" / "models" / "todo.py").exists()
     assert (
         project_dir / "src" / "todo_list_service" / "application" / "use_cases" / "create_todo.py"
+    ).exists()
+    assert (
+        project_dir / "src" / "todo_list_service" / "domain" / "ports" / "inbound" / "create_todo.py"
     ).exists()
 
 
@@ -214,6 +218,9 @@ def test_scaffold_and_run(temp_workspace: Path):
     assert (
         project_dir / "src" / "test_plan_service" / "application" / "use_cases" / "plan_shopping_list.py"
     ).exists()
+    assert (
+        project_dir / "src" / "test_plan_service" / "domain" / "ports" / "inbound" / "plan_shopping_list.py"
+    ).exists()
 
     result = subprocess.run(
         [
@@ -234,9 +241,15 @@ def test_scaffold_and_run(temp_workspace: Path):
     import_script = "\n".join(
         [
             "from test_plan_service.domain.models.shopping_item import ShoppingItem",
+            "from test_plan_service.domain.ports.inbound.plan_shopping_list import PlanShoppingListPort",
             "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase",
             "from test_plan_service.application.planners.shopping_intent import ShoppingIntentPlanner",
-            "print(ShoppingItem.__name__, PlanShoppingListUseCase.__name__, ShoppingIntentPlanner.__name__)",
+            "print("
+            "ShoppingItem.__name__, "
+            "PlanShoppingListPort.__name__, "
+            "PlanShoppingListUseCase.__name__, "
+            "ShoppingIntentPlanner.__name__"
+            ")",
         ]
     )
     result = subprocess.run(
@@ -253,7 +266,7 @@ def test_scaffold_and_run(temp_workspace: Path):
         timeout=30,
     )
     assert result.returncode == 0, f"Core scaffold import failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
-    assert "ShoppingItem PlanShoppingListUseCase ShoppingIntentPlanner" in result.stdout
+    assert "ShoppingItem PlanShoppingListPort PlanShoppingListUseCase ShoppingIntentPlanner" in result.stdout
 
     # Step 7 — validate non-interactive adapter generation through the CLI entry point
     result = subprocess.run(

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -238,18 +238,21 @@ def test_scaffold_and_run(temp_workspace: Path):
         project_dir / "src" / "test_plan_service" / "application" / "planners" / "shopping_intent.py"
     ).exists()
 
+    printed_names = ", ".join(
+        [
+            "ShoppingItem.__name__",
+            "PlanShoppingListPort.__name__",
+            "PlanShoppingListUseCase.__name__",
+            "ShoppingIntentPlanner.__name__",
+        ]
+    )
     import_script = "\n".join(
         [
             "from test_plan_service.domain.models.shopping_item import ShoppingItem",
             "from test_plan_service.domain.ports.inbound.plan_shopping_list import PlanShoppingListPort",
             "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase",
             "from test_plan_service.application.planners.shopping_intent import ShoppingIntentPlanner",
-            "print("
-            "ShoppingItem.__name__, "
-            "PlanShoppingListPort.__name__, "
-            "PlanShoppingListUseCase.__name__, "
-            "ShoppingIntentPlanner.__name__"
-            ")",
+            f"print({printed_names})",
         ]
     )
     result = subprocess.run(

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -125,7 +125,10 @@ dev = [
     { name = "ruff", specifier = "==0.15.6" },
     { name = "types-pyyaml", specifier = "==6.0.12.20250516" },
 ]
-docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-material", specifier = ">=9.7.7" },
+]
 
 [[package]]
 name = "arclith-cli"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,12 +36,13 @@ Fichiers générés :
 
 ```text
 src/<package>/domain/models/shopping_item.py
+src/<package>/domain/ports/inbound/plan_shopping_list.py
 src/<package>/application/use_cases/plan_shopping_list.py
 src/<package>/application/planners/shopping_intent.py
 ```
 
-Le développeur garde la responsabilité de définir les champs, invariants, ports et orchestration
-métier. Les adapters se branchent ensuite explicitement via `add-adapter`.
+Le développeur garde la responsabilité de définir les champs, invariants et orchestration métier.
+Les adapters se branchent ensuite explicitement via `add-adapter` et appellent les ports inbound.
 
 ## Catalogue actuel
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,8 +130,9 @@ arclith-cli add-planner ShoppingIntent
 ```
 
 Ces commandes créent des fichiers minimaux dans `src/<package>/domain/models/` et
-`src/<package>/application/use_cases/` ou `src/<package>/application/planners/`. Les champs,
-invariants, ports et appels aux adapters restent du code métier à écrire dans le projet.
+`src/<package>/domain/ports/inbound/`, `src/<package>/application/use_cases/` ou
+`src/<package>/application/planners/`. Les champs, invariants et appels aux adapters restent du code
+métier à écrire dans le projet.
 
 L'adapter actif est déclaré dans:
 

--- a/docs/tutorials/todo-list/03-create-usecase.md
+++ b/docs/tutorials/todo-list/03-create-usecase.md
@@ -1,7 +1,7 @@
 # 3. Créer le use case
 
-Objectif: utiliser la CLI pour créer le fichier minimal, puis écrire le cas d'usage qui enregistre
-une todo via un port repository.
+Objectif: utiliser la CLI pour créer le port inbound et le fichier minimal, puis écrire le cas
+d'usage qui enregistre une todo via un port repository.
 
 ![Capture interactive add-usecase](assets/03-create-usecase.svg)
 
@@ -21,17 +21,18 @@ Cas d'usage (ex : PlanShoppingList, find_by_name)
 La CLI crée:
 
 ```text
+src/todo_list_service/domain/ports/inbound/create_todo.py
 src/todo_list_service/application/use_cases/create_todo.py
 ```
 
-Remplacer le contenu par:
+Remplacer `src/todo_list_service/domain/ports/inbound/create_todo.py` par:
 
 ```python
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from abc import ABC, abstractmethod
+from datetime import date, datetime
 
-from arclith.domain.ports.outbound.repository import Repository
 from pydantic import BaseModel, Field
 
 from todo_list_service.domain.models.todo import Todo, TodoStatus
@@ -45,7 +46,26 @@ class CreateTodoCommand(BaseModel):
     completed_at: datetime | None = None
 
 
-class CreateTodoUseCase:
+class CreateTodoPort(ABC):
+    @abstractmethod
+    async def execute(self, command: CreateTodoCommand) -> Todo:
+        raise NotImplementedError
+```
+
+Remplacer `src/todo_list_service/application/use_cases/create_todo.py` par:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from arclith.domain.ports.outbound.repository import Repository
+
+from todo_list_service.domain.models.todo import Todo, TodoStatus
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
+
+
+class CreateTodoUseCase(CreateTodoPort):
     def __init__(self, repository: Repository[Todo]) -> None:
         self._repository = repository
 
@@ -64,8 +84,8 @@ class CreateTodoUseCase:
         return await self._repository.create(todo)
 ```
 
-Le use case dépend seulement de `Repository[Todo]`. Il ne connaît ni FastAPI, ni FastMCP, ni
-LangGraph, ni MongoDB.
+Le use case implémente `CreateTodoPort` et dépend seulement de `Repository[Todo]`. Il ne connaît ni
+FastAPI, ni FastMCP, ni LangGraph, ni MongoDB.
 
 Créer ensuite le container applicatif `src/todo_list_service/infrastructure/containers/todo_container.py`:
 
@@ -77,6 +97,7 @@ from arclith.domain.ports.outbound.repository import Repository
 
 from todo_list_service.application.use_cases.create_todo import CreateTodoUseCase
 from todo_list_service.domain.models.todo import Todo
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoPort
 
 _repository: Repository[Todo] | None = None
 
@@ -88,7 +109,7 @@ def build_todo_repository(app: Arclith) -> Repository[Todo]:
     return _repository
 
 
-def build_create_todo_use_case(app: Arclith) -> CreateTodoUseCase:
+def build_create_todo_use_case(app: Arclith) -> CreateTodoPort:
     return CreateTodoUseCase(build_todo_repository(app))
 ```
 
@@ -105,8 +126,9 @@ from datetime import date
 import pytest
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 
-from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
+from todo_list_service.application.use_cases.create_todo import CreateTodoUseCase
 from todo_list_service.domain.models.todo import Todo, TodoStatus
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand
 
 
 @pytest.mark.asyncio

--- a/docs/tutorials/todo-list/04-api.md
+++ b/docs/tutorials/todo-list/04-api.md
@@ -1,6 +1,6 @@
 # 4. Exposer une API
 
-Objectif: générer la configuration FastAPI avec la CLI, puis exposer `CreateTodoUseCase` par HTTP.
+Objectif: générer la configuration FastAPI avec la CLI, puis exposer `CreateTodoPort` par HTTP.
 
 ![Capture interactive FastAPI](assets/04-api.svg)
 
@@ -87,12 +87,12 @@ from fastapi import APIRouter, Request, Response
 
 from arclith.domain.ports.outbound.repository import Repository
 from todo_list_service.adapters.inbound.schemas.todo_schema import TodoCreateSchema, TodoSchema
-from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
 from todo_list_service.domain.models.todo import Todo
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
 
 
 class TodoRouter:
-    def __init__(self, create_todo: CreateTodoUseCase, repository: Repository[Todo]) -> None:
+    def __init__(self, create_todo: CreateTodoPort, repository: Repository[Todo]) -> None:
         self._create_todo = create_todo
         self._repository = repository
         self.router = APIRouter(prefix="/v1/todos", tags=["todos"])

--- a/docs/tutorials/todo-list/05-mcp.md
+++ b/docs/tutorials/todo-list/05-mcp.md
@@ -47,14 +47,14 @@ from pydantic import Field
 
 from arclith.domain.ports.outbound.repository import Repository
 from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
-from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
 from todo_list_service.domain.models.todo import Todo, TodoStatus
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
 
 
 class TodoMCP:
     def __init__(
         self,
-        create_todo: CreateTodoUseCase,
+        create_todo: CreateTodoPort,
         repository: Repository[Todo],
         mcp: fastmcp.FastMCP,
     ) -> None:

--- a/docs/tutorials/todo-list/06-agent.md
+++ b/docs/tutorials/todo-list/06-agent.md
@@ -1,7 +1,7 @@
 # 6. Ajouter un agent
 
-Objectif: créer un agent LangGraph qui pose les questions manquantes, puis appelle
-`CreateTodoUseCase` avec les mêmes données que l'API et le MCP.
+Objectif: créer un agent LangGraph qui pose les questions manquantes, puis appelle `CreateTodoPort`
+avec les mêmes données que l'API et le MCP.
 
 ![Capture interactive agent](assets/06-agent.svg)
 
@@ -175,8 +175,8 @@ from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
 from langgraph.graph import END, START
 
 from todo_list_service.application.planners.todo_conversation import TodoConversationPlanner, TodoDraft
-from todo_list_service.application.use_cases.create_todo import CreateTodoCommand, CreateTodoUseCase
 from todo_list_service.domain.models.todo import TodoStatus
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
 from todo_list_service.infrastructure.containers.todo_container import build_create_todo_use_case
 
 
@@ -190,7 +190,7 @@ arclith = Arclith("config")
 
 
 @lru_cache(maxsize=1)
-def _create_todo_use_case() -> CreateTodoUseCase:
+def _create_todo_use_case() -> CreateTodoPort:
     return build_create_todo_use_case(arclith)
 
 

--- a/docs/tutorials/todo-list/assets/03-create-usecase.svg
+++ b/docs/tutorials/todo-list/assets/03-create-usecase.svg
@@ -9,5 +9,6 @@
   <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-usecase</text>
   <text x="24" y="118" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Cas d'usage (ex : PlanShoppingList, find_by_name)</text>
   <text x="24" y="154" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom du cas d'usage: CreateTodo</text>
-  <text x="24" y="210" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Cas d'usage CreateTodoUseCase cree : src/.../application/use_cases/create_todo.py</text>
+  <text x="24" y="204" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Port inbound CreateTodoPort créé : src/.../domain/ports/inbound/create_todo.py</text>
+  <text x="24" y="240" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Cas d'usage CreateTodoUseCase créé : src/.../application/use_cases/create_todo.py</text>
 </svg>

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -5,6 +5,7 @@ Ce tutoriel part de zéro et construit une todo list Arclith étape par étape.
 Le fil conducteur est volontairement simple:
 
 - une entité `Todo`;
+- un port inbound `CreateTodoPort`;
 - un use case `CreateTodoUseCase` pour enregistrer une todo;
 - une API FastAPI;
 - un serveur MCP FastMCP;
@@ -30,13 +31,14 @@ Une todo contient:
 ```text
 Client HTTP / Client MCP / LangGraph
   -> adapter inbound
+  -> CreateTodoPort
   -> CreateTodoUseCase
   -> Repository[Todo]
   -> memory, puis MongoDB
 ```
 
 L'agent ne persiste jamais directement. Il transforme une conversation en commande structurée puis
-appelle `CreateTodoUseCase`, exactement comme l'API et le MCP.
+appelle `CreateTodoPort`, exactement comme l'API et le MCP.
 
 ## Étapes
 


### PR DESCRIPTION
## Summary
- make `arclith-cli init` create `domain/ports/inbound`
- make `arclith-cli add-usecase` generate both an inbound port and its use case implementation
- update CLI tests, E2E scaffold tests, and the Todo tutorial so API/MCP/LangGraph depend on `CreateTodoPort`
- align the docs with the new scaffold behavior

## Validation
- `cd cli && uv run ruff check arclith_cli tests`
- `cd cli && uv run pytest tests/test_core_scaffold.py tests/test_e2e_scaffold.py`
- `make docs`
- `uv lock --check && cd cli && uv lock --check && git diff --check`
- `make quality`
- smoke: `arclith-cli init` + `arclith-cli add-usecase CreateTodo` generated `domain/ports/inbound/create_todo.py` and `application/use_cases/create_todo.py` with the expected inheritance
