### PR TITLE
fix: align tutorial with observability format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   `observability.enabled`, pour activer `langsmith` et `opentelemetry` en parallèle. L'ancien
   format scalaire `observability: langsmith|opentelemetry|none` n'est plus accepté, et
   `opentelemetry.yaml` ne contient plus de flag `enabled`.
+- **Versions observability** — `arclith` passe à `0.14.0`; `arclith-cli` passe à `0.11.0`
+  et dépend de `arclith>=0.14.0`, afin que les projets générés utilisent le même schéma de
+  configuration que le tutoriel.
 
 ---
 

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -72,22 +72,7 @@ def _framework_version() -> str:
     try:
         return version("arclith")
     except PackageNotFoundError:
-        return "0.13.0"
-
-
-def _local_framework_source() -> Path | None:
-    cli_source_root = Path(__file__).resolve().parents[2]
-    if (cli_source_root / "pyproject.toml").is_file() and (cli_source_root / "arclith").is_dir():
-        return cli_source_root
-    return None
-
-
-def _framework_dependency_spec() -> str:
-    local_source = _local_framework_source()
-    if local_source is not None:
-        return f"arclith[fastapi,mcp] @ {local_source.as_uri()}"
-    framework_version = _framework_version()
-    return f"arclith[fastapi,mcp]>={framework_version}"
+        return "0.14.0"
 
 
 def _create_package_layout(package_root: Path) -> None:
@@ -114,7 +99,7 @@ def _create_package_layout(package_root: Path) -> None:
 
 
 def _write_project_files(target_dir: Path, project_name: str, package_name: str) -> None:
-    framework_dependency = _framework_dependency_spec()
+    framework_version = _framework_version()
     (target_dir / "pyproject.toml").write_text(
         f"""[build-system]
 requires = ["hatchling"]
@@ -126,7 +111,7 @@ version = "0.1.0"
 description = "Arclith service"
 requires-python = ">=3.13"
 dependencies = [
-    "{framework_dependency}",
+    "arclith[fastapi,mcp]>={framework_version}",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -75,6 +75,21 @@ def _framework_version() -> str:
         return "0.13.0"
 
 
+def _local_framework_source() -> Path | None:
+    cli_source_root = Path(__file__).resolve().parents[2]
+    if (cli_source_root / "pyproject.toml").is_file() and (cli_source_root / "arclith").is_dir():
+        return cli_source_root
+    return None
+
+
+def _framework_dependency_spec() -> str:
+    local_source = _local_framework_source()
+    if local_source is not None:
+        return f"arclith[fastapi,mcp] @ {local_source.as_uri()}"
+    framework_version = _framework_version()
+    return f"arclith[fastapi,mcp]>={framework_version}"
+
+
 def _create_package_layout(package_root: Path) -> None:
     dirs = (
         package_root,
@@ -99,7 +114,7 @@ def _create_package_layout(package_root: Path) -> None:
 
 
 def _write_project_files(target_dir: Path, project_name: str, package_name: str) -> None:
-    framework_version = _framework_version()
+    framework_dependency = _framework_dependency_spec()
     (target_dir / "pyproject.toml").write_text(
         f"""[build-system]
 requires = ["hatchling"]
@@ -111,7 +126,7 @@ version = "0.1.0"
 description = "Arclith service"
 requires-python = ">=3.13"
 dependencies = [
-    "arclith[fastapi,mcp]>={framework_version}",
+    "{framework_dependency}",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arclith-cli"
-version = "0.10.0"
+version = "0.11.0"
 description = "CLI scaffolding tool for arclith — hexagonal architecture framework"
 license = { file = "LICENSE" }
 requires-python = ">=3.13"
@@ -16,7 +16,7 @@ dependencies = [
     "typer>=0.15.0",
     "rich>=13.0.0",
     "httpx>=0.27.0",
-    "arclith>=0.13.0",
+    "arclith>=0.14.0",
 ]
 
 [tool.uv.sources]

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -47,6 +47,7 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
         "observability:\n"
         "  enabled: []\n"
     )
+    assert "arclith[fastapi,mcp] @ file://" in (generated / "pyproject.toml").read_text(encoding="utf-8")
     assert (package_root / "domain" / "models" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "inbound" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "outbound" / "__init__.py").exists()

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -47,7 +47,7 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
         "observability:\n"
         "  enabled: []\n"
     )
-    assert "arclith[fastapi,mcp] @ file://" in (generated / "pyproject.toml").read_text(encoding="utf-8")
+    assert "arclith[fastapi,mcp]>=0.14.0" in (generated / "pyproject.toml").read_text(encoding="utf-8")
     assert (package_root / "domain" / "models" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "inbound" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "outbound" / "__init__.py").exists()

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "arclith"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "../" }
 dependencies = [
     { name = "fastapi" },
@@ -132,7 +132,7 @@ docs = [
 
 [[package]]
 name = "arclith-cli"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "arclith" },

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -27,6 +27,10 @@ cd todo-list-service
 uv sync
 ```
 
+Si `arclith-cli` est exécuté depuis le dépôt Arclith (mode source locale), la dépendance
+`arclith` générée dans `pyproject.toml` pointe automatiquement vers ce dépôt (`file://...`),
+pour éviter tout décalage de version pendant le tutoriel.
+
 Le projet démarre avec `repository: memory`:
 
 ```yaml

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -10,6 +10,7 @@ Depuis le dossier qui contiendra les projets de test:
 mkdir -p ~/Perso/projets/demo-arclith
 cd ~/Perso/projets/demo-arclith
 
+uv tool upgrade arclith-cli
 arclith-cli init
 ```
 
@@ -27,9 +28,9 @@ cd todo-list-service
 uv sync
 ```
 
-Si `arclith-cli` est exécuté depuis le dépôt Arclith (mode source locale), la dépendance
-`arclith` générée dans `pyproject.toml` pointe automatiquement vers ce dépôt (`file://...`),
-pour éviter tout décalage de version pendant le tutoriel.
+Ce tutoriel nécessite `arclith-cli>=0.11.0`, qui génère une dépendance
+`arclith>=0.14.0`. Ces versions utilisent uniquement le nouveau format
+`observability.enabled`.
 
 Le projet démarre avec `repository: memory`:
 
@@ -73,6 +74,7 @@ tests/test_project_bootstrap.py ..   [100%]
 ## Voie rapide
 
 ```bash
+uv tool upgrade arclith-cli
 arclith-cli init todo-list-service
 cd todo-list-service
 uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arclith"
-version = "0.13.0"
+version = "0.14.0"
 description = "Hexagonal architecture framework — domain, use cases, repositories, adapters"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -69,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "arclith"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- bump arclith to 0.14.0 and arclith-cli to 0.11.0
- require arclith>=0.14.0 in CLI-generated projects
- update tutorial init steps to upgrade arclith-cli before scaffolding
- keep observability config on the new observability.enabled format only

## Why
The tutorial scaffold could resolve an older published Arclith version, causing config schema mismatch during bootstrap tests. This PR aligns release versions so generated projects and tutorial config use the same schema.