### PR TITLE
Allow parallel observability adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - **Observability cumulative** — `adapters.observability` devient une configuration structurée
   `observability.enabled`, pour activer `langsmith` et `opentelemetry` en parallèle. L'ancien
-  format scalaire `observability: langsmith|opentelemetry|none` n'est plus accepté.
+  format scalaire `observability: langsmith|opentelemetry|none` n'est plus accepté, et
+  `opentelemetry.yaml` ne contient plus de flag `enabled`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Observability cumulative** — `adapters.observability` devient une configuration structurée
+  `observability.enabled`, pour activer `langsmith` et `opentelemetry` en parallèle. L'ancien
+  format scalaire `observability: langsmith|opentelemetry|none` n'est plus accepté.
+
 ---
 
 ## [0.13.0] — 2026-08-06

--- a/README.md
+++ b/README.md
@@ -78,17 +78,21 @@ pip install "arclith[opentelemetry]"
 pip install "arclith[all]"
 ```
 
-Pour ajouter LangGraph et LangSmith à un projet généré:
+Pour ajouter LangGraph, LangSmith et OpenTelemetry à un projet généré:
 
 ```bash
 uv add "arclith[langgraph]"
+uv add "arclith[opentelemetry]"
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
+arclith-cli add-adapter --capability observability --adapter opentelemetry
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
 Arclith génère `langgraph.json`, le point d'entrée LangGraph et le câblage `Arclith.langgraph(...)`.
 Le code spécifique du projet reste dans `src/<package>/adapters/inbound/langgraph/agent.py`.
+LangSmith et OpenTelemetry sont ajoutés dans `observability.enabled` et peuvent être actifs en
+parallèle.
 
 ## Development
 

--- a/arclith/adapters/outbound/opentelemetry/fastapi.py
+++ b/arclith/adapters/outbound/opentelemetry/fastapi.py
@@ -32,7 +32,9 @@ def instrument_fastapi_app(
     try:
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     except ImportError as exc:
-        raise RuntimeError('observability=opentelemetry requiert l\'extra "arclith[opentelemetry]".') from exc
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
 
     FastAPIInstrumentor.instrument_app(app)
 
@@ -50,7 +52,9 @@ def _configure_opentelemetry(
         from opentelemetry.instrumentation.logging import LoggingInstrumentor
         from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
     except ImportError as exc:
-        raise RuntimeError('observability=opentelemetry requiert l\'extra "arclith[opentelemetry]".') from exc
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
 
     resource = Resource.create({
         SERVICE_NAME: settings.service_name or service_name,
@@ -72,7 +76,9 @@ def _configure_traces(settings: "OpenTelemetrySettings", resource: Any) -> None:
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
     except ImportError as exc:
-        raise RuntimeError('observability=opentelemetry requiert l\'extra "arclith[opentelemetry]".') from exc
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
 
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(_build_span_exporter(settings)))
@@ -85,7 +91,9 @@ def _configure_metrics(settings: "OpenTelemetrySettings", resource: Any) -> None
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     except ImportError as exc:
-        raise RuntimeError('observability=opentelemetry requiert l\'extra "arclith[opentelemetry]".') from exc
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
 
     reader = PeriodicExportingMetricReader(
         _build_metric_exporter(settings),

--- a/arclith/adapters/outbound/opentelemetry/fastapi.py
+++ b/arclith/adapters/outbound/opentelemetry/fastapi.py
@@ -22,7 +22,7 @@ def instrument_fastapi_app(
     service_name: str,
     service_version: str,
 ) -> None:
-    if not settings.enabled or not (settings.traces or settings.metrics):
+    if not (settings.traces or settings.metrics):
         return
 
     _configure_opentelemetry(settings, service_name=service_name, service_version=service_version)

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -113,7 +113,7 @@ class Arclith:
         app = FastAPI(lifespan=_lifespan, **kwargs)
         self._add_fastapi_observability(app)
         self._add_fastapi_http_middlewares(app)
-        if self.config.adapters.observability == "opentelemetry":
+        if self.config.adapters.observability.is_enabled("opentelemetry"):
             self._instrument_fastapi_opentelemetry(app)
 
         if self.config.keycloak:

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
 
@@ -99,6 +99,23 @@ class OpenTelemetrySettings(BaseModel):
         return v
 
 
+ObservabilityAdapter = Literal["langsmith", "opentelemetry"]
+
+
+class ObservabilitySettings(BaseModel):
+    enabled: list[ObservabilityAdapter] = Field(default_factory=list)
+
+    @field_validator("enabled")
+    @classmethod
+    def must_not_contain_duplicates(cls, v: list[ObservabilityAdapter]) -> list[ObservabilityAdapter]:
+        if len(v) != len(set(v)):
+            raise ValueError("observability.enabled ne doit pas contenir de doublons")
+        return v
+
+    def is_enabled(self, adapter: ObservabilityAdapter) -> bool:
+        return adapter in self.enabled
+
+
 class LangGraphSettings(BaseModel):
     name: str = "agent"
     graph: str = "agent"
@@ -111,7 +128,7 @@ _REPOSITORY_CONFIG_SECTIONS: dict[str, str] = {
     "duckdb": "duckdb",
     "mariadb": "mariadb",
 }
-_OBSERVABILITY_CONFIG_SECTIONS: dict[str, str] = {
+_OBSERVABILITY_CONFIG_SECTIONS: dict[ObservabilityAdapter, str] = {
     "langsmith": "langsmith",
     "opentelemetry": "opentelemetry",
 }
@@ -131,7 +148,7 @@ class SoftDeleteSettings(BaseModel):
 class AdaptersSettings(BaseModel):
     logger: Literal["console"] = "console"
     repository: str = "memory"
-    observability: str = "none"
+    observability: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
     mongodb: MongoDBSettings | None = None
     duckdb: DuckDBSettings | None = None
     mariadb: MariaDBSettings | None = None
@@ -159,12 +176,13 @@ class AdaptersSettings(BaseModel):
                 f"repository={self.repository} mais aucune section [adapters.{repository_section}] dans config.yaml"
             )
 
-        observability_section = _OBSERVABILITY_CONFIG_SECTIONS.get(self.observability)
-        if observability_section is not None and getattr(self, observability_section) is None:
-            raise ValueError(
-                f"observability={self.observability} mais aucune section [adapters.{observability_section}] "
-                "dans config.yaml"
-            )
+        for observability_adapter in self.observability.enabled:
+            observability_section = _OBSERVABILITY_CONFIG_SECTIONS[observability_adapter]
+            if getattr(self, observability_section) is None:
+                raise ValueError(
+                    f"observability.enabled contient {observability_adapter} mais aucune section "
+                    f"[adapters.{observability_section}] dans config.yaml"
+                )
         return self
 
 

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
 
@@ -79,7 +79,8 @@ class LangSmithSettings(BaseModel):
 
 
 class OpenTelemetrySettings(BaseModel):
-    enabled: bool = True
+    model_config = ConfigDict(extra="forbid")
+
     service_name: str | None = None
     endpoint: str = "http://localhost:4318"
     traces_endpoint: str | None = None

--- a/cli/README.md
+++ b/cli/README.md
@@ -220,6 +220,8 @@ arclith-cli add-adapter --capability observability --adapter opentelemetry --par
 L'adapter `observability/opentelemetry` génère `config/adapters/outbound/opentelemetry.yaml`, met à
 jour `.env`, l'ajoute à `observability.enabled` et branche l'instrumentation FastAPI quand
 `Arclith.fastapi()` construit l'application. Il peut être activé en même temps que LangSmith.
+Le fichier `opentelemetry.yaml` ne porte pas de flag `enabled`: l'activation se fait uniquement dans
+`observability.enabled`.
 
 Parcours complet avec entité, API, LangGraph, LangSmith et LM Studio:
 [`docs/agent-quickstart.md`](../docs/agent-quickstart.md).

--- a/cli/README.md
+++ b/cli/README.md
@@ -159,7 +159,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `langsmith` → `tracing`, `project`, `endpoint`, `LANGSMITH_API_KEY`
    - `opentelemetry` → `service_name`, `endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
    - `memory` → aucun paramètre
-4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités à sélecteur (`repository: <adapter>` ou `observability: <adapter>`) ; `api/fastapi`, `mcp/fastmcp`, `llm/*` et `agent/langgraph` sont exposés par leurs fichiers de configuration scopés
+4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `llm/*` et `agent/langgraph` sont exposés par leurs fichiers de configuration scopés
 5. **Récapitulatif** — liste des fichiers créés ou remplacés avant confirmation
 
 | Option | Défaut | Description |
@@ -205,7 +205,7 @@ L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet ne modifie ensuite que ce fichier pour
 son agent. Comme `fastapi` et `fastmcp`, LangGraph est configuré par son nom produit dans
 `AppConfig.langgraph`, sans `adapters.agent`. L'adapter `observability/langsmith` génère
-`config/adapters/outbound/langsmith.yaml`, met
+`config/adapters/outbound/langsmith.yaml`, l'ajoute à `observability.enabled`, met
 à jour `.env` et ajoute `.env` au `.gitignore` si besoin. LangSmith Studio devient l'endroit standard
 pour tester les agents. Une `LANGSMITH_API_KEY` déjà présente est conservée si aucune nouvelle valeur
 n'est fournie.
@@ -218,8 +218,8 @@ arclith-cli add-adapter --capability observability --adapter opentelemetry --par
 ```
 
 L'adapter `observability/opentelemetry` génère `config/adapters/outbound/opentelemetry.yaml`, met à
-jour `.env`, active `observability: opentelemetry` et branche l'instrumentation FastAPI quand
-`Arclith.fastapi()` construit l'application.
+jour `.env`, l'ajoute à `observability.enabled` et branche l'instrumentation FastAPI quand
+`Arclith.fastapi()` construit l'application. Il peut être activé en même temps que LangSmith.
 
 Parcours complet avec entité, API, LangGraph, LangSmith et LM Studio:
 [`docs/agent-quickstart.md`](../docs/agent-quickstart.md).
@@ -288,7 +288,7 @@ config/
   soft_delete.yaml                # soft_delete: { retention_days }
   secrets.yaml                    # secrets: { resolver, mappings, vault, yaml }
   adapters/
-    adapters.yaml                 # adapters: { logger, repository }   ← adapter actif
+    adapters.yaml                 # adapters: { logger, repository, observability.enabled }
     outbound/
       mongodb.yaml                # adapters.mongodb: { db_name, multitenant }
       duckdb.yaml                 # adapters.duckdb: { path, multitenant }
@@ -311,7 +311,10 @@ Pour changer l'adapter actif sans passer par le wizard :
 ```yaml
 # config/adapters/adapters.yaml
 repository: duckdb   # memory | mongodb | duckdb | mariadb
-observability: langsmith   # none | langsmith | opentelemetry
+observability:
+  enabled:
+    - langsmith
+    - opentelemetry
 ```
 
 Pour MariaDB, ne committez pas le mot de passe. Mappez `adapters.mariadb.password` ou `adapters.mariadb.url` via `config/secrets.yaml`, un resolver `env` ou Vault.

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -386,7 +386,7 @@ def _show_recap(
         cfg_path = project_dir / "config" / "adapters" / "adapters.yaml"
         table.add_row(
             str(cfg_path.relative_to(project_dir)),
-            f"[cyan]mis à jour ({capability.activation_config_key})[/cyan]",
+            f"[cyan]mis à jour ({_activation_config_label(capability)})[/cyan]",
         )
 
     console.print()
@@ -434,6 +434,12 @@ def _list_generated_files(
         files.append((container, "remplacé ⚠" if container.exists() else "créé"))
 
     return files
+
+
+def _activation_config_label(capability: CapabilitySpec) -> str:
+    if capability.name == "observability":
+        return "observability.enabled"
+    return capability.activation_config_key or ""
 
 
 # ── Step 5 : generate ─────────────────────────────────────────────────────────
@@ -549,6 +555,10 @@ def _file_template_vars(
 def _update_active_capability(project_dir: Path, capability: CapabilitySpec, adapter: AdapterSpec) -> None:
     if capability.activation_config_key is None:
         return
+    if capability.name == "observability":
+        _enable_observability_adapter(project_dir, adapter)
+        return
+
     cfg = project_dir / "config" / "adapters" / "adapters.yaml"
     key = capability.activation_config_key
     escaped_key = re.escape(key)
@@ -563,6 +573,29 @@ def _update_active_capability(project_dir: Path, capability: CapabilitySpec, ada
             text = text.rstrip("\n") + f"\n{key}: {adapter.name}\n"
         cfg.write_text(text, encoding="utf-8")
     console.print(f"[cyan]↺[/cyan] config/adapters/adapters.yaml → {key}: {adapter.name}")
+
+
+def _enable_observability_adapter(project_dir: Path, adapter: AdapterSpec) -> None:
+    cfg = project_dir / "config" / "adapters" / "adapters.yaml"
+    data = _read_yaml_mapping(cfg)
+    existing = data.get("observability")
+    if isinstance(existing, dict) and isinstance(existing.get("enabled"), list):
+        enabled = []
+        for name in existing["enabled"]:
+            if isinstance(name, str) and name not in enabled:
+                enabled.append(name)
+    else:
+        enabled = []
+
+    if adapter.name not in enabled:
+        enabled.append(adapter.name)
+
+    data["observability"] = {"enabled": enabled}
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    console.print(
+        f"[cyan]↺[/cyan] config/adapters/adapters.yaml → observability.enabled += {adapter.name}"
+    )
 
 
 def _parse_env_template(rendered: str) -> dict[str, str]:

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -579,7 +579,6 @@ LANGSMITH_API_KEY={api_key}
             description="Export OTLP traces/metrics et instrumentation FastAPI.",
             config_path="config/adapters/outbound/opentelemetry.yaml",
             config_template="""\
-enabled: {enabled}
 service_name: "{service_name}"
 endpoint: "{endpoint}"
 protocol: "{protocol}"
@@ -597,12 +596,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL={protocol}
 OTEL_EXPORTER_OTLP_HEADERS={headers}
 """,
             parameters=(
-                ParameterSpec(
-                    name="enabled",
-                    kind="boolean",
-                    prompt="Activer OpenTelemetry",
-                    default=True,
-                ),
                 ParameterSpec(
                     name="service_name",
                     kind="string",

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -519,7 +519,7 @@ agent = arclith.langgraph(AgentState, register_agent, name="{graph_name}")
 OBSERVABILITY_CAPABILITY = CapabilitySpec(
     name="observability",
     layer="outbound",
-    description="Observabilité et boucle de test agent via LangSmith Studio.",
+    description="Observabilité activable en parallèle via LangSmith et OpenTelemetry.",
     activation_config_key="observability",
     adapters=(
         AdapterSpec(

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -199,7 +199,8 @@ description: "{project_name} — built with Arclith"
     (adapters_dir / "adapters.yaml").write_text(
         """logger: console
 repository: memory
-observability: none
+observability:
+  enabled: []
 """,
         encoding="utf-8",
     )

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -345,7 +345,6 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     config = (project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml").read_text(
         encoding="utf-8"
     )
-    assert "enabled: true" in config
     assert 'service_name: "demo-api"' in config
     assert 'endpoint: "http://otel-collector:4318"' in config
     assert 'protocol: "http/protobuf"' in config

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 import typer
+import yaml
 
 from arclith_cli.add_adapter import _resolve_parameter, add_adapter_cmd
 from arclith_cli.capabilities import ParameterSpec
@@ -26,7 +27,10 @@ def _minimal_project(tmp_path: Path) -> Path:
     (project_dir / "src" / package_name / "infrastructure" / "containers").mkdir(parents=True)
     config_dir = project_dir / "config" / "adapters"
     config_dir.mkdir(parents=True)
-    (config_dir / "adapters.yaml").write_text("logger: console\nrepository: memory\n", encoding="utf-8")
+    (config_dir / "adapters.yaml").write_text(
+        "logger: console\nrepository: memory\nobservability:\n  enabled: []\n",
+        encoding="utf-8",
+    )
     return project_dir
 
 
@@ -135,9 +139,10 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path)
     assert 'endpoint: "https://eu.api.smith.langchain.com"' in config
     assert "api_key_env: LANGSMITH_API_KEY" in config
     assert 'langgraph_api_min_version: "0.11.0"' in config
-    assert "observability: langsmith" in (
-        project_dir / "config" / "adapters" / "adapters.yaml"
-    ).read_text(encoding="utf-8")
+    adapters_config = yaml.safe_load(
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+    )
+    assert adapters_config["observability"]["enabled"] == ["langsmith"]
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
     assert "EXISTING=value" in env
@@ -349,9 +354,10 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     assert "metrics: true" in config
     assert "instrument_fastapi: true" in config
     assert "metrics_export_interval_millis: 15000" in config
-    assert "observability: opentelemetry" in (
-        project_dir / "config" / "adapters" / "adapters.yaml"
-    ).read_text(encoding="utf-8")
+    adapters_config = yaml.safe_load(
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+    )
+    assert adapters_config["observability"]["enabled"] == ["opentelemetry"]
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
     assert "EXISTING=value" in env
@@ -360,6 +366,30 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in env
     assert "OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer test" in env
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_add_observability_adapters_accumulates_enabled_backends(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        adapter_params={"project": "agent-tests"},
+        yes=True,
+    )
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="opentelemetry",
+        adapter_params={"service_name": "demo-api"},
+        yes=True,
+    )
+
+    adapters_config = yaml.safe_load(
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+    )
+    assert adapters_config["observability"]["enabled"] == ["langsmith", "opentelemetry"]
 
 
 def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -105,7 +105,6 @@ def test_observability_capability_catalog_declares_opentelemetry() -> None:
     assert opentelemetry.env_path == ".env"
     assert opentelemetry.entity_scoped is False
     assert [parameter.name for parameter in opentelemetry.parameters] == [
-        "enabled",
         "service_name",
         "endpoint",
         "protocol",

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -44,7 +44,8 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert (generated / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8") == (
         "logger: console\n"
         "repository: memory\n"
-        "observability: none\n"
+        "observability:\n"
+        "  enabled: []\n"
     )
     assert (package_root / "domain" / "models" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "inbound" / "__init__.py").exists()

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -116,6 +116,9 @@ arclith-cli add-adapter \
   --yes
 ```
 
+La commande ajoute `langsmith` dans `config/adapters/adapters.yaml` sous
+`observability.enabled`.
+
 Résultat attendu:
 
 ```text

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -165,7 +165,6 @@ OpenTelemetry se configure avec:
 
 ```yaml
 # config/adapters/outbound/opentelemetry.yaml
-enabled: true
 service_name: "my-service"
 endpoint: "http://localhost:4318"
 protocol: "http/protobuf"
@@ -175,6 +174,9 @@ metrics: false
 instrument_fastapi: true
 metrics_export_interval_millis: 60000
 ```
+
+`opentelemetry.yaml` décrit l'export OTLP. L'activation reste uniquement dans
+`config/adapters/adapters.yaml`, via `observability.enabled`.
 
 Installer l'extra avant d'activer l'adapter:
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -147,10 +147,14 @@ Adapters disponibles:
 Activation:
 
 ```yaml
-observability: langsmith
-# ou
-observability: opentelemetry
+observability:
+  enabled:
+    - langsmith
+    - opentelemetry
 ```
+
+La liste peut contenir un seul adapter ou les deux. Arclith ne garde pas de sélecteur unique
+pour l'observabilité: LangSmith et OpenTelemetry peuvent être actifs en parallèle.
 
 Arclith considère LangSmith Studio comme l'endroit standard pour tester un agent. Le serveur local
 LangGraph doit lire `.env` via `langgraph.json`; `.env` contient `LANGSMITH_API_KEY`,
@@ -285,6 +289,9 @@ arclith-cli add-adapter \
   --param metrics=true \
   --yes
 ```
+
+Ces deux commandes ajoutent chacune leur adapter dans `observability.enabled`; elles ne se
+remplacent pas.
 
 Pour OpenAI:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -216,13 +216,14 @@ necessaire si LangGraph Studio et LangSmith couvrent les tests conversationnels 
 
 **Decision :** declarer le runtime agent comme une capacite inbound `agent`, avec un adapter
 standard `langgraph`, et declarer l'observabilite agent comme une capacite outbound
-`observability`, avec un adapter standard `langsmith`. La CLI genere le point d'entree LangGraph,
+`observability`, avec les adapters standards `langsmith` et `opentelemetry` activables en
+parallele via `observability.enabled`. La CLI genere le point d'entree LangGraph,
 `langgraph.json` et le cablage `Arclith.langgraph(...)`. La configuration runtime reste nommee par
 produit, comme `fastapi` et `fastmcp`: `config/adapters/inbound/langgraph.yaml` alimente
 `AppConfig.langgraph`, sans cle generique `adapters.agent`. La CLI demande ensuite les informations
 LangSmith au moment du `add-adapter`, genere `config/adapters/outbound/langsmith.yaml`, met a jour
-`.env`, et ignore `.env` dans Git. LangSmith Studio devient l'endroit standard pour tester les
-agents.
+`.env`, et ignore `.env` dans Git. OpenTelemetry peut etre ajoute ensuite sans remplacer LangSmith.
+LangSmith Studio devient l'endroit standard pour tester les agents.
 
 **Pourquoi pas l'alternative evidente (une UI de test generee par Arclith) :**
 Une UI de test serait une surface produit supplementaire a maintenir, sans porter le metier. Elle
@@ -239,7 +240,8 @@ tests agent.
   principe produit que `fastapi` et `fastmcp`.
 - `arclith-cli add-adapter --capability observability --adapter langsmith` demande les parametres
   LangSmith et n'essaie pas de generer un repository par entite.
-- `AdaptersSettings.observability` active l'observabilite sans coupler le coeur aux SDK agent.
+- `AdaptersSettings.observability.enabled` active une ou plusieurs sorties d'observabilite sans
+  coupler le coeur aux SDK agent.
 - `Arclith.langgraph(...)` standardise la creation et la compilation du graphe sans exposer cette
   plomberie a chaque projet.
 - Le serveur LangGraph local lit `.env` via le `langgraph.json` genere.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -284,8 +284,8 @@ LangGraph est configuré par son nom produit dans `AppConfig.langgraph`, sans cl
 `adapters.agent`.
 
 L'adapter `observability/langsmith` demande le projet LangSmith, l'endpoint, l'activation du tracing et
-`LANGSMITH_API_KEY`. Elle génère `config/adapters/outbound/langsmith.yaml`, met à jour `.env`,
-et ajoute `.env` au `.gitignore` si besoin.
+`LANGSMITH_API_KEY`. Elle génère `config/adapters/outbound/langsmith.yaml`, ajoute `langsmith` à
+`observability.enabled`, met à jour `.env`, et ajoute `.env` au `.gitignore` si besoin.
 
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
 `AppConfig.adapters.lm`. Le planner applicatif consomme ensuite un `LLMPort`; LangGraph ne fait

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -33,7 +33,8 @@ Le projet démarre avec `repository: memory`:
 # config/adapters/adapters.yaml
 logger: console
 repository: memory
-observability: none
+observability:
+  enabled: []
 ```
 
 La structure attendue est:

--- a/docs/tutorials/todo-list/06-agent.md
+++ b/docs/tutorials/todo-list/06-agent.md
@@ -133,7 +133,8 @@ Répondre:
   Confirmer la génération ? [y/n] (y): y
 ```
 
-La clé reste dans `.env`, jamais dans Git.
+La clé reste dans `.env`, jamais dans Git. La CLI ajoute `langsmith` à la liste
+`observability.enabled`; OpenTelemetry peut être ajouté ensuite dans la même liste.
 
 ## Générer l'entrypoint LangGraph
 

--- a/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
@@ -9,8 +9,8 @@ from arclith.adapters.outbound.opentelemetry.fastapi import (
 from arclith.infrastructure.config import OpenTelemetrySettings
 
 
-def test_instrument_fastapi_app_returns_when_disabled() -> None:
-    settings = OpenTelemetrySettings(enabled=False)
+def test_instrument_fastapi_app_returns_when_exports_disabled() -> None:
+    settings = OpenTelemetrySettings(traces=False, metrics=False)
 
     instrument_fastapi_app(FastAPI(), settings, service_name="demo", service_version="1.0.0")
 

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -25,7 +25,7 @@ from arclith.infrastructure.config import (
 
 def test_default_config_uses_memory():
     assert AppConfig().adapters.repository == "memory"
-    assert AppConfig().adapters.observability == "none"
+    assert AppConfig().adapters.observability.enabled == []
 
 
 def test_custom_repository_adapter_name_is_allowed():
@@ -189,7 +189,7 @@ def test_load_config_dir_mariadb_scoped():
 
 def test_load_config_dir_langsmith_scoped():
     path = _make_config_dir({
-        "adapters/adapters.yaml": {"observability": "langsmith"},
+        "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith"]}},
         "adapters/outbound/langsmith.yaml": {
             "tracing": True,
             "project": "agent-tests",
@@ -200,7 +200,8 @@ def test_load_config_dir_langsmith_scoped():
         },
     })
     config = load_config_dir(path)
-    assert config.adapters.observability == "langsmith"
+    assert config.adapters.observability.enabled == ["langsmith"]
+    assert config.adapters.observability.is_enabled("langsmith") is True
     assert config.adapters.langsmith is not None
     assert config.adapters.langsmith.project == "agent-tests"
     assert config.adapters.langsmith.endpoint == "https://eu.api.smith.langchain.com"
@@ -208,7 +209,7 @@ def test_load_config_dir_langsmith_scoped():
 
 def test_load_config_dir_opentelemetry_scoped():
     path = _make_config_dir({
-        "adapters/adapters.yaml": {"observability": "opentelemetry"},
+        "adapters/adapters.yaml": {"observability": {"enabled": ["opentelemetry"]}},
         "adapters/outbound/opentelemetry.yaml": {
             "enabled": True,
             "service_name": "demo-api",
@@ -221,12 +222,26 @@ def test_load_config_dir_opentelemetry_scoped():
         },
     })
     config = load_config_dir(path)
-    assert config.adapters.observability == "opentelemetry"
+    assert config.adapters.observability.enabled == ["opentelemetry"]
+    assert config.adapters.observability.is_enabled("opentelemetry") is True
     assert config.adapters.opentelemetry is not None
     assert config.adapters.opentelemetry.service_name == "demo-api"
     assert config.adapters.opentelemetry.endpoint == "http://otel-collector:4318"
     assert config.adapters.opentelemetry.metrics is True
     assert config.adapters.opentelemetry.metrics_export_interval_millis == 15000
+
+
+def test_load_config_dir_parallel_observability_scoped():
+    path = _make_config_dir({
+        "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith", "opentelemetry"]}},
+        "adapters/outbound/langsmith.yaml": {"project": "agent-tests"},
+        "adapters/outbound/opentelemetry.yaml": {"enabled": True},
+    })
+    config = load_config_dir(path)
+
+    assert config.adapters.observability.enabled == ["langsmith", "opentelemetry"]
+    assert config.adapters.langsmith is not None
+    assert config.adapters.opentelemetry is not None
 
 
 def test_load_config_dir_langgraph_scoped():
@@ -247,13 +262,28 @@ def test_load_config_dir_langgraph_scoped():
 
 
 def test_langsmith_observability_requires_scoped_config():
-    with pytest.raises(ValidationError, match="observability=langsmith"):
-        AppConfig.model_validate({"adapters": {"observability": "langsmith"}})
+    with pytest.raises(ValidationError, match="observability.enabled contient langsmith"):
+        AppConfig.model_validate({"adapters": {"observability": {"enabled": ["langsmith"]}}})
 
 
 def test_opentelemetry_observability_requires_scoped_config():
-    with pytest.raises(ValidationError, match="observability=opentelemetry"):
-        AppConfig.model_validate({"adapters": {"observability": "opentelemetry"}})
+    with pytest.raises(ValidationError, match="observability.enabled contient opentelemetry"):
+        AppConfig.model_validate({"adapters": {"observability": {"enabled": ["opentelemetry"]}}})
+
+
+def test_observability_scalar_format_is_rejected():
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate({"adapters": {"observability": "langsmith"}})
+
+
+def test_observability_enabled_rejects_duplicates():
+    with pytest.raises(ValidationError, match="doublons"):
+        AppConfig.model_validate({
+            "adapters": {
+                "observability": {"enabled": ["langsmith", "langsmith"]},
+                "langsmith": {"project": "agent-tests"},
+            }
+        })
 
 
 def test_langgraph_settings_defaults():

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -211,7 +211,6 @@ def test_load_config_dir_opentelemetry_scoped():
     path = _make_config_dir({
         "adapters/adapters.yaml": {"observability": {"enabled": ["opentelemetry"]}},
         "adapters/outbound/opentelemetry.yaml": {
-            "enabled": True,
             "service_name": "demo-api",
             "endpoint": "http://otel-collector:4318",
             "protocol": "http/protobuf",
@@ -235,7 +234,7 @@ def test_load_config_dir_parallel_observability_scoped():
     path = _make_config_dir({
         "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith", "opentelemetry"]}},
         "adapters/outbound/langsmith.yaml": {"project": "agent-tests"},
-        "adapters/outbound/opentelemetry.yaml": {"enabled": True},
+        "adapters/outbound/opentelemetry.yaml": {"instrument_fastapi": True},
     })
     config = load_config_dir(path)
 
@@ -307,7 +306,6 @@ def test_langsmith_settings_defaults():
 def test_opentelemetry_settings_defaults():
     settings = OpenTelemetrySettings()
 
-    assert settings.enabled is True
     assert settings.service_name is None
     assert settings.endpoint == "http://localhost:4318"
     assert settings.traces_endpoint is None
@@ -318,6 +316,11 @@ def test_opentelemetry_settings_defaults():
     assert settings.metrics is False
     assert settings.instrument_fastapi is True
     assert settings.metrics_export_interval_millis == 60000
+
+
+def test_opentelemetry_settings_rejects_legacy_enabled_flag():
+    with pytest.raises(ValidationError):
+        OpenTelemetrySettings.model_validate({"enabled": True})
 
 
 def test_opentelemetry_settings_validates_interval():

--- a/tests/units/test_arclith_opentelemetry.py
+++ b/tests/units/test_arclith_opentelemetry.py
@@ -15,7 +15,11 @@ def _make_config_dir(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (config_dir / "adapters" / "adapters.yaml").write_text(
-        yaml.dump({"observability": "opentelemetry"}),
+        yaml.dump({"observability": {"enabled": ["langsmith", "opentelemetry"]}}),
+        encoding="utf-8",
+    )
+    (config_dir / "adapters" / "outbound" / "langsmith.yaml").write_text(
+        yaml.dump({"project": "agent-tests"}),
         encoding="utf-8",
     )
     (config_dir / "adapters" / "outbound" / "opentelemetry.yaml").write_text(

--- a/tests/units/test_arclith_opentelemetry.py
+++ b/tests/units/test_arclith_opentelemetry.py
@@ -23,7 +23,7 @@ def _make_config_dir(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (config_dir / "adapters" / "outbound" / "opentelemetry.yaml").write_text(
-        yaml.dump({"enabled": True, "instrument_fastapi": True}),
+        yaml.dump({"instrument_fastapi": True}),
         encoding="utf-8",
     )
     return config_dir


### PR DESCRIPTION
## What changed

- Replace the scalar `adapters.observability` selector with the structured `observability.enabled` list.
- Allow `langsmith` and `opentelemetry` to be enabled together while rejecting the old scalar runtime format.
- Remove the local `enabled` flag from `opentelemetry.yaml`; activation now lives only in `observability.enabled`.
- Update `arclith-cli add-adapter` so observability adapters append idempotently instead of replacing each other.
- Update generated project defaults, README/docs/changelog, and tests for the new contract.

## Impact

Projects should now configure observability like:

```yaml
observability:
  enabled:
    - langsmith
    - opentelemetry
```

The OpenTelemetry adapter file only describes OTLP export settings:

```yaml
service_name: "my-service"
endpoint: "http://localhost:4318"
protocol: "http/protobuf"
headers_env: OTEL_EXPORTER_OTLP_HEADERS
traces: true
metrics: false
instrument_fastapi: true
metrics_export_interval_millis: 60000
```

The legacy scalar form `observability: langsmith|opentelemetry|none` is intentionally not supported, and `opentelemetry.yaml` rejects the old `enabled` field.

## Validation

- `make lint`
- `make security`
- `make complexity`
- `make typecheck`
- `make coverage`
- `make docs`
- `uv run --frozen python -m pytest tests/ -q` from `cli/`
