### PR TITLE
Update todo POC tutorial

### DIFF
--- a/docs/tutorials/todo-list/04-api.md
+++ b/docs/tutorials/todo-list/04-api.md
@@ -49,6 +49,19 @@ L'objectif est de montrer le standard Arclith attendu:
 
 ## Schémas HTTP
 
+Les fichiers de l'adapter API ont chacun une responsabilité précise:
+
+| Fichier | Rôle |
+| --- | --- |
+| `adapters/inbound/schemas/todo_schema.py` | Définit les payloads et réponses HTTP. C'est le contrat exposé dans Swagger, pas le modèle métier. |
+| `adapters/inbound/fastapi/handlers/todo_handlers.py` | Traduit HTTP vers `CreateTodoCommand` et `ListTodosQuery`, puis traduit les résultats en réponses Arclith. |
+| `adapters/inbound/fastapi/routers/todo_router.py` | Déclare les routes, métadonnées OpenAPI, exemples, headers et statuts HTTP. |
+| `adapters/inbound/fastapi/register.py` | Récupère les use cases via le container et branche le router dans l'application FastAPI. |
+| `main.py` | Crée l'instance `Arclith`, l'application FastAPI et lance le transport choisi. |
+
+Le découpage évite de mélanger contrat HTTP, orchestration applicative et wiring. Le handler voit
+les ports inbound; le router voit FastAPI; aucun des deux ne manipule directement `Repository[Todo]`.
+
 Créer `src/todo_list_service/adapters/inbound/schemas/todo_schema.py`:
 
 ```python

--- a/docs/tutorials/todo-list/05-mcp.md
+++ b/docs/tutorials/todo-list/05-mcp.md
@@ -34,6 +34,18 @@ config/adapters/inbound/fastmcp.yaml
 
 ## Tools MCP
 
+Le MCP expose le même coeur métier sous forme de tools appelables par un modèle ou un client MCP:
+
+| Fichier | Rôle |
+| --- | --- |
+| `adapters/inbound/fastmcp/tools/todo_tools.py` | Déclare les tools `create_todo_item` et `list_todo_items`, leurs paramètres typés et leur payload de retour. |
+| `adapters/inbound/fastmcp/tools/__init__.py` | Exporte `TodoMCP` pour garder un import stable côté registration. |
+| `adapters/inbound/fastmcp/register.py` | Construit les use cases via le container et installe les tools sur l'instance FastMCP. |
+| `main.py` | Conserve un seul point d'entrée pour API, MCP HTTP ou les deux transports. |
+
+Un tool MCP n'est pas un raccourci vers la base. Il adapte un appel tool vers un port inbound, comme
+l'API adapte une requête HTTP vers le même port.
+
 Créer `src/todo_list_service/adapters/inbound/fastmcp/tools/todo_tools.py`:
 
 ```python
@@ -140,7 +152,8 @@ from arclith import Arclith
 from todo_list_service.adapters.inbound.fastapi.register import register_routers
 from todo_list_service.adapters.inbound.fastmcp.register import register_tools
 
-_CONFIG = Path(__file__).parent / "config"
+_DEFAULT_CONFIG = Path(__file__).parent / "config"
+_CONFIG = Path(os.getenv("TODO_LIST_CONFIG_DIR", str(_DEFAULT_CONFIG)))
 _VALID_MODES = {"api", "mcp_http", "all"}
 
 MODE = os.getenv("MODE", "api")
@@ -154,10 +167,11 @@ app = arclith.fastapi()
 register_routers(app, arclith)
 
 
-def build_mcp() -> fastmcp.FastMCP:
-    mcp = arclith.fastmcp("Todo MCP")
-    register_tools(mcp, arclith)
-    arclith.instrument_mcp(mcp)
+def build_mcp(config_dir: Path | str | None = None) -> fastmcp.FastMCP:
+    current_arclith = arclith if config_dir is None else Arclith(Path(config_dir))
+    mcp = current_arclith.fastmcp("Todo MCP")
+    register_tools(mcp, current_arclith)
+    current_arclith.instrument_mcp(mcp)
     return mcp
 
 
@@ -211,6 +225,12 @@ async def test_mcp_create_and_list_todos() -> None:
         listed = await client.call_tool("list_todo_items", {})
         assert not listed.is_error
 ```
+
+Quand le runtime final passera à MongoDB, gardez les tests rapides en mémoire avec une fixture qui
+copie `config/` dans un dossier temporaire, remplace seulement `repository: mongodb` par
+`repository: memory`, puis appelle `build_mcp(memory_config)`. Le POC publié contient cette variante
+pour prouver que `create_todo_item` et `list_todo_items` partagent bien le même repository mémoire
+dans le même processus de test.
 
 Lancer:
 

--- a/docs/tutorials/todo-list/06-agent.md
+++ b/docs/tutorials/todo-list/06-agent.md
@@ -1,16 +1,30 @@
 # 6. Ajouter un agent
 
-Objectif: créer un agent LangGraph qui pose les questions manquantes, puis appelle `CreateTodoPort`
-avec les mêmes données que l'API et le MCP.
+Objectif: créer un agent LangGraph qui comprend une demande en langage naturel, choisit l'action
+todo à exécuter, collecte seulement les champs vraiment manquants, puis appelle les mêmes ports
+inbound que l'API et le MCP.
 
 ![Capture interactive agent](assets/06-agent.svg)
 
-L'agent a deux responsabilités:
+L'agent a quatre responsabilités:
 
-- transformer la conversation en `TodoDraft`;
-- demander les champs manquants avant d'enregistrer.
+- classifier l'intention: créer une todo, lister les todos, annuler une création en cours ou répondre
+  que la demande n'est pas prise en charge;
+- transformer une conversation en `TodoDraft`;
+- conserver `draft` et `pending_field` dans l'état LangGraph pendant la phase de questionnement;
+- appeler `CreateTodoPort` ou `ListTodosPort`.
 
-Il ne connaît pas la persistance. Il appelle le use case applicatif.
+Il ne connaît pas la persistance. Il ne parle ni à MongoDB ni au repository directement. Le chemin
+reste:
+
+```text
+message utilisateur
+  -> adapter LangGraph
+  -> intent-interpreter / parsing local
+  -> CreateTodoPort ou ListTodosPort
+  -> use case applicatif
+  -> Repository[Todo]
+```
 
 ## Installer les dépendances agent
 
@@ -18,11 +32,12 @@ Il ne connaît pas la persistance. Il appelle le use case applicatif.
 uv add "arclith[langgraph]"
 ```
 
-## Créer l'interpréteur d'intention
+## Créer les intent-interpreters
 
-Depuis la racine du projet:
+Depuis la racine du projet, créer deux interpréteurs:
 
 ```bash
+arclith-cli add-intent-interpreter
 arclith-cli add-intent-interpreter
 ```
 
@@ -30,10 +45,62 @@ Répondre:
 
 ```text
 Interpréteur d'intention (ex : IngredientIntent, todo_intent)
+  Nom de l'interpréteur: TodoAction
+
+Interpréteur d'intention (ex : IngredientIntent, todo_intent)
   Nom de l'interpréteur: TodoConversation
 ```
 
-Remplacer `src/todo_list_service/application/intent_interpreters/todo_conversation.py` par:
+Les deux fichiers ne font pas le même travail:
+
+| Fichier | Rôle |
+| --- | --- |
+| `application/intent_interpreters/todo_action.py` | Classe l'action globale: créer, lister, annuler ou inconnu. C'est le fallback LLM quand le fast path local n'est pas assez sûr. |
+| `application/intent_interpreters/todo_conversation.py` | Extrait les champs d'une todo dans un `TodoDraft`: titre, échéance, description, statut, date de réalisation. |
+
+Ce découpage évite de demander au même prompt LLM de décider à la fois "quoi faire" et "quels champs
+extraire". Le graphe peut router vite les cas évidents, puis appeler l'extraction uniquement quand
+l'action est bien une création de todo.
+
+Créer `src/todo_list_service/application/intent_interpreters/todo_action.py`:
+
+```python
+from enum import StrEnum
+
+from arclith.domain.ports.outbound.llm import LLMPort
+from pydantic import BaseModel, Field
+
+
+class TodoAction(StrEnum):
+    CREATE_TODO = "create_todo"
+    LIST_TODOS = "list_todos"
+    CANCEL_TODO_CREATION = "cancel_todo_creation"
+    UNKNOWN = "unknown"
+
+
+class TodoActionDecision(BaseModel):
+    action: TodoAction = Field(default=TodoAction.UNKNOWN)
+
+
+class TodoActionInterpreter:
+    def __init__(self, llm: LLMPort) -> None:
+        self._llm = llm
+
+    async def classify(self, prompt: str) -> TodoActionDecision:
+        return await self._llm.complete_structured(
+            prompt,
+            output_type=TodoActionDecision,
+            instructions=(
+                "Tu classes l'intention d'un utilisateur qui parle a un agent de gestion de todos. "
+                "Retourne create_todo quand il veut creer, ajouter ou enregistrer une tache. "
+                "Retourne list_todos quand il veut afficher, lister ou consulter les taches existantes. "
+                "Retourne cancel_todo_creation quand il annule une creation de todo en cours. "
+                "Retourne unknown quand l'intention n'est pas une action todo prise en charge."
+            ),
+        )
+```
+
+Créer `src/todo_list_service/application/intent_interpreters/todo_conversation.py`:
 
 ```python
 from __future__ import annotations
@@ -59,15 +126,20 @@ class TodoConversationInterpreter:
         self._llm = llm
 
     async def extract(self, prompt: str, current: TodoDraft) -> TodoDraft:
+        today = date.today()
         return await self._llm.complete_structured(
             prompt,
             output_type=TodoDraft,
             instructions=(
-                "Tu extrais les champs d'une todo à partir d'une conversation en français. "
-                "Quand la demande est de type 'ajoute une todo pour X' ou 'crée une todo pour X', "
+                "Tu extrais les champs d'une todo a partir d'une conversation en francais. "
+                "Quand la demande est de type 'ajoute une todo pour X' ou 'cree une todo pour X', "
                 "X est le titre de la todo, sauf si l'utilisateur dit explicitement que c'est une description. "
-                "Retourne uniquement les champs explicitement présents ou clairement déduits. "
-                "Ne fabrique pas de titre, de description ou de date. "
+                "Quand l'utilisateur dit 'je dois X', X est le titre de la todo. "
+                f"Date courante: {today.isoformat()}. Interprete les dates relatives comme 'demain'. "
+                "Si aucune description n'est explicite, laisse la description vide. "
+                "Si aucun statut n'est explicite, utilise todo. "
+                "Retourne uniquement les champs explicitement presents ou clairement deduits. "
+                "Ne fabrique pas de titre ou de date. "
                 f"Draft actuel: {current.model_dump_json(exclude_none=True)}"
             ),
         )
@@ -184,188 +256,223 @@ config/adapters/inbound/langgraph.yaml
 src/todo_list_service/adapters/inbound/langgraph/agent.py
 ```
 
-## Code agent
+## Découper l'agent
 
-Remplacer `src/todo_list_service/adapters/inbound/langgraph/agent.py` par:
+Remplacer l'agent monolithique généré par un package LangGraph découpé par responsabilités:
+
+```text
+src/todo_list_service/adapters/inbound/langgraph/
+  agent.py
+  collection.py
+  dependencies.py
+  formatters.py
+  intent.py
+  nodes.py
+  parsing.py
+  routing.py
+  state.py
+```
+
+| Fichier | Rôle |
+| --- | --- |
+| `agent.py` | Assemble le graphe LangGraph, déclare les noeuds et expose l'objet `agent` utilisé par `langgraph.json`. |
+| `state.py` | Définit `AgentState`, lit le dernier message utilisateur, reconstruit un `TodoDraft` depuis l'état, fabrique les messages assistant. |
+| `dependencies.py` | Centralise l'instance `Arclith`, l'adapter LLM et les ports applicatifs, avec cache local par process. |
+| `nodes.py` | Contient les fonctions de noeuds: router l'intention, collecter les champs, créer, lister, annuler, répondre inconnu. |
+| `routing.py` | Contient uniquement les fonctions de conditional edges LangGraph. |
+| `intent.py` | Fait la détection locale haute confiance avant fallback LLM. C'est ce qui évite de créer une tâche pour "Qu'est-ce que je dois faire aujourd'hui ?". |
+| `collection.py` | Met à jour le draft, applique les défauts, détecte les champs manquants et génère la prochaine question. |
+| `parsing.py` | Normalise le français, détecte les dates relatives, les statuts, l'annulation et les titres simples. |
+| `formatters.py` | Transforme le résultat de `ListTodosUseCase` en réponse lisible pour l'utilisateur et en payload JSON. |
+
+Ce découpage rend l'agent testable par morceaux. La logique de parsing local peut être testée sans
+LangGraph, les noeuds peuvent être testés avec de faux use cases, et `agent.py` reste un fichier de
+wiring.
+
+## Fast path local et fallback LLM
+
+Le noeud `route_intent` suit cette règle:
+
+1. essayer `detect_high_confidence_action(prompt, state)`;
+2. si le résultat est sûr, router sans appeler le LLM;
+3. sinon appeler `TodoActionInterpreter.classify()`.
+
+Exemples de fast path:
+
+| Message | Action |
+| --- | --- |
+| `Liste mes todos` | `LIST_TODOS` |
+| `Qu'est ce que je dois faire aujourd'hui ?` | `LIST_TODOS` |
+| `Je dois acheter des bananes demain` | `CREATE_TODO` |
+| `Annule` pendant une création | `CANCEL_TODO_CREATION` |
+
+Le fallback LLM reste nécessaire pour les formulations ambiguës. Il ne persiste rien: il retourne
+seulement une décision structurée.
+
+## Collecte intelligente
+
+La création utilise deux couches:
+
+- `parsing.py` extrait localement les cas fréquents: `je dois X`, `demain`, `aujourd'hui`, `après-demain`;
+- `TodoConversationInterpreter` complète via LLM quand le local ne suffit pas.
+
+Les défauts sont appliqués côté `collection.py`:
+
+- si aucune description n'est explicite, `description=""`;
+- si aucun statut n'est explicite, `status=todo`;
+- `completed_at` n'est demandé que si `status=done`;
+- `due_date` reste obligatoire.
+
+Ainsi, `Je dois acheter des bananes demain` crée directement une todo:
+
+```text
+title: acheter des bananes
+due_date: demain
+description: ""
+status: todo
+```
+
+L'utilisateur peut aussi se raviser. Si `draft` ou `pending_field` existe et que le message ressemble
+à une annulation, le graphe route vers `cancel_todo_creation` et vide le brouillon.
+
+## Assembler le graphe
+
+`agent.py` ne porte plus la logique métier. Il importe les noeuds, branche les routes conditionnelles
+et expose `agent`:
 
 ```python
-from __future__ import annotations
-
-from datetime import date, datetime
-from functools import lru_cache
-from typing import Any, TypedDict
+from typing import Any
 
 from arclith import Arclith
-from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
 from langgraph.graph import END, START
 
-from todo_list_service.application.intent_interpreters.todo_conversation import TodoConversationInterpreter, TodoDraft
-from todo_list_service.domain.models.todo import TodoStatus
-from todo_list_service.domain.ports.inbound.create_todo import CreateTodoCommand, CreateTodoPort
-from todo_list_service.infrastructure.containers.todo_container import build_create_todo_use_case
+from todo_list_service.adapters.inbound.langgraph.dependencies import (
+    action_interpreter,
+    arclith,
+    create_todo_use_case,
+    intent_interpreter,
+    list_todos_use_case,
+)
+from todo_list_service.adapters.inbound.langgraph.nodes import (
+    answer_unknown as answer_unknown_node,
+    cancel_todo_creation as cancel_todo_creation_node,
+    collect_todo_details as collect_todo_details_node,
+    create_todo as create_todo_node,
+    list_todos as list_todos_node,
+    route_intent as route_intent_node,
+)
+from todo_list_service.adapters.inbound.langgraph.routing import (
+    route_after_collection,
+    route_after_intent,
+)
+from todo_list_service.adapters.inbound.langgraph.state import AgentState
+from todo_list_service.application.intent_interpreters.todo_action import TodoActionInterpreter
+from todo_list_service.application.intent_interpreters.todo_conversation import TodoConversationInterpreter
+from todo_list_service.domain.ports.inbound.create_todo import CreateTodoPort
+from todo_list_service.domain.ports.inbound.list_todos import ListTodosPort
 
 
-class AgentState(TypedDict, total=False):
-    messages: list[dict[str, Any]]
-    draft: dict[str, Any]
-    pending_field: str | None
-    answer: str
-
-
-arclith = Arclith("config")
-
-
-@lru_cache(maxsize=1)
 def _create_todo_use_case() -> CreateTodoPort:
-    return build_create_todo_use_case(arclith)
+    return create_todo_use_case()
 
 
-@lru_cache(maxsize=1)
+def _list_todos_use_case() -> ListTodosPort:
+    return list_todos_use_case()
+
+
+def _action_interpreter() -> TodoActionInterpreter:
+    return action_interpreter()
+
+
 def _intent_interpreter() -> TodoConversationInterpreter:
-    lm_settings = arclith.config.adapters.lm
-    if lm_settings is None:
-        raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour l'agent.")
-    return TodoConversationInterpreter(PydanticAILLMAdapter(lm_settings))
+    return intent_interpreter()
 
 
-def _last_user_message(state: AgentState) -> str:
-    for message in reversed(state.get("messages", [])):
-        if message.get("role") in {"user", "human"}:
-            return str(message.get("content", ""))
-    return ""
+def _route_after_intent(state: AgentState) -> str:
+    return route_after_intent(state)
 
 
-def _draft_from_state(state: AgentState) -> TodoDraft:
-    return TodoDraft.model_validate(state.get("draft", {}))
+def _route_after_collection(state: AgentState) -> str:
+    return route_after_collection(state)
 
 
-def _parse_status(raw: str) -> TodoStatus | None:
-    normalized = raw.strip().lower()
-    aliases = {
-        "à faire": TodoStatus.TODO,
-        "a faire": TodoStatus.TODO,
-        "todo": TodoStatus.TODO,
-        "en cours": TodoStatus.WIP,
-        "wip": TodoStatus.WIP,
-        "terminé": TodoStatus.DONE,
-        "termine": TodoStatus.DONE,
-        "done": TodoStatus.DONE,
-    }
-    if normalized in aliases:
-        return aliases[normalized]
-    try:
-        return TodoStatus(normalized)
-    except ValueError:
-        return None
+async def route_intent(state: AgentState) -> AgentState:
+    return await route_intent_node(state, _action_interpreter)
 
 
-def _apply_pending_answer(prompt: str, current: TodoDraft, pending_field: str | None) -> tuple[TodoDraft, bool]:
-    answer = prompt.strip()
-    if not answer or pending_field is None:
-        return current, False
-
-    match pending_field:
-        case "title":
-            return current.model_copy(update={"title": answer}), True
-        case "description":
-            return current.model_copy(update={"description": answer}), True
-        case "status":
-            status = _parse_status(answer)
-            if status is None:
-                return current, False
-            return current.model_copy(update={"status": status}), True
-        case "due_date":
-            try:
-                return current.model_copy(update={"due_date": date.fromisoformat(answer)}), True
-            except ValueError:
-                return current, False
-        case "completed_at":
-            try:
-                return current.model_copy(update={"completed_at": datetime.fromisoformat(answer)}), True
-            except ValueError:
-                return current, False
-        case _:
-            return current, False
+async def collect_todo_details(state: AgentState) -> AgentState:
+    return await collect_todo_details_node(state, _intent_interpreter)
 
 
-def _missing_fields(draft: TodoDraft) -> list[str]:
-    missing: list[str] = []
-    if not draft.title:
-        missing.append("title")
-    if not draft.description:
-        missing.append("description")
-    if draft.due_date is None:
-        missing.append("due_date")
-    if draft.status is None:
-        missing.append("status")
-    if draft.status == TodoStatus.DONE and draft.completed_at is None:
-        missing.append("completed_at")
-    return missing
+async def create_todo(state: AgentState) -> AgentState:
+    return await create_todo_node(state, _create_todo_use_case)
 
 
-def _question_for(field: str) -> str:
-    questions = {
-        "title": "Quel est le titre de la todo ?",
-        "description": "Quelle description veux-tu enregistrer ?",
-        "due_date": "Quelle est la date d'échéance ?",
-        "status": "Quel est le statut : todo, wip ou done ?",
-        "completed_at": "Quelle est la date de réalisation ?",
-    }
-    return questions[field]
+async def list_todos(state: AgentState) -> AgentState:
+    return await list_todos_node(state, _list_todos_use_case)
+
+
+async def answer_unknown(state: AgentState) -> AgentState:
+    return await answer_unknown_node(state)
+
+
+async def cancel_todo_creation(state: AgentState) -> AgentState:
+    return await cancel_todo_creation_node(state)
 
 
 async def run_agent(state: AgentState) -> AgentState:
-    prompt = _last_user_message(state)
-    current = _draft_from_state(state)
-    pending_field = state.get("pending_field")
-
-    if prompt:
-        current, handled_pending = _apply_pending_answer(prompt, current, pending_field)
-        if not handled_pending:
-            if pending_field:
-                prompt = f"Le message utilisateur répond au champ {pending_field!r}: {prompt}"
-            extracted = await _intent_interpreter().extract(prompt, current)
-            current = current.model_copy(update=extracted.model_dump(exclude_none=True))
-
-    missing = _missing_fields(current)
-    if missing:
-        pending_field = missing[0]
-        answer = _question_for(pending_field)
-        messages = [*state.get("messages", []), {"role": "assistant", "content": answer}]
-        return {
-            **state,
-            "draft": current.model_dump(mode="json", exclude_none=True),
-            "pending_field": pending_field,
-            "answer": answer,
-            "messages": messages,
-        }
-
-    todo = await _create_todo_use_case().execute(
-        CreateTodoCommand(
-            title=current.title or "",
-            description=current.description or "",
-            due_date=current.due_date,
-            status=current.status or TodoStatus.TODO,
-            completed_at=current.completed_at,
-        )
-    )
-    answer = f"Todo créée: {todo.title} ({todo.uuid})."
-    messages = [*state.get("messages", []), {"role": "assistant", "content": answer}]
-    return {**state, "draft": {}, "pending_field": None, "answer": answer, "messages": messages}
+    return await agent.ainvoke(state)
 
 
 def register_agent(builder: Any, app: Arclith) -> None:
-    builder.add_node("agent", run_agent)
-    builder.add_edge(START, "agent")
-    builder.add_edge("agent", END)
+    builder.add_node("route_intent", route_intent)
+    builder.add_node("collect_todo_details", collect_todo_details)
+    builder.add_node("create_todo", create_todo)
+    builder.add_node("list_todos", list_todos)
+    builder.add_node("answer_unknown", answer_unknown)
+    builder.add_node("cancel_todo_creation", cancel_todo_creation)
+
+    builder.add_edge(START, "route_intent")
+    builder.add_conditional_edges(
+        "route_intent",
+        _route_after_intent,
+        ["collect_todo_details", "list_todos", "cancel_todo_creation", "answer_unknown"],
+    )
+    builder.add_conditional_edges(
+        "collect_todo_details",
+        _route_after_collection,
+        ["create_todo", END],
+    )
+    builder.add_edge("create_todo", END)
+    builder.add_edge("list_todos", END)
+    builder.add_edge("answer_unknown", END)
+    builder.add_edge("cancel_todo_creation", END)
 
 
 agent = arclith.langgraph(AgentState, register_agent, name="todo_agent")
 ```
 
+Le code complet des autres fichiers est dans le POC téléchargeable:
+<https://github.com/karned-rekipe/arclith-POC-todo>.
+
 ## Tester l'agent
 
-Lancer LangGraph Studio:
+Lancer les tests unitaires agent:
+
+```bash
+uv run python -m pytest tests/test_todo_agent.py
+```
+
+Ces tests doivent couvrir les comportements importants:
+
+- une réponse à `pending_field` met à jour le bon champ au lieu de relancer la même question;
+- `Je dois acheter des bananes demain` extrait le titre et la date sans LLM;
+- une annulation vide le brouillon et n'appelle pas `CreateTodoPort`;
+- `Liste mes todos` appelle `ListTodosPort`;
+- `Qu'est ce que je dois faire aujourd'hui ?` liste les todos au lieu de créer une tâche;
+- les prompts ambigus passent par `TodoActionInterpreter`.
+
+Lancer ensuite LangGraph Studio:
 
 ```bash
 uv run langgraph dev --no-browser --allow-blocking --port 2024
@@ -397,7 +504,41 @@ Dans Studio:
 4. répondre aux questions dans le même thread pour conserver `draft` et `pending_field`;
 5. revenir dans le projet LangSmith pour lire la trace du run.
 
-Envoyer un état incomplet:
+Créer une todo simple:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Je dois acheter des bananes demain"
+    }
+  ]
+}
+```
+
+Résultat attendu:
+
+```text
+Todo creee: acheter des bananes (<uuid>).
+```
+
+Lister les todos:
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Qu'est ce que je dois faire aujourd'hui ?"
+    }
+  ]
+}
+```
+
+Résultat attendu: une réponse de listing, pas une question de création.
+
+Tester une création incomplète:
 
 ```json
 {
@@ -410,27 +551,30 @@ Envoyer un état incomplet:
 }
 ```
 
-L'agent doit demander le premier champ manquant, par exemple la description ou la date d'échéance.
-Répondre ensuite dans le même thread LangGraph: l'état conserve `draft` et `pending_field`, ce qui
-permet d'affecter une réponse courte comme `Écrire la doc` au champ qui vient d'être demandé.
+L'agent doit demander la date d'échéance, car `description` et `status` ont des défauts. Répondre
+ensuite dans le même thread LangGraph pour conserver `draft` et `pending_field`.
 
-Envoyer ensuite un état complet:
+Tester une annulation dans un état de création:
 
 ```json
 {
   "messages": [
     {
       "role": "user",
-      "content": "Crée une todo titre Écrire la doc, description couvrir API MCP agent, échéance 2026-09-01, statut todo"
+      "content": "Annule"
     }
-  ]
+  ],
+  "draft": {
+    "title": "acheter des bananes"
+  },
+  "pending_field": "due_date"
 }
 ```
 
 Résultat attendu:
 
 ```text
-Todo créée: Écrire la doc (<uuid>).
+Creation de todo annulee.
 ```
 
 ## Passer à MongoDB ensuite
@@ -477,10 +621,16 @@ repository: mongodb
 Il reste ensuite à démarrer MongoDB, déclarer l'URI dans un resolver de secrets local, puis relancer
 API, MCP et LangGraph. Le pas-à-pas complet est dans [les annexes locales](07-local-services.md).
 
+Les tests peuvent rester en `memory`: créez une fixture qui copie `config/` dans `tmp_path`, remplace
+`repository: mongodb` par `repository: memory`, puis nettoie le cache du container entre deux tests.
+C'est le bon compromis: le runtime prouve le partage inter-processus via MongoDB, et les tests restent
+rapides, déterministes et sans dépendance à Docker.
+
 ## Voie rapide
 
 ```bash
 uv add "arclith[langgraph]"
+arclith-cli add-intent-interpreter TodoAction
 arclith-cli add-intent-interpreter TodoConversation
 arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name="<model-id-lm-studio>" --yes
 arclith-cli add-adapter --capability observability --adapter langsmith

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -30,10 +30,22 @@ Le fil conducteur est volontairement simple:
 - deux use cases applicatifs pour enregistrer et lister les todos;
 - une API FastAPI;
 - un serveur MCP FastMCP;
-- un agent LangGraph qui collecte les champs manquants avant d'appeler le même use case.
+- un agent LangGraph qui crée, liste et annule une création de todo en appelant les mêmes use cases.
 
 Le chemin principal utilise `repository: memory`. À la fin, on ajoute MongoDB pour partager les
 données entre l'API, le MCP et l'agent quand ils tournent dans des processus différents.
+
+Le POC complet est disponible si vous voulez récupérer directement le résultat final:
+
+```bash
+git clone https://github.com/karned-rekipe/arclith-POC-todo.git
+cd arclith-POC-todo
+uv sync
+uv run python -m pytest
+```
+
+Ce dépôt sert de version téléchargeable du tutoriel. Les pages ci-dessous restent le pas-à-pas pour
+comprendre pourquoi chaque fichier existe.
 
 ## Modèle cible
 
@@ -60,7 +72,7 @@ Client HTTP / Client MCP / LangGraph
 
 Les adapters inbound ne parlent jamais directement au repository. Ils appellent les ports inbound,
 exactement comme l'agent qui transforme une conversation en commande structurée puis appelle
-`CreateTodoPort`.
+`CreateTodoPort` ou `ListTodosPort`.
 
 L'étape FastAPI pousse aussi le contrat HTTP: format de réponse enveloppé, pagination, headers
 standard, exemples OpenAPI et documentation détaillée des erreurs. L'idée est que la maturité API


### PR DESCRIPTION
## What changed

- Add the downloadable Todo POC repository link to the tutorial index.
- Expand the FastAPI and FastMCP tutorial pages with each adapter file responsibility.
- Rewrite the LangGraph agent page around the split agent structure: intent routing, draft collection, dependencies, nodes, routing, parsing, formatting, and state.
- Document the new TodoActionInterpreter alongside TodoConversationInterpreter, including fast-path local intent detection with LLM fallback.

## Why

The Todo POC now demonstrates the intended Arclith boundary more clearly: FastAPI, FastMCP, and LangGraph all call application ports/use cases instead of repositories directly.

## Validation

- make docs
- POC validation: uv run python -m pytest in todo-list-service (26 passed)
