### PR TITLE
Fix LM Studio structured output and intent interpreter scaffold

### DIFF
--- a/arclith/adapters/outbound/yaml/secret_adapter.py
+++ b/arclith/adapters/outbound/yaml/secret_adapter.py
@@ -17,7 +17,7 @@ class YamlSecretAdapter(SecretResolver):
           mongodb:
             uri: mongodb://localhost:5971
         lm:
-          planner:
+          intent_interpreter:
             api_key: sk-ant-xxxx
     """
 
@@ -42,4 +42,3 @@ class YamlSecretAdapter(SecretResolver):
                 return None
             current = current[key]
         return str(current) if current is not None else None
-

--- a/arclith/infrastructure/lm.py
+++ b/arclith/infrastructure/lm.py
@@ -11,11 +11,13 @@ def build_pydantic_ai_model(settings: LMSettings):
     """
     if settings.provider == "anthropic":
         from pydantic_ai.models.anthropic import AnthropicModel
+        from pydantic_ai.profiles.anthropic import AnthropicModelProfile
         from pydantic_ai.providers.anthropic import AnthropicProvider
 
         return AnthropicModel(
             settings.model_name,
             provider=AnthropicProvider(api_key=settings.api_key),
+            profile=AnthropicModelProfile(default_structured_output_mode="native"),
         )
 
     # provider == "openai" — aussi utilisé pour LLMs locaux (Ollama, LM Studio…)
@@ -29,7 +31,9 @@ def build_pydantic_ai_model(settings: LMSettings):
         settings.model_name,
         provider=OpenAIProvider(base_url=settings.base_url, api_key=settings.api_key),
         profile=OpenAIModelProfile(
-            default_structured_output_mode="prompted",
+            default_structured_output_mode="native",
+            supports_json_schema_output=True,
+            supports_json_object_output=False,
             openai_chat_send_back_thinking_parts=False,
         ),
     )

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,25 +96,27 @@ Comme `add-entity`, cette commande ne câble pas FastAPI, FastMCP, LangGraph, un
 
 ---
 
-### `add-planner` — Ajouter un planner applicatif
+### `add-intent-interpreter` — Ajouter un interpréteur d'intention
 
-Crée uniquement le fichier minimal d'un planner dans `src/<package>/application/planners/`.
+Crée uniquement le fichier minimal d'un interpréteur d'intention dans
+`src/<package>/application/intent_interpreters/`.
 
 ```bash
 cd my-recipe-service
-arclith-cli add-planner IngredientIntent
-arclith-cli add-planner command-router
+arclith-cli add-intent-interpreter IngredientIntent
+arclith-cli add-intent-interpreter command-router
 ```
 
 Fichier généré :
 
 ```text
-src/<package>/application/planners/ingredient_intent.py
+src/<package>/application/intent_interpreters/ingredient_intent.py
 ```
 
-Le planner est le composant applicatif qui transforme une demande naturelle en commande ou DTO
-structuré. Il ne remplace pas LangGraph : LangGraph orchestre les nœuds, tandis que le planner porte
-la traduction d'intention. Le fichier généré reste volontairement vide de logique métier.
+L'interpréteur d'intention est le composant applicatif qui transforme une demande naturelle en
+commande ou DTO structuré. Il ne remplace pas LangGraph : LangGraph orchestre les nœuds, tandis que
+l'interpréteur porte la traduction d'intention. Le fichier généré reste volontairement vide de
+logique métier.
 
 ---
 

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -314,7 +314,7 @@ port: {port}
 LLM_CAPABILITY = CapabilitySpec(
     name="llm",
     layer="outbound",
-    description="Configuration LLM pour planners et agents via une factory Arclith.",
+    description="Configuration LLM pour interpréteurs d'intention et agents via une factory Arclith.",
     activation_config_key=None,
     adapters=(
         AdapterSpec(
@@ -401,7 +401,7 @@ OPENAI_API_KEY={api_key}
             name="anthropic",
             capability="llm",
             layer="outbound",
-            description="Modèle Anthropic pour planners et agents.",
+            description="Modèle Anthropic pour interpréteurs d'intention et agents.",
             config_path="config/adapters/outbound/lm.yaml",
             config_template="""\
 provider: anthropic

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -38,9 +38,9 @@ class {class_name}UseCase({class_name}Port):
         raise NotImplementedError("Implement {class_name}UseCase.execute")
 """
 
-_PLANNER_TEMPLATE = """class {class_name}Planner:
-    async def plan(self, prompt: str) -> None:
-        raise NotImplementedError("Implement {class_name}Planner.plan")
+_INTENT_INTERPRETER_TEMPLATE = """class {class_name}Interpreter:
+    async def interpret(self, prompt: str) -> None:
+        raise NotImplementedError("Implement {class_name}Interpreter.interpret")
 """
 
 
@@ -61,17 +61,17 @@ class UseCaseNames:
 
 
 @dataclass(frozen=True)
-class PlannerNames:
+class IntentInterpreterNames:
     pascal: str
     snake: str
 
     @classmethod
-    def from_input(cls, raw: str) -> PlannerNames:
+    def from_input(cls, raw: str) -> IntentInterpreterNames:
         names = EntityNames.from_input(raw)
-        pascal = _strip_pascal_planner_suffix(names.pascal)
-        snake = _strip_snake_planner_suffix(names.snake)
+        pascal = _strip_pascal_intent_interpreter_suffix(names.pascal)
+        snake = _strip_snake_intent_interpreter_suffix(names.snake)
         if not pascal or not snake:
-            console.print(f"[red]✗[/red] Nom de planner invalide : [bold]{raw}[/bold].")
+            console.print(f"[red]✗[/red] Nom d'interpréteur d'intention invalide : [bold]{raw}[/bold].")
             raise typer.Exit(1)
         return cls(pascal=pascal, snake=snake)
 
@@ -130,24 +130,24 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
     return usecase_file
 
 
-def add_planner_cmd(*, project_dir: Path | None = None, planner_name: str) -> Path:
+def add_intent_interpreter_cmd(*, project_dir: Path | None = None, intent_name: str) -> Path:
     project_dir = project_dir or Path.cwd()
-    planner_name = planner_name.strip()
-    _assert_project_root(project_dir, command="add-planner")
-    _assert_valid_name(planner_name, label="planner")
+    intent_name = intent_name.strip()
+    _assert_project_root(project_dir, command="add-intent-interpreter")
+    _assert_valid_name(intent_name, label="interpréteur d'intention")
 
     paths = detect_project_paths(project_dir)
-    names = PlannerNames.from_input(planner_name)
-    planner_file = paths.application_planners / f"{names.snake}.py"
-    _assert_missing(planner_file, project_dir)
+    names = IntentInterpreterNames.from_input(intent_name)
+    intent_file = paths.application_intent_interpreters / f"{names.snake}.py"
+    _assert_missing(intent_file, project_dir)
 
-    _ensure_package_dirs(paths, "application", "planners")
-    planner_file.write_text(_PLANNER_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    _ensure_package_dirs(paths, "application", "intent_interpreters")
+    intent_file.write_text(_INTENT_INTERPRETER_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
     console.print(
-        f"[green]✓[/green] Planner {names.pascal}Planner créé : "
-        f"[bold]{planner_file.relative_to(project_dir)}[/bold]"
+        f"[green]✓[/green] Interpréteur d'intention {names.pascal}Interpreter créé : "
+        f"[bold]{intent_file.relative_to(project_dir)}[/bold]"
     )
-    return planner_file
+    return intent_file
 
 
 def _assert_project_root(project_dir: Path, *, command: str) -> None:
@@ -232,8 +232,8 @@ def _strip_snake_suffix(value: str) -> str:
         value = stripped
 
 
-def _strip_pascal_planner_suffix(value: str) -> str:
-    suffixes = ("Planner",)
+def _strip_pascal_intent_interpreter_suffix(value: str) -> str:
+    suffixes = ("Interpreter",)
     while True:
         stripped = value
         for suffix in suffixes:
@@ -245,8 +245,8 @@ def _strip_pascal_planner_suffix(value: str) -> str:
         value = stripped
 
 
-def _strip_snake_planner_suffix(value: str) -> str:
-    suffixes = ("_planner",)
+def _strip_snake_intent_interpreter_suffix(value: str) -> str:
+    suffixes = ("_interpreter",)
     while True:
         stripped = value
         for suffix in suffixes:

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -85,7 +85,7 @@ def _create_package_layout(package_root: Path) -> None:
         package_root / "domain" / "ports" / "outbound",
         package_root / "application",
         package_root / "application" / "use_cases",
-        package_root / "application" / "planners",
+        package_root / "application" / "intent_interpreters",
         package_root / "adapters",
         package_root / "adapters" / "inbound",
         package_root / "adapters" / "outbound",

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -15,7 +15,7 @@ from rich.tree import Tree
 from . import __version__
 from .add_adapter import add_adapter_cmd
 from .capabilities import CAPABILITY_CATALOG, capability_catalog_as_dict
-from .core_scaffold import add_entity_cmd, add_planner_cmd, add_usecase_cmd
+from .core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .init_project import init_project_cmd
 from .rename import EntityNames, apply_rename
@@ -221,17 +221,17 @@ def add_usecase(
     add_usecase_cmd(usecase_name=usecase or _prompt_usecase())
 
 
-@app.command(name="add-planner")
-def add_planner(
-    planner: Annotated[
+@app.command(name="add-intent-interpreter")
+def add_intent_interpreter(
+    intent: Annotated[
         str | None,
         typer.Argument(
-            help="Nom du planner applicatif. Exemple : IngredientIntent, todo_planner, command-router",
+            help="Nom de l'interpréteur d'intention. Exemple : IngredientIntent, todo-intent, command-router",
         ),
     ] = None,
 ) -> None:
-    """Créer uniquement le fichier minimal d'un planner dans application/planners."""
-    add_planner_cmd(planner_name=planner or _prompt_planner())
+    """Créer uniquement le fichier minimal d'un interpréteur d'intention."""
+    add_intent_interpreter_cmd(intent_name=intent or _prompt_intent_interpreter())
 
 
 @app.command(name="capabilities")
@@ -327,10 +327,10 @@ def _prompt_usecase() -> str:
             return value
 
 
-def _prompt_planner() -> str:
-    console.print("\n[bold]Planner[/bold] [dim](ex : IngredientIntent, todo_planner)[/dim]")
+def _prompt_intent_interpreter() -> str:
+    console.print("\n[bold]Interpréteur d'intention[/bold] [dim](ex : IngredientIntent, todo_intent)[/dim]")
     while True:
-        value = Prompt.ask("  [bold green]Nom du planner[/bold green]").strip()
+        value = Prompt.ask("  [bold green]Nom de l'interpréteur[/bold green]").strip()
         if not value:
             console.print("  [red]Le nom ne peut pas être vide.[/red]")
         elif not _ENTITY_RE.match(value):

--- a/cli/arclith_cli/project_paths.py
+++ b/cli/arclith_cli/project_paths.py
@@ -21,8 +21,8 @@ class ProjectPaths:
         return self.package_root / "domain" / "ports" / "inbound"
 
     @property
-    def application_planners(self) -> Path:
-        return self.package_root / "application" / "planners"
+    def application_intent_interpreters(self) -> Path:
+        return self.package_root / "application" / "intent_interpreters"
 
     @property
     def adapters_outbound(self) -> Path:

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import typer
 
-from arclith_cli.core_scaffold import add_entity_cmd, add_planner_cmd, add_usecase_cmd
+from arclith_cli.core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_usecase_cmd
 from arclith_cli.init_project import init_project_cmd
 
 
@@ -97,19 +97,23 @@ def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> N
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
 
-def test_add_planner_creates_minimal_planner_in_src_package(tmp_path: Path) -> None:
+def test_add_intent_interpreter_creates_minimal_interpreter_in_src_package(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_planner_cmd(project_dir=project_dir, planner_name="IngredientIntent")
+    generated = add_intent_interpreter_cmd(project_dir=project_dir, intent_name="IngredientIntent")
 
-    assert generated == project_dir / "src" / "demo_service" / "application" / "planners" / "ingredient_intent.py"
+    assert generated == (
+        project_dir / "src" / "demo_service" / "application" / "intent_interpreters" / "ingredient_intent.py"
+    )
     assert generated.read_text(encoding="utf-8") == (
-        "class IngredientIntentPlanner:\n"
-        "    async def plan(self, prompt: str) -> None:\n"
-        '        raise NotImplementedError("Implement IngredientIntentPlanner.plan")\n'
+        "class IngredientIntentInterpreter:\n"
+        "    async def interpret(self, prompt: str) -> None:\n"
+        '        raise NotImplementedError("Implement IngredientIntentInterpreter.interpret")\n'
     )
     assert (project_dir / "src" / "demo_service" / "application" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "application" / "planners" / "__init__.py").exists()
+    assert (
+        project_dir / "src" / "demo_service" / "application" / "intent_interpreters" / "__init__.py"
+    ).exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
 
@@ -129,14 +133,17 @@ def test_add_usecase_strips_repeated_usecase_suffix(tmp_path: Path) -> None:
     assert "UseCaseUseCase" not in generated.read_text(encoding="utf-8")
 
 
-def test_add_planner_strips_repeated_planner_suffix(tmp_path: Path) -> None:
+def test_add_intent_interpreter_strips_repeated_interpreter_suffix(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_planner_cmd(project_dir=project_dir, planner_name="ingredient-intent-planner-planner")
+    generated = add_intent_interpreter_cmd(
+        project_dir=project_dir,
+        intent_name="ingredient-intent-interpreter-interpreter",
+    )
 
     assert generated.name == "ingredient_intent.py"
-    assert "class IngredientIntentPlanner:" in generated.read_text(encoding="utf-8")
-    assert "PlannerPlanner" not in generated.read_text(encoding="utf-8")
+    assert "class IngredientIntentInterpreter:" in generated.read_text(encoding="utf-8")
+    assert "InterpreterInterpreter" not in generated.read_text(encoding="utf-8")
 
 
 def test_add_entity_supports_legacy_root_layout(tmp_path: Path) -> None:
@@ -201,8 +208,8 @@ def test_add_usecase_refuses_to_overwrite_existing_inbound_port(tmp_path: Path) 
     assert not (project_dir / "src" / "demo_service" / "application" / "use_cases" / "recipe.py").exists()
 
 
-def test_add_planner_rejects_invalid_name(tmp_path: Path) -> None:
+def test_add_intent_interpreter_rejects_invalid_name(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
     with pytest.raises(typer.Exit):
-        add_planner_cmd(project_dir=project_dir, planner_name="123-planner")
+        add_intent_interpreter_cmd(project_dir=project_dir, intent_name="123-intent")

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -225,7 +225,7 @@ def test_scaffold_and_run(temp_workspace: Path):
     result = subprocess.run(
         [
             "arclith-cli",
-            "add-planner",
+            "add-intent-interpreter",
             "ShoppingIntent",
         ],
         cwd=project_dir,
@@ -233,9 +233,11 @@ def test_scaffold_and_run(temp_workspace: Path):
         text=True,
         timeout=30,
     )
-    assert result.returncode == 0, f"add-planner failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"add-intent-interpreter failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
     assert (
-        project_dir / "src" / "test_plan_service" / "application" / "planners" / "shopping_intent.py"
+        project_dir / "src" / "test_plan_service" / "application" / "intent_interpreters" / "shopping_intent.py"
     ).exists()
 
     printed_names = ", ".join(
@@ -243,7 +245,7 @@ def test_scaffold_and_run(temp_workspace: Path):
             "ShoppingItem.__name__",
             "PlanShoppingListPort.__name__",
             "PlanShoppingListUseCase.__name__",
-            "ShoppingIntentPlanner.__name__",
+            "ShoppingIntentInterpreter.__name__",
         ]
     )
     import_script = "\n".join(
@@ -251,7 +253,7 @@ def test_scaffold_and_run(temp_workspace: Path):
             "from test_plan_service.domain.models.shopping_item import ShoppingItem",
             "from test_plan_service.domain.ports.inbound.plan_shopping_list import PlanShoppingListPort",
             "from test_plan_service.application.use_cases.plan_shopping_list import PlanShoppingListUseCase",
-            "from test_plan_service.application.planners.shopping_intent import ShoppingIntentPlanner",
+            "from test_plan_service.application.intent_interpreters.shopping_intent import ShoppingIntentInterpreter",
             f"print({printed_names})",
         ]
     )
@@ -269,7 +271,7 @@ def test_scaffold_and_run(temp_workspace: Path):
         timeout=30,
     )
     assert result.returncode == 0, f"Core scaffold import failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
-    assert "ShoppingItem PlanShoppingListPort PlanShoppingListUseCase ShoppingIntentPlanner" in result.stdout
+    assert "ShoppingItem PlanShoppingListPort PlanShoppingListUseCase ShoppingIntentInterpreter" in result.stdout
 
     # Step 7 — validate non-interactive adapter generation through the CLI entry point
     result = subprocess.run(

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -13,7 +13,7 @@ La règle d'architecture reste la même du début à la fin:
 ```text
 Demande naturelle
   -> adapter inbound LangGraph
-  -> planner LLM derrière configuration locale
+  -> interpréteur d'intention LLM derrière configuration locale
   -> commande structurée
   -> service/use case métier
   -> repository de l'entité
@@ -126,7 +126,7 @@ langgraph.json
 config/adapters/inbound/langgraph.yaml
 config/adapters/outbound/lm.yaml
 config/adapters/outbound/langsmith.yaml
-src/pantry_agent/application/planners/ingredient_intent.py
+src/pantry_agent/application/intent_interpreters/ingredient_intent.py
 src/pantry_agent/adapters/inbound/langgraph/agent.py
 .env
 ```
@@ -134,7 +134,7 @@ src/pantry_agent/adapters/inbound/langgraph/agent.py
 `langgraph.json` pointe vers `.env`; le serveur LangGraph local charge donc les variables
 `LANGSMITH_TRACING`, `LANGSMITH_PROJECT`, `LANGSMITH_ENDPOINT` et `LANGSMITH_API_KEY`.
 
-## 4. Configurer LM Studio et le planner
+## 4. Configurer LM Studio et l'interpréteur d'intention
 
 Dans LM Studio:
 
@@ -162,13 +162,13 @@ arclith-cli add-adapter \
 Si LM Studio tourne sur la machine hôte et que l'agent tourne en container, remplacer souvent
 `127.0.0.1` par `host.docker.internal`.
 
-Créer le fichier minimal du planner applicatif:
+Créer le fichier minimal de l'interpréteur d'intention applicatif:
 
 ```bash
-arclith-cli add-planner IngredientIntent
+arclith-cli add-intent-interpreter IngredientIntent
 ```
 
-Remplacer `src/pantry_agent/application/planners/ingredient_intent.py` par:
+Remplacer `src/pantry_agent/application/intent_interpreters/ingredient_intent.py` par:
 
 ```python
 from typing import Literal
@@ -187,11 +187,11 @@ class IngredientIntent(BaseModel):
     )
 
 
-class IngredientIntentPlanner:
+class IngredientIntentInterpreter:
     def __init__(self, llm: LLMPort) -> None:
         self._llm = llm
 
-    async def plan(self, prompt: str) -> IngredientIntent:
+    async def interpret(self, prompt: str) -> IngredientIntent:
         return await self._llm.complete_structured(
             prompt,
             output_type=IngredientIntent,
@@ -217,7 +217,7 @@ from arclith import Arclith
 from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
 from langgraph.graph import END, START
 
-from pantry_agent.application.planners.ingredient_intent import IngredientIntentPlanner
+from pantry_agent.application.intent_interpreters.ingredient_intent import IngredientIntentInterpreter
 from pantry_agent.application.services.ingredient_service import IngredientService
 from pantry_agent.domain.models.ingredient import Ingredient
 from pantry_agent.infrastructure.containers.ingredient_container import build_ingredient_service
@@ -238,11 +238,11 @@ def _ingredient_service() -> IngredientService:
 
 
 @lru_cache(maxsize=1)
-def _intent_planner() -> IngredientIntentPlanner:
+def _intent_interpreter() -> IngredientIntentInterpreter:
     lm_settings = arclith.config.adapters.lm
     if lm_settings is None:
-        raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour le planner agent.")
-    return IngredientIntentPlanner(PydanticAILLMAdapter(lm_settings))
+        raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour l'interpréteur d'intention.")
+    return IngredientIntentInterpreter(PydanticAILLMAdapter(lm_settings))
 
 
 def _last_user_message(state: AgentState) -> str:
@@ -261,7 +261,7 @@ async def run_agent(state: AgentState) -> AgentState:
         messages = [*state.get("messages", []), {"role": "assistant", "content": answer}]
         return {**state, "messages": messages, "answer": answer}
 
-    intent = await _intent_planner().plan(prompt)
+    intent = await _intent_interpreter().interpret(prompt)
 
     if intent.action == "create":
         if not intent.name:
@@ -369,7 +369,7 @@ Le quickstart est valide seulement si:
 - l'API crée et relit une ressource `Ingredient`;
 - LangGraph compile et expose le graphe `pantry_agent`;
 - le nœud agent appelle le service applicatif généré;
-- le planner applicatif traduit la demande en `IngredientIntent`;
+- l'interpréteur d'intention applicatif traduit la demande en `IngredientIntent`;
 - LM Studio répond sur `/v1/models`;
 - LangSmith reçoit les traces quand `LANGSMITH_TRACING=true`.
 
@@ -377,6 +377,6 @@ Le quickstart est valide seulement si:
 
 - Garder le domaine et les use cases indépendants de FastAPI, LangGraph, LangSmith et LM Studio.
 - Faire produire au LLM un objet structuré, puis laisser les use cases appliquer le métier.
-- Garder un planner deterministic ou des tests sans LLM pour les gates CI.
+- Garder un interpréteur déterministe ou des tests sans LLM pour les gates CI.
 - Garder `.env` et les credentials hors Git.
 - Utiliser LangGraph Studio et LangSmith pour tester les conversations et inspecter les traces.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -29,7 +29,7 @@ arclith-cli init todo-list-service
 cd todo-list-service
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
-arclith-cli add-planner ShoppingIntent
+arclith-cli add-intent-interpreter ShoppingIntent
 ```
 
 Fichiers générés :
@@ -38,7 +38,7 @@ Fichiers générés :
 src/<package>/domain/models/shopping_item.py
 src/<package>/domain/ports/inbound/plan_shopping_list.py
 src/<package>/application/use_cases/plan_shopping_list.py
-src/<package>/application/planners/shopping_intent.py
+src/<package>/application/intent_interpreters/shopping_intent.py
 ```
 
 Le développeur garde la responsabilité de définir les champs, invariants et orchestration métier.
@@ -110,7 +110,7 @@ Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml
 
 ### `llm`
 
-Capacité outbound pour configurer le modèle utilisé par les planners et agents.
+Capacité outbound pour configurer le modèle utilisé par les interpréteurs d'intention et agents.
 
 Adapters disponibles:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,13 +126,13 @@ Pour ajouter seulement du cœur métier, sans CRUD ni adapter automatique :
 ```bash
 arclith-cli add-entity ShoppingItem
 arclith-cli add-usecase PlanShoppingList
-arclith-cli add-planner ShoppingIntent
+arclith-cli add-intent-interpreter ShoppingIntent
 ```
 
 Ces commandes créent des fichiers minimaux dans `src/<package>/domain/models/` et
 `src/<package>/domain/ports/inbound/`, `src/<package>/application/use_cases/` ou
-`src/<package>/application/planners/`. Les champs, invariants et appels aux adapters restent du code
-métier à écrire dans le projet.
+`src/<package>/application/intent_interpreters/`. Les champs, invariants et appels aux adapters
+restent du code métier à écrire dans le projet.
 
 L'adapter actif est déclaré dans:
 
@@ -249,7 +249,7 @@ Pour un agent, le cœur doit rester testable sans LLM:
 Natural language
   -> adapter inbound API / MCP / bus
   -> use case application
-  -> planner port
+  -> intent interpreter port
   -> command / DTO structure
   -> service métier
 ```
@@ -259,7 +259,7 @@ structurées, mais n'exécute pas directement le métier.
 
 Exemple de ports applicatifs cibles:
 
-- `PlannerPort`: transforme une phrase en commande structurée;
+- `IntentInterpreterPort`: transforme une phrase en commande structurée;
 - `RepositoryPort`: persiste les entités;
 - `TracePort`: envoie les traces LangSmith ou autre;
 - `EventBusPort`: publie des événements si besoin.
@@ -288,8 +288,8 @@ L'adapter `observability/langsmith` demande le projet LangSmith, l'endpoint, l'a
 `observability.enabled`, met à jour `.env`, et ajoute `.env` au `.gitignore` si besoin.
 
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
-`AppConfig.adapters.lm`. Le planner applicatif consomme ensuite un `LLMPort`; LangGraph ne fait
-qu'orchestrer les nœuds et injecter l'adapter outbound.
+`AppConfig.adapters.lm`. L'interpréteur d'intention applicatif consomme ensuite un `LLMPort`;
+LangGraph ne fait qu'orchestrer les nœuds et injecter l'adapter outbound.
 
 Le `langgraph.json` généré pointe vers `.env` pour que le serveur local charge les variables LangSmith.
 Les tests conversationnels et traces agent se font ensuite dans LangSmith Studio.

--- a/docs/tutorials/todo-list/06-agent.md
+++ b/docs/tutorials/todo-list/06-agent.md
@@ -18,22 +18,22 @@ Il ne connaît pas la persistance. Il appelle le use case applicatif.
 uv add "arclith[langgraph]"
 ```
 
-## Créer le planner
+## Créer l'interpréteur d'intention
 
 Depuis la racine du projet:
 
 ```bash
-arclith-cli add-planner
+arclith-cli add-intent-interpreter
 ```
 
 Répondre:
 
 ```text
-Planner (ex : IngredientIntent, todo_planner)
-  Nom du planner: TodoConversation
+Interpréteur d'intention (ex : IngredientIntent, todo_intent)
+  Nom de l'interpréteur: TodoConversation
 ```
 
-Remplacer `src/todo_list_service/application/planners/todo_conversation.py` par:
+Remplacer `src/todo_list_service/application/intent_interpreters/todo_conversation.py` par:
 
 ```python
 from __future__ import annotations
@@ -54,7 +54,7 @@ class TodoDraft(BaseModel):
     completed_at: datetime | None = Field(default=None)
 
 
-class TodoConversationPlanner:
+class TodoConversationInterpreter:
     def __init__(self, llm: LLMPort) -> None:
         self._llm = llm
 
@@ -175,7 +175,7 @@ from arclith import Arclith
 from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
 from langgraph.graph import END, START
 
-from todo_list_service.application.planners.todo_conversation import TodoConversationPlanner, TodoDraft
+from todo_list_service.application.intent_interpreters.todo_conversation import TodoConversationInterpreter, TodoDraft
 from todo_list_service.domain.models.todo import TodoStatus
 from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
 from todo_list_service.infrastructure.containers.todo_container import build_create_todo_use_case
@@ -196,11 +196,11 @@ def _create_todo_use_case() -> CreateTodoPort:
 
 
 @lru_cache(maxsize=1)
-def _planner() -> TodoConversationPlanner:
+def _intent_interpreter() -> TodoConversationInterpreter:
     lm_settings = arclith.config.adapters.lm
     if lm_settings is None:
         raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour l'agent.")
-    return TodoConversationPlanner(PydanticAILLMAdapter(lm_settings))
+    return TodoConversationInterpreter(PydanticAILLMAdapter(lm_settings))
 
 
 def _last_user_message(state: AgentState) -> str:
@@ -245,7 +245,7 @@ async def run_agent(state: AgentState) -> AgentState:
     current = _draft_from_state(state)
 
     if prompt:
-        extracted = await _planner().extract(prompt, current)
+        extracted = await _intent_interpreter().extract(prompt, current)
         current = current.model_copy(update=extracted.model_dump(exclude_none=True))
 
     missing = _missing_fields(current)
@@ -366,7 +366,7 @@ Configurer l'URI MongoDB via le resolver de secrets local, puis relancer API, MC
 
 ```bash
 uv add "arclith[langgraph]"
-arclith-cli add-planner TodoConversation
+arclith-cli add-intent-interpreter TodoConversation
 arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name="<model-id-lm-studio>" --yes
 arclith-cli add-adapter --capability observability --adapter langsmith
 arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=todo_agent --yes

--- a/tests/units/adapters/outbound/test_secret_adapters.py
+++ b/tests/units/adapters/outbound/test_secret_adapters.py
@@ -67,8 +67,8 @@ def test_env_missing_var_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_env_key_derivation(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LM_PLANNER_API_KEY", "sk-test")
-    assert EnvSecretAdapter().get("lm.planner.api_key", "ignored") == "sk-test"
+    monkeypatch.setenv("LM_INTENT_INTERPRETER_API_KEY", "sk-test")
+    assert EnvSecretAdapter().get("lm.intent_interpreter.api_key", "ignored") == "sk-test"
 
 
 def test_env_uses_explicit_secret_key_before_derived_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/units/infrastructure/test_lm.py
+++ b/tests/units/infrastructure/test_lm.py
@@ -32,6 +32,7 @@ def test_build_anthropic_model():
     model = build_pydantic_ai_model(settings)
     from pydantic_ai.models.anthropic import AnthropicModel
     assert isinstance(model, AnthropicModel)
+    assert model.profile["default_structured_output_mode"] == "native"
 
 
 def test_build_openai_model():
@@ -44,10 +45,12 @@ def test_build_openai_model():
     model = build_pydantic_ai_model(settings)
     from pydantic_ai.models.openai import OpenAIChatModel
     assert isinstance(model, OpenAIChatModel)
+    assert model.profile["default_structured_output_mode"] == "native"
+    assert model.profile["supports_json_schema_output"] is True
+    assert model.profile["supports_json_object_output"] is False
 
 
 def test_build_openai_model_requires_base_url():
     settings = LMSettings(provider="openai", model_name="gpt-4o", api_key="sk-x")
     with pytest.raises(ValueError, match="base_url is required"):
         build_pydantic_ai_model(settings)
-


### PR DESCRIPTION
## What changed

- Switch Pydantic AI structured output for OpenAI-compatible models to native `json_schema` mode and disable the `json_object` profile flag that LM Studio rejects.
- Keep Anthropic structured extraction on Pydantic AI native structured output for supported Claude models.
- Rename the generated application component from `planner` to `intent_interpreter`:
  - CLI command becomes `add-intent-interpreter`.
  - Generated package path becomes `application/intent_interpreters/`.
  - Generated class method becomes `interpret(...)`.
- Update CLI docs, quickstarts, Todo tutorial, and tests to use the new vocabulary.

## Why

LM Studio receives the request but rejects `response_format.type=json_object` on the OpenAI-compatible chat completions endpoint used by Arclith. Pydantic AI native structured output sends `response_format.type=json_schema`, which works with the current LM Studio server and remains the right structured-output path for OpenAI-compatible models.

The old `planner` naming was misleading: this component does not plan a multi-step graph. It interprets natural-language intent into a structured command or DTO, while LangGraph owns graph orchestration.

## Validation

- `PYTHONPATH=/Users/killian/Perso/projets/Arclith/arclith uv run python ...` against `/Users/killian/Perso/projets/demo-arclith/todo-list-service` and the running LM Studio server.
- LM Studio log confirmed `response_format.type=json_schema`.
- `make precommit`
- `uv run pytest -q`
- `uv run --directory cli pytest tests/ -q`
- `uv run --group docs mkdocs build --strict`
- `git diff --check`

Note: `uv run ruff check .` still reports pre-existing unused imports in tests outside this PR scope; the repository Makefile lint target checks `arclith/` and passes.