### PR TITLE
Clarify todo tutorial hexagonal flow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Le chemin recommandé pour découvrir le projet est le tutoriel Todo:
 - [Vue d'ensemble](tutorials/todo-list/index.md)
 - [Initialiser le projet](tutorials/todo-list/01-init-project.md)
 - [Créer l'entité](tutorials/todo-list/02-create-entity.md)
-- [Créer le use case](tutorials/todo-list/03-create-usecase.md)
+- [Créer les use cases](tutorials/todo-list/03-create-usecase.md)
 - [Exposer une API](tutorials/todo-list/04-api.md)
 - [Exposer un MCP](tutorials/todo-list/05-mcp.md)
 - [Ajouter un agent](tutorials/todo-list/06-agent.md)

--- a/docs/tutorials/todo-list/02-create-entity.md
+++ b/docs/tutorials/todo-list/02-create-entity.md
@@ -126,4 +126,4 @@ uv run python -m pytest tests/test_todo_entity.py
 arclith-cli add-entity Todo
 ```
 
-Étape suivante: [créer le use case](03-create-usecase.md).
+Étape suivante: [créer les use cases](03-create-usecase.md).

--- a/docs/tutorials/todo-list/03-create-usecase.md
+++ b/docs/tutorials/todo-list/03-create-usecase.md
@@ -106,12 +106,26 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from pydantic import BaseModel, Field
+
 from todo_list_service.domain.models.todo import Todo
+
+
+class ListTodosQuery(BaseModel):
+    page: int = Field(default=1, ge=1)
+    per_page: int = Field(default=20, ge=1, le=100)
+
+
+class ListTodosResult(BaseModel):
+    items: list[Todo]
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    per_page: int = Field(ge=1, le=100)
 
 
 class ListTodosPort(ABC):
     @abstractmethod
-    async def execute(self) -> list[Todo]:
+    async def execute(self, query: ListTodosQuery) -> ListTodosResult:
         raise NotImplementedError
 ```
 
@@ -123,15 +137,26 @@ from __future__ import annotations
 from arclith.domain.ports.outbound.repository import Repository
 
 from todo_list_service.domain.models.todo import Todo
-from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
+from todo_list_service.domain.ports.inbound.list_todos import (
+    ListTodosPort,
+    ListTodosQuery,
+    ListTodosResult,
+)
 
 
 class ListTodosUseCase(ListTodosPort):
     def __init__(self, repository: Repository[Todo]) -> None:
         self._repository = repository
 
-    async def execute(self) -> list[Todo]:
-        return [todo for todo in await self._repository.find_all() if not todo.is_deleted]
+    async def execute(self, query: ListTodosQuery) -> ListTodosResult:
+        offset = (query.page - 1) * query.per_page
+        items, total = await self._repository.find_page(offset=offset, limit=query.per_page)
+        return ListTodosResult(
+            items=items,
+            total=total,
+            page=query.page,
+            per_page=query.per_page,
+        )
 ```
 
 Les use cases implémentent les ports inbound et dépendent seulement de `Repository[Todo]`. Ils ne
@@ -186,6 +211,7 @@ from todo_list_service.application.use_cases.create_todo import CreateTodoUseCas
 from todo_list_service.application.use_cases.list_todos import ListTodosUseCase
 from todo_list_service.domain.models.todo import Todo, TodoStatus
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosQuery
 
 
 @pytest.mark.asyncio
@@ -234,7 +260,12 @@ async def test_list_todos_returns_persisted_entities() -> None:
         )
     )
 
-    assert await list_todos.execute() == [todo]
+    result = await list_todos.execute(ListTodosQuery())
+
+    assert result.items == [todo]
+    assert result.total == 1
+    assert result.page == 1
+    assert result.per_page == 20
 ```
 
 Lancer:

--- a/docs/tutorials/todo-list/03-create-usecase.md
+++ b/docs/tutorials/todo-list/03-create-usecase.md
@@ -1,7 +1,7 @@
-# 3. Créer le use case
+# 3. Créer les use cases
 
-Objectif: utiliser la CLI pour créer le port inbound et le fichier minimal, puis écrire le cas
-d'usage qui enregistre une todo via un port repository.
+Objectif: utiliser la CLI pour créer les ports inbound et les fichiers minimaux, puis écrire les cas
+d'usage qui enregistrent et listent les todos via un port repository.
 
 ![Capture interactive add-usecase](assets/03-create-usecase.svg)
 
@@ -18,11 +18,26 @@ Cas d'usage (ex : PlanShoppingList, find_by_name)
   Nom du cas d'usage: CreateTodo
 ```
 
+Relancer ensuite le même wizard pour le listing:
+
+```bash
+arclith-cli add-usecase
+```
+
+Répondre au prompt:
+
+```text
+Cas d'usage (ex : PlanShoppingList, find_by_name)
+  Nom du cas d'usage: ListTodos
+```
+
 La CLI crée:
 
 ```text
 src/todo_list_service/domain/ports/inbound/create_todo.py
+src/todo_list_service/domain/ports/inbound/list_todos.py
 src/todo_list_service/application/use_cases/create_todo.py
+src/todo_list_service/application/use_cases/list_todos.py
 ```
 
 Remplacer `src/todo_list_service/domain/ports/inbound/create_todo.py` par:
@@ -84,8 +99,43 @@ class CreateTodoUseCase(CreateTodoPort):
         return await self._repository.create(todo)
 ```
 
-Le use case implémente `CreateTodoPort` et dépend seulement de `Repository[Todo]`. Il ne connaît ni
-FastAPI, ni FastMCP, ni LangGraph, ni MongoDB.
+Remplacer `src/todo_list_service/domain/ports/inbound/list_todos.py` par:
+
+```python
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from todo_list_service.domain.models.todo import Todo
+
+
+class ListTodosPort(ABC):
+    @abstractmethod
+    async def execute(self) -> list[Todo]:
+        raise NotImplementedError
+```
+
+Remplacer `src/todo_list_service/application/use_cases/list_todos.py` par:
+
+```python
+from __future__ import annotations
+
+from arclith.domain.ports.outbound.repository import Repository
+
+from todo_list_service.domain.models.todo import Todo
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
+
+
+class ListTodosUseCase(ListTodosPort):
+    def __init__(self, repository: Repository[Todo]) -> None:
+        self._repository = repository
+
+    async def execute(self) -> list[Todo]:
+        return [todo for todo in await self._repository.find_all() if not todo.is_deleted]
+```
+
+Les use cases implémentent les ports inbound et dépendent seulement de `Repository[Todo]`. Ils ne
+connaissent ni FastAPI, ni FastMCP, ni LangGraph, ni MongoDB.
 
 Créer ensuite le container applicatif `src/todo_list_service/infrastructure/containers/todo_container.py`:
 
@@ -96,8 +146,10 @@ from arclith import Arclith
 from arclith.domain.ports.outbound.repository import Repository
 
 from todo_list_service.application.use_cases.create_todo import CreateTodoUseCase
+from todo_list_service.application.use_cases.list_todos import ListTodosUseCase
 from todo_list_service.domain.models.todo import Todo
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
 
 _repository: Repository[Todo] | None = None
 
@@ -111,6 +163,10 @@ def build_todo_repository(app: Arclith) -> Repository[Todo]:
 
 def build_create_todo_use_case(app: Arclith) -> CreateTodoPort:
     return CreateTodoUseCase(build_todo_repository(app))
+
+
+def build_list_todos_use_case(app: Arclith) -> ListTodosPort:
+    return ListTodosUseCase(build_todo_repository(app))
 ```
 
 Le cache module-level est volontaire pour le mode `memory`: tous les appels API/MCP du même
@@ -118,7 +174,7 @@ processus partagent le même repository.
 
 ## Tester
 
-Créer `tests/test_create_todo_usecase.py`:
+Créer `tests/test_todo_usecases.py`:
 
 ```python
 from datetime import date
@@ -127,6 +183,7 @@ import pytest
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 
 from todo_list_service.application.use_cases.create_todo import CreateTodoUseCase
+from todo_list_service.application.use_cases.list_todos import ListTodosUseCase
 from todo_list_service.domain.models.todo import Todo, TodoStatus
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand
 
@@ -162,18 +219,35 @@ async def test_done_todo_gets_completion_date() -> None:
     )
 
     assert todo.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_list_todos_returns_persisted_entities() -> None:
+    repository = InMemoryRepository[Todo]()
+    create_todo = CreateTodoUseCase(repository)
+    list_todos = ListTodosUseCase(repository)
+
+    todo = await create_todo.execute(
+        CreateTodoCommand(
+            title="Tester le listing",
+            due_date=date(2026, 9, 1),
+        )
+    )
+
+    assert await list_todos.execute() == [todo]
 ```
 
 Lancer:
 
 ```bash
-uv run python -m pytest tests/test_todo_entity.py tests/test_create_todo_usecase.py
+uv run python -m pytest tests/test_todo_entity.py tests/test_todo_usecases.py
 ```
 
 ## Voie rapide
 
 ```bash
 arclith-cli add-usecase CreateTodo
+arclith-cli add-usecase ListTodos
 ```
 
 Étape suivante: [exposer une API](04-api.md).

--- a/docs/tutorials/todo-list/04-api.md
+++ b/docs/tutorials/todo-list/04-api.md
@@ -33,6 +33,20 @@ La CLI crée:
 config/adapters/inbound/fastapi.yaml
 ```
 
+## Niveau de maturité API attendu
+
+Même dans un tutoriel, l'API doit publier un contrat propre dans `/docs` et `/openapi.json`.
+L'objectif est de montrer le standard Arclith attendu:
+
+- les routes appellent des ports inbound, jamais un repository;
+- chaque endpoint déclare `status_code`, `response_model`, `responses`, `summary`,
+  `description`, `response_description` et `operation_id`;
+- les réponses suivent les enveloppes `ApiResponse` et `PaginatedResponse`;
+- les headers utiles (`Location`, `Link`, `X-Total-Count`, `X-Idempotency-Replay`) sont
+  documentés;
+- les paramètres HTTP (`Prefer`, `page`, `per_page`) sont typés avec `Header` et `Query`;
+- les schémas Pydantic portent descriptions et exemples pour enrichir Swagger UI.
+
 ## Schémas HTTP
 
 Créer `src/todo_list_service/adapters/inbound/schemas/todo_schema.py`:
@@ -49,25 +63,87 @@ from todo_list_service.domain.models.todo import TodoStatus
 
 
 class TodoCreateSchema(BaseModel):
-    title: str = Field(min_length=1, max_length=140)
-    description: str = Field(default="", max_length=4000)
-    due_date: date
-    status: TodoStatus = TodoStatus.TODO
-    completed_at: datetime | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "title": "Écrire le tutoriel",
+                    "description": "Couvrir API, MCP et agent",
+                    "due_date": "2026-09-01",
+                    "status": "todo",
+                }
+            ]
+        }
+    )
+
+    title: str = Field(
+        min_length=1,
+        max_length=140,
+        description="Titre court de la todo.",
+        examples=["Écrire le tutoriel"],
+    )
+    description: str = Field(
+        default="",
+        max_length=4000,
+        description="Description détaillée.",
+        examples=["Couvrir API, MCP et agent"],
+    )
+    due_date: date = Field(
+        description="Date d'échéance au format ISO 8601.",
+        examples=["2026-09-01"],
+    )
+    status: TodoStatus = Field(
+        default=TodoStatus.TODO,
+        description="Statut courant de la todo.",
+        examples=["todo"],
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description="Date de réalisation, uniquement quand le statut est done.",
+        examples=[None],
+    )
+
+
+class TodoCreatedSchema(BaseModel):
+    uuid: UUID = Field(
+        description="Identifiant public de la todo créée.",
+        examples=["01951234-5678-7abc-def0-123456789abc"],
+    )
 
 
 class TodoSchema(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
+            "examples": [
+                {
+                    "uuid": "01951234-5678-7abc-def0-123456789abc",
+                    "title": "Écrire le tutoriel",
+                    "description": "Couvrir API, MCP et agent",
+                    "due_date": "2026-09-01",
+                    "completed_at": None,
+                    "status": "todo",
+                    "created_at": "2026-08-07T10:30:00Z",
+                    "updated_at": "2026-08-07T10:30:00Z",
+                    "version": 1,
+                }
+            ]
+        },
+    )
 
-    uuid: UUID
-    title: str
-    description: str
-    due_date: date
-    completed_at: datetime | None
-    status: TodoStatus
-    created_at: datetime
-    updated_at: datetime
-    version: int
+    uuid: UUID = Field(description="Identifiant public de la todo.")
+    title: str = Field(description="Titre court.")
+    description: str = Field(description="Description détaillée.")
+    due_date: date = Field(description="Date d'échéance.")
+    completed_at: datetime | None = Field(
+        description="Date de réalisation éventuelle."
+    )
+    status: TodoStatus = Field(description="Statut courant.")
+    created_at: datetime = Field(description="Date de création.")
+    updated_at: datetime = Field(description="Date de dernière modification.")
+    version: int = Field(
+        description="Version métier utilisée par les mécanismes HTTP comme ETag."
+    )
 ```
 
 Créer aussi le package:
@@ -81,17 +157,32 @@ touch src/todo_list_service/adapters/inbound/schemas/__init__.py
 
 Les handlers adaptent HTTP vers les ports inbound. Ils convertissent les schémas HTTP en commandes
 applicatives et ne connaissent ni repository, ni MongoDB, ni adapter de persistance.
+Ils peuvent en revanche traduire une erreur applicative en statut HTTP, car cette traduction fait
+partie du rôle de l'adapter inbound.
 
 Créer `src/todo_list_service/adapters/inbound/fastapi/handlers/todo_handlers.py`:
 
 ```python
 from __future__ import annotations
 
-from fastapi import Request, Response
+from typing import Annotated
 
-from todo_list_service.adapters.inbound.schemas.todo_schema import TodoCreateSchema, TodoSchema
+from fastapi import Header, HTTPException, Query, Request, Response
+from pydantic import ValidationError
+
+from arclith.adapters.inbound.schemas import (
+    ApiResponse,
+    PaginatedResponse,
+    paginated_response,
+    success_response,
+)
+from todo_list_service.adapters.inbound.schemas.todo_schema import (
+    TodoCreatedSchema,
+    TodoCreateSchema,
+    TodoSchema,
+)
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
-from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort, ListTodosQuery
 
 
 class TodoHandlers:
@@ -99,22 +190,77 @@ class TodoHandlers:
         self._create_todo = create_todo
         self._list_todos = list_todos
 
-    async def create_todo(self, payload: TodoCreateSchema, response: Response, request: Request) -> TodoSchema:
-        todo = await self._create_todo.execute(
-            CreateTodoCommand(
-                title=payload.title,
-                description=payload.description,
-                due_date=payload.due_date,
-                status=payload.status,
-                completed_at=payload.completed_at,
+    async def create_todo(
+        self,
+        payload: TodoCreateSchema,
+        response: Response,
+        request: Request,
+        prefer: Annotated[
+            str | None,
+            Header(
+                description=(
+                    "RFC 7240. Utiliser return=representation pour recevoir "
+                    "la todo complète."
+                )
+            ),
+        ] = None,
+    ) -> ApiResponse[TodoCreatedSchema | TodoSchema]:
+        try:
+            todo = await self._create_todo.execute(
+                CreateTodoCommand(
+                    title=payload.title,
+                    description=payload.description,
+                    due_date=payload.due_date,
+                    status=payload.status,
+                    completed_at=payload.completed_at,
+                )
             )
-        )
-        response.headers["Location"] = f"{request.url.path.rstrip('/')}/{todo.uuid}"
-        return TodoSchema.model_validate(todo)
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=exc.errors()) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    async def list_todos(self) -> list[TodoSchema]:
-        todos = await self._list_todos.execute()
-        return [TodoSchema.model_validate(todo) for todo in todos]
+        collection_url = request.url.path.rstrip("/")
+        location = f"{collection_url}/{todo.uuid}"
+        links = {"self": location, "collection": collection_url}
+
+        response.headers["Location"] = location
+        response.headers["Link"] = (
+            f'<{location}>; rel="self", <{collection_url}>; rel="collection"'
+        )
+
+        if prefer and "return=representation" in prefer.lower():
+            return success_response(TodoSchema.model_validate(todo), links=links)
+        return success_response(TodoCreatedSchema(uuid=todo.uuid), links=links)
+
+    async def list_todos(
+        self,
+        response: Response,
+        request: Request,
+        page: Annotated[
+            int,
+            Query(ge=1, description="Page à retourner, à partir de 1."),
+        ] = 1,
+        per_page: Annotated[
+            int,
+            Query(ge=1, le=100, description="Nombre d'éléments par page."),
+        ] = 20,
+    ) -> PaginatedResponse[TodoSchema]:
+        result = await self._list_todos.execute(
+            ListTodosQuery(page=page, per_page=per_page)
+        )
+        todos = [TodoSchema.model_validate(todo) for todo in result.items]
+        collection_url = request.url.path.rstrip("/")
+
+        response.headers["X-Total-Count"] = str(result.total)
+        response.headers["Link"] = f'<{collection_url}>; rel="self"'
+        return paginated_response(
+            todos,
+            total=result.total,
+            page=result.page,
+            per_page=result.per_page,
+            links={"self": collection_url},
+        )
 ```
 
 Créer le package handlers:
@@ -136,8 +282,150 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from arclith.adapters.inbound.schemas import ApiResponse, PaginatedResponse
 from todo_list_service.adapters.inbound.fastapi.handlers.todo_handlers import TodoHandlers
-from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
+from todo_list_service.adapters.inbound.schemas.todo_schema import (
+    TodoCreatedSchema,
+    TodoSchema,
+)
+
+_CREATED_TODO_EXAMPLE = {
+    "status": "success",
+    "data": {"uuid": "01951234-5678-7abc-def0-123456789abc"},
+    "metadata": {
+        "request_id": "01951234-5678-7abc-def0-123456789abc",
+        "timestamp": "2026-08-07T10:30:00Z",
+        "version": "v1",
+        "links": {
+            "self": "/v1/todos/01951234-5678-7abc-def0-123456789abc",
+            "collection": "/v1/todos",
+        },
+    },
+}
+
+_FULL_TODO_EXAMPLE = {
+    "status": "success",
+    "data": {
+        "uuid": "01951234-5678-7abc-def0-123456789abc",
+        "title": "Écrire le tutoriel",
+        "description": "Couvrir API, MCP et agent",
+        "due_date": "2026-09-01",
+        "completed_at": None,
+        "status": "todo",
+        "created_at": "2026-08-07T10:30:00Z",
+        "updated_at": "2026-08-07T10:30:00Z",
+        "version": 1,
+    },
+    "metadata": _CREATED_TODO_EXAMPLE["metadata"],
+}
+
+_TODO_LIST_EXAMPLE = {
+    "status": "success",
+    "data": [_FULL_TODO_EXAMPLE["data"]],
+    "pagination": {
+        "total": 1,
+        "page": 1,
+        "per_page": 20,
+        "pages": 1,
+        "has_next": False,
+        "has_prev": False,
+        "next_page": None,
+        "prev_page": None,
+    },
+    "metadata": {
+        "request_id": "01951234-5678-7abc-def0-123456789abc",
+        "timestamp": "2026-08-07T10:30:00Z",
+        "version": "v1",
+        "links": {"self": "/v1/todos"},
+    },
+}
+
+_VALIDATION_ERROR_RESPONSE = {
+    "description": "Payload ou paramètres invalides.",
+    "content": {
+        "application/json": {
+            "example": {
+                "detail": [
+                    {
+                        "type": "greater_than_equal",
+                        "loc": ["query", "page"],
+                        "msg": "Input should be greater than or equal to 1",
+                        "input": 0,
+                        "ctx": {"ge": 1},
+                    }
+                ]
+            }
+        }
+    },
+}
+
+_BAD_REQUEST_RESPONSE = {
+    "description": "Requête invalide avant exécution du use case.",
+    "content": {
+        "application/json": {
+            "example": {
+                "detail": "Idempotency-Key exceeds 255 characters",
+            }
+        }
+    },
+}
+
+_CREATE_TODO_RESPONSES = {
+    201: {
+        "description": (
+            "Todo créée. La réponse minimale contient l'UUID; Prefer permet "
+            "la représentation complète."
+        ),
+        "headers": {
+            "Location": {
+                "description": "URL canonique de la todo créée.",
+                "schema": {"type": "string"},
+            },
+            "Link": {
+                "description": "Liens HATEOAS self et collection.",
+                "schema": {"type": "string"},
+            },
+            "X-Idempotency-Replay": {
+                "description": "Présent à true si la réponse vient du cache d'idempotence.",
+                "schema": {"type": "boolean"},
+            },
+        },
+        "content": {
+            "application/json": {
+                "examples": {
+                    "minimal": {
+                        "summary": "Réponse par défaut",
+                        "value": _CREATED_TODO_EXAMPLE,
+                    },
+                    "representation": {
+                        "summary": "Avec Prefer: return=representation",
+                        "value": _FULL_TODO_EXAMPLE,
+                    },
+                }
+            }
+        },
+    },
+    400: _BAD_REQUEST_RESPONSE,
+    422: _VALIDATION_ERROR_RESPONSE,
+}
+
+_LIST_TODOS_RESPONSES = {
+    200: {
+        "description": "Page de todos actives.",
+        "headers": {
+            "X-Total-Count": {
+                "description": "Nombre total de todos actives avant pagination.",
+                "schema": {"type": "integer"},
+            },
+            "Link": {
+                "description": "Lien HATEOAS vers la collection.",
+                "schema": {"type": "string"},
+            },
+        },
+        "content": {"application/json": {"example": _TODO_LIST_EXAMPLE}},
+    },
+    422: _VALIDATION_ERROR_RESPONSE,
+}
 
 
 def build_todo_router(handlers: TodoHandlers) -> APIRouter:
@@ -146,16 +434,32 @@ def build_todo_router(handlers: TodoHandlers) -> APIRouter:
         "/",
         handlers.create_todo,
         methods=["POST"],
-        response_model=TodoSchema,
+        response_model=ApiResponse[TodoCreatedSchema | TodoSchema],
+        response_model_exclude_none=True,
         status_code=201,
-        summary="Create todo",
+        summary="Créer une todo",
+        description=(
+            "Crée une todo via `CreateTodoPort`, sans accès direct au repository."
+        ),
+        response_description="Todo créée dans l'enveloppe de réponse Arclith.",
+        operation_id="createTodo",
+        responses=_CREATE_TODO_RESPONSES,
     )
     router.add_api_route(
         "/",
         handlers.list_todos,
         methods=["GET"],
-        response_model=list[TodoSchema],
-        summary="List todos",
+        response_model=PaginatedResponse[TodoSchema],
+        response_model_exclude_none=True,
+        status_code=200,
+        summary="Lister les todos",
+        description=(
+            "Retourne une page de todos via `ListTodosPort`, "
+            "sans accès direct au repository."
+        ),
+        response_description="Page de todos dans l'enveloppe paginée Arclith.",
+        operation_id="listTodos",
+        responses=_LIST_TODOS_RESPONSES,
     )
     return router
 ```
@@ -236,7 +540,7 @@ Dans un autre terminal:
 
 ```bash
 curl -fsS http://127.0.0.1:9000/health
-curl -fsS -X POST http://127.0.0.1:8120/v1/todos/ \
+curl -i -fsS -X POST http://127.0.0.1:8120/v1/todos/ \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: todo-demo-1" \
   -d '{
@@ -246,11 +550,28 @@ curl -fsS -X POST http://127.0.0.1:8120/v1/todos/ \
     "status": "todo"
   }'
 
-curl -fsS http://127.0.0.1:8120/v1/todos/
+curl -i -fsS -X POST http://127.0.0.1:8120/v1/todos/ \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: todo-demo-2" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "title": "Relire Swagger",
+    "description": "Vérifier les exemples OpenAPI",
+    "due_date": "2026-09-02",
+    "status": "wip"
+  }'
+
+curl -i -fsS "http://127.0.0.1:8120/v1/todos/?page=1&per_page=20"
+curl -fsS http://127.0.0.1:8120/openapi.json | python -m json.tool
 ```
 
-La réponse `POST` doit contenir les champs de la todo créée, dont `uuid`, `title`, `due_date`,
-`status`, `created_at` et `version`.
+À vérifier:
+
+- le `POST` retourne `201`, `Location`, `Link` et une enveloppe `{ "status": "success", "data": ... }`;
+- sans `Prefer`, `data` contient seulement l'`uuid`;
+- avec `Prefer: return=representation`, `data` contient la todo complète;
+- le `GET` retourne `200`, `X-Total-Count`, `pagination` et une liste dans `data`;
+- `/docs` et `/openapi.json` affichent les `operationId`, exemples, headers et réponses `422`.
 
 ## Voie rapide
 

--- a/docs/tutorials/todo-list/04-api.md
+++ b/docs/tutorials/todo-list/04-api.md
@@ -1,6 +1,7 @@
 # 4. Exposer une API
 
-Objectif: générer la configuration FastAPI avec la CLI, puis exposer `CreateTodoPort` par HTTP.
+Objectif: générer la configuration FastAPI avec la CLI, puis exposer `CreateTodoPort` et
+`ListTodosPort` par HTTP.
 
 ![Capture interactive FastAPI](assets/04-api.svg)
 
@@ -76,44 +77,27 @@ mkdir -p src/todo_list_service/adapters/inbound/schemas
 touch src/todo_list_service/adapters/inbound/schemas/__init__.py
 ```
 
-## Router FastAPI
+## Handlers FastAPI
 
-Créer `src/todo_list_service/adapters/inbound/fastapi/routers/todo_router.py`:
+Les handlers adaptent HTTP vers les ports inbound. Ils convertissent les schémas HTTP en commandes
+applicatives et ne connaissent ni repository, ni MongoDB, ni adapter de persistance.
+
+Créer `src/todo_list_service/adapters/inbound/fastapi/handlers/todo_handlers.py`:
 
 ```python
 from __future__ import annotations
 
-from fastapi import APIRouter, Request, Response
+from fastapi import Request, Response
 
-from arclith.domain.ports.outbound.repository import Repository
 from todo_list_service.adapters.inbound.schemas.todo_schema import TodoCreateSchema, TodoSchema
-from todo_list_service.domain.models.todo import Todo
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
 
 
-class TodoRouter:
-    def __init__(self, create_todo: CreateTodoPort, repository: Repository[Todo]) -> None:
+class TodoHandlers:
+    def __init__(self, create_todo: CreateTodoPort, list_todos: ListTodosPort) -> None:
         self._create_todo = create_todo
-        self._repository = repository
-        self.router = APIRouter(prefix="/v1/todos", tags=["todos"])
-        self._register_routes()
-
-    def _register_routes(self) -> None:
-        self.router.add_api_route(
-            "/",
-            self.create_todo,
-            methods=["POST"],
-            response_model=TodoSchema,
-            status_code=201,
-            summary="Create todo",
-        )
-        self.router.add_api_route(
-            "/",
-            self.list_todos,
-            methods=["GET"],
-            response_model=list[TodoSchema],
-            summary="List todos",
-        )
+        self._list_todos = list_todos
 
     async def create_todo(self, payload: TodoCreateSchema, response: Response, request: Request) -> TodoSchema:
         todo = await self._create_todo.execute(
@@ -129,8 +113,51 @@ class TodoRouter:
         return TodoSchema.model_validate(todo)
 
     async def list_todos(self) -> list[TodoSchema]:
-        todos = await self._repository.find_all()
+        todos = await self._list_todos.execute()
         return [TodoSchema.model_validate(todo) for todo in todos]
+```
+
+Créer le package handlers:
+
+```bash
+mkdir -p src/todo_list_service/adapters/inbound/fastapi/handlers
+touch src/todo_list_service/adapters/inbound/fastapi/handlers/__init__.py
+```
+
+## Router FastAPI
+
+Le router déclare uniquement les URLs, méthodes HTTP, modèles de réponse et métadonnées OpenAPI. Il
+ne contient pas de logique métier.
+
+Créer `src/todo_list_service/adapters/inbound/fastapi/routers/todo_router.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from todo_list_service.adapters.inbound.fastapi.handlers.todo_handlers import TodoHandlers
+from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
+
+
+def build_todo_router(handlers: TodoHandlers) -> APIRouter:
+    router = APIRouter(prefix="/v1/todos", tags=["todos"])
+    router.add_api_route(
+        "/",
+        handlers.create_todo,
+        methods=["POST"],
+        response_model=TodoSchema,
+        status_code=201,
+        summary="Create todo",
+    )
+    router.add_api_route(
+        "/",
+        handlers.list_todos,
+        methods=["GET"],
+        response_model=list[TodoSchema],
+        summary="List todos",
+    )
+    return router
 ```
 
 Créer le package router:
@@ -150,17 +177,19 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from arclith import Arclith
-from todo_list_service.adapters.inbound.fastapi.routers.todo_router import TodoRouter
+from todo_list_service.adapters.inbound.fastapi.handlers.todo_handlers import TodoHandlers
+from todo_list_service.adapters.inbound.fastapi.routers.todo_router import build_todo_router
 from todo_list_service.infrastructure.containers.todo_container import (
     build_create_todo_use_case,
-    build_todo_repository,
+    build_list_todos_use_case,
 )
 
 
 def register_routers(app: FastAPI, arclith: Arclith) -> None:
-    repository = build_todo_repository(arclith)
     create_todo = build_create_todo_use_case(arclith)
-    app.include_router(TodoRouter(create_todo, repository).router)
+    list_todos = build_list_todos_use_case(arclith)
+    handlers = TodoHandlers(create_todo, list_todos)
+    app.include_router(build_todo_router(handlers))
 ```
 
 Mettre à jour `main.py`:

--- a/docs/tutorials/todo-list/05-mcp.md
+++ b/docs/tutorials/todo-list/05-mcp.md
@@ -48,7 +48,7 @@ from pydantic import Field
 from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
 from todo_list_service.domain.models.todo import TodoStatus
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
-from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort, ListTodosQuery
 
 
 class TodoMCP:
@@ -90,8 +90,8 @@ class TodoMCP:
         @self._mcp.tool
         async def list_todo_items() -> list[dict]:
             """List todos through the application use case."""
-            todos = await list_todos.execute()
-            return [TodoSchema.model_validate(todo).model_dump(mode="json") for todo in todos]
+            result = await list_todos.execute(ListTodosQuery(page=1, per_page=100))
+            return [TodoSchema.model_validate(todo).model_dump(mode="json") for todo in result.items]
 ```
 
 Créer `src/todo_list_service/adapters/inbound/fastmcp/tools/__init__.py`:

--- a/docs/tutorials/todo-list/05-mcp.md
+++ b/docs/tutorials/todo-list/05-mcp.md
@@ -45,27 +45,27 @@ from typing import Annotated
 import fastmcp
 from pydantic import Field
 
-from arclith.domain.ports.outbound.repository import Repository
 from todo_list_service.adapters.inbound.schemas.todo_schema import TodoSchema
-from todo_list_service.domain.models.todo import Todo, TodoStatus
+from todo_list_service.domain.models.todo import TodoStatus
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
 
 
 class TodoMCP:
     def __init__(
         self,
         create_todo: CreateTodoPort,
-        repository: Repository[Todo],
+        list_todos: ListTodosPort,
         mcp: fastmcp.FastMCP,
     ) -> None:
         self._create_todo = create_todo
-        self._repository = repository
+        self._list_todos = list_todos
         self._mcp = mcp
         self._register_tools()
 
     def _register_tools(self) -> None:
         create_todo = self._create_todo
-        repository = self._repository
+        list_todos = self._list_todos
 
         @self._mcp.tool
         async def create_todo_item(
@@ -89,8 +89,8 @@ class TodoMCP:
 
         @self._mcp.tool
         async def list_todo_items() -> list[dict]:
-            """List todos currently available in the repository."""
-            todos = await repository.find_all()
+            """List todos through the application use case."""
+            todos = await list_todos.execute()
             return [TodoSchema.model_validate(todo).model_dump(mode="json") for todo in todos]
 ```
 
@@ -113,14 +113,14 @@ from arclith import Arclith
 from todo_list_service.adapters.inbound.fastmcp.tools import TodoMCP
 from todo_list_service.infrastructure.containers.todo_container import (
     build_create_todo_use_case,
-    build_todo_repository,
+    build_list_todos_use_case,
 )
 
 
 def register_tools(mcp: fastmcp.FastMCP, arclith: Arclith) -> None:
-    repository = build_todo_repository(arclith)
     create_todo = build_create_todo_use_case(arclith)
-    TodoMCP(create_todo, repository, mcp)
+    list_todos = build_list_todos_use_case(arclith)
+    TodoMCP(create_todo, list_todos, mcp)
 ```
 
 ## Entrypoint API + MCP

--- a/docs/tutorials/todo-list/assets/03-create-usecase.svg
+++ b/docs/tutorials/todo-list/assets/03-create-usecase.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="300" viewBox="0 0 1120 300" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="360" viewBox="0 0 1120 360" role="img" aria-labelledby="title desc">
   <title id="title">Capture terminal - arclith-cli add-usecase</title>
-  <desc id="desc">Création interactive du use case CreateTodo.</desc>
-  <rect width="1120" height="300" rx="8" fill="#1f2933"/>
+  <desc id="desc">Création interactive des use cases CreateTodo et ListTodos.</desc>
+  <rect width="1120" height="360" rx="8" fill="#1f2933"/>
   <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
   <circle cx="22" cy="18" r="6" fill="#f87171"/>
   <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
@@ -9,6 +9,8 @@
   <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-usecase</text>
   <text x="24" y="118" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Cas d'usage (ex : PlanShoppingList, find_by_name)</text>
   <text x="24" y="154" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom du cas d'usage: CreateTodo</text>
-  <text x="24" y="204" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Port inbound CreateTodoPort créé : src/.../domain/ports/inbound/create_todo.py</text>
-  <text x="24" y="240" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Cas d'usage CreateTodoUseCase créé : src/.../application/use_cases/create_todo.py</text>
+  <text x="24" y="198" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-usecase</text>
+  <text x="24" y="240" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Cas d'usage (ex : PlanShoppingList, find_by_name)</text>
+  <text x="24" y="276" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom du cas d'usage: ListTodos</text>
+  <text x="24" y="326" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Ports inbound et use cases créés pour CreateTodo et ListTodos</text>
 </svg>

--- a/docs/tutorials/todo-list/assets/04-api.svg
+++ b/docs/tutorials/todo-list/assets/04-api.svg
@@ -12,5 +12,5 @@
   <text x="24" y="186" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1</text>
   <text x="24" y="224" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Host FastAPI: 0.0.0.0    Port FastAPI: 8120    reload: yes</text>
   <text x="24" y="280" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ config/adapters/inbound/fastapi.yaml</text>
-  <text x="24" y="316" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastapi scaffolde avec succes.</text>
+  <text x="24" y="316" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastapi scaffoldé avec succès.</text>
 </svg>

--- a/docs/tutorials/todo-list/assets/05-mcp.svg
+++ b/docs/tutorials/todo-list/assets/05-mcp.svg
@@ -11,5 +11,5 @@
   <text x="48" y="148" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">1  fastmcp</text>
   <text x="24" y="186" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1</text>
   <text x="24" y="224" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Host FastMCP: 127.0.0.1    Port FastMCP: 8121</text>
-  <text x="24" y="280" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastmcp scaffolde avec succes.</text>
+  <text x="24" y="280" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Adapter fastmcp scaffoldé avec succès.</text>
 </svg>

--- a/docs/tutorials/todo-list/assets/06-agent.svg
+++ b/docs/tutorials/todo-list/assets/06-agent.svg
@@ -12,5 +12,5 @@
   <text x="24" y="206" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-adapter --capability agent</text>
   <text x="24" y="244" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Votre choix: 1  Nom du graphe LangGraph: todo_agent</text>
   <text x="24" y="300" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ uv run langgraph dev --no-browser --allow-blocking --port 2024</text>
-  <text x="24" y="354" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Agent: Je peux enregistrer la todo. Quelle est sa date d'echeance ?</text>
+  <text x="24" y="354" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Agent: Je peux enregistrer la todo. Quelle est sa date d'échéance ?</text>
 </svg>

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -57,6 +57,10 @@ Les adapters inbound ne parlent jamais directement au repository. Ils appellent 
 exactement comme l'agent qui transforme une conversation en commande structurée puis appelle
 `CreateTodoPort`.
 
+L'étape FastAPI pousse aussi le contrat HTTP: format de réponse enveloppé, pagination, headers
+standard, exemples OpenAPI et documentation détaillée des erreurs. L'idée est que la maturité API
+vienne de l'adapter HTTP, tout en gardant le métier testable sans serveur web.
+
 ## Étapes
 
 1. [Initialiser le projet](01-init-project.md)

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -2,11 +2,27 @@
 
 Ce tutoriel part de zéro et construit une todo list Arclith étape par étape.
 
+## Méthodologie Arclith
+
+Arclith pousse une démarche hexagonale simple: on commence par le métier, puis on branche les outils
+autour. Le cœur se construit dans cet ordre:
+
+1. créer les entités qui portent les données et règles métier;
+2. définir les ports inbound, c'est-à-dire les intentions que l'application expose;
+3. écrire les use cases qui implémentent ces ports et orchestrent le métier;
+4. brancher les adapters inbound comme FastAPI, FastMCP ou LangGraph;
+5. choisir les adapters outbound comme `memory` ou MongoDB pour la persistance.
+
+Cette séparation apporte la souplesse attendue d'une architecture hexagonale: l'API, le MCP, l'agent
+et la base de données sont remplaçables sans déplacer le métier. On peut développer et tester les
+use cases complètement indépendamment de FastAPI, FastMCP, LangGraph ou MongoDB, puis brancher ces
+outils seulement quand le comportement applicatif est clair.
+
 Le fil conducteur est volontairement simple:
 
 - une entité `Todo`;
-- un port inbound `CreateTodoPort`;
-- un use case `CreateTodoUseCase` pour enregistrer une todo;
+- deux ports inbound `CreateTodoPort` et `ListTodosPort`;
+- deux use cases applicatifs pour enregistrer et lister les todos;
 - une API FastAPI;
 - un serveur MCP FastMCP;
 - un agent LangGraph qui collecte les champs manquants avant d'appeler le même use case.
@@ -31,20 +47,21 @@ Une todo contient:
 ```text
 Client HTTP / Client MCP / LangGraph
   -> adapter inbound
-  -> CreateTodoPort
-  -> CreateTodoUseCase
+  -> CreateTodoPort / ListTodosPort
+  -> use case applicatif
   -> Repository[Todo]
   -> memory, puis MongoDB
 ```
 
-L'agent ne persiste jamais directement. Il transforme une conversation en commande structurée puis
-appelle `CreateTodoPort`, exactement comme l'API et le MCP.
+Les adapters inbound ne parlent jamais directement au repository. Ils appellent les ports inbound,
+exactement comme l'agent qui transforme une conversation en commande structurée puis appelle
+`CreateTodoPort`.
 
 ## Étapes
 
 1. [Initialiser le projet](01-init-project.md)
 2. [Créer l'entité Todo](02-create-entity.md)
-3. [Créer le use case d'enregistrement](03-create-usecase.md)
+3. [Créer les use cases](03-create-usecase.md)
 4. [Exposer une API FastAPI](04-api.md)
 5. [Exposer un MCP FastMCP](05-mcp.md)
 6. [Ajouter un agent LangGraph](06-agent.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
       - Vue d'ensemble: tutorials/todo-list/index.md
       - 1. Initialiser le projet: tutorials/todo-list/01-init-project.md
       - 2. Créer l'entité: tutorials/todo-list/02-create-entity.md
-      - 3. Créer le use case: tutorials/todo-list/03-create-usecase.md
+      - 3. Créer les use cases: tutorials/todo-list/03-create-usecase.md
       - 4. Exposer une API: tutorials/todo-list/04-api.md
       - 5. Exposer un MCP: tutorials/todo-list/05-mcp.md
       - 6. Ajouter un agent: tutorials/todo-list/06-agent.md


### PR DESCRIPTION
## What changed

- Add a methodology section at the start of the Todo tutorial explaining the Arclith hexagonal flow: entity, inbound port, use case, then inbound/outbound adapters.
- Add a dedicated `ListTodosPort` and `ListTodosUseCase` to keep listing behind an application use case.
- Split the FastAPI example into HTTP handlers and route registration so routes stay declarative and handlers adapt HTTP to inbound ports.
- Update the FastMCP example so listing calls `ListTodosPort` instead of the repository directly.
- Align tutorial navigation and SVG captures, including accent fixes.

## Why

The tutorial previously let inbound adapters reach into `Repository[Todo]` for listing. That weakened the hexagonal boundary and made the generated project look less KISS/SRP than intended. The corrected flow keeps infrastructure and transport tools outside the application core.

## Validation

- `make docs`
