### PR TITLE
fix: serialize date fields in MongoDB adapter

### DIFF
--- a/arclith/adapters/outbound/mongodb/repository.py
+++ b/arclith/adapters/outbound/mongodb/repository.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from typing import Any, Generic, Optional, TypeVar
 from uuid6 import UUID, uuid7
@@ -65,13 +65,21 @@ class MongoDBRepository(Repository[T], Generic[T]):
     def _collection(self) -> _MongoCollection:
         return _MongoCollection(self._config, self._logger)
 
+    def _to_mongo_value(self, value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {key: self._to_mongo_value(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._to_mongo_value(item) for item in value]
+        return value
+
     def _to_doc(self, entity: T) -> dict[str, Any]:
         doc = entity.model_dump()
         doc["_id"] = str(doc.pop("uuid"))
-        for key, value in doc.items():
-            if isinstance(value, datetime):
-                doc[key] = value.isoformat()
-        return doc
+        return {key: self._to_mongo_value(value) for key, value in doc.items()}
 
     def _from_doc(self, doc: dict[str, Any]) -> T:
         doc = dict(doc)

--- a/tests/units/adapters/outbound/test_mongodb_repository.py
+++ b/tests/units/adapters/outbound/test_mongodb_repository.py
@@ -1,0 +1,27 @@
+from datetime import date, datetime, timezone
+from typing import Any
+
+from arclith.adapters.outbound.mongodb.config import MongoDBConfig
+from arclith.adapters.outbound.mongodb.repository import MongoDBRepository
+from arclith.domain.models.entity import Entity
+from pydantic import Field
+
+
+class Item(Entity):
+    due_on: date
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def test_to_doc_serializes_date_and_datetime(logger) -> None:
+    repository = MongoDBRepository(MongoDBConfig(db_name="demo"), Item, logger)
+    completed_at = datetime(2026, 8, 8, 10, 0, tzinfo=timezone.utc)
+    item = Item(
+        due_on=date(2026, 9, 1),
+        metadata={"completed_at": completed_at, "milestones": [date(2026, 9, 2)]},
+    )
+
+    doc = repository._to_doc(item)
+
+    assert doc["due_on"] == "2026-09-01"
+    assert doc["metadata"]["completed_at"] == completed_at.isoformat()
+    assert doc["metadata"]["milestones"] == ["2026-09-02"]


### PR DESCRIPTION
## Why
MongoDB rejects native Python date objects in documents. This caused runtime failures when generic repositories persisted entities containing date fields.

## What changes
- serialize date and datetime values to ISO strings
- apply serialization recursively for nested dict/list payloads
- add unit coverage for top-level and nested values

## Impact
This makes Arclith's MongoDB repository safe for generic use with entities containing date fields, reducing per-project workarounds.