### PR TITLE
Complete OpenTelemetry OTLP foundation

### DIFF
--- a/arclith/adapters/outbound/console/logger.py
+++ b/arclith/adapters/outbound/console/logger.py
@@ -23,5 +23,5 @@ loguru_logger.add(sys.stderr, format = _FORMAT)
 class ConsoleLogger(Logger):
     def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
         emoji = _LEVEL_EMOJI.get(level.value, "💬")
-        bound = loguru_logger.bind(level_emoji = emoji, meta = {**current_trace_metadata(), **metadata})
+        bound = loguru_logger.bind(level_emoji = emoji, meta = {**metadata, **current_trace_metadata()})
         getattr(bound, level.value.lower())(message)

--- a/arclith/adapters/outbound/console/logger.py
+++ b/arclith/adapters/outbound/console/logger.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from loguru import logger as loguru_logger
 
+from arclith.adapters.outbound.opentelemetry.correlation import current_trace_metadata
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 
 _LEVEL_EMOJI = {
@@ -22,5 +23,5 @@ loguru_logger.add(sys.stderr, format = _FORMAT)
 class ConsoleLogger(Logger):
     def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
         emoji = _LEVEL_EMOJI.get(level.value, "💬")
-        bound = loguru_logger.bind(level_emoji = emoji, meta = metadata)
+        bound = loguru_logger.bind(level_emoji = emoji, meta = {**current_trace_metadata(), **metadata})
         getattr(bound, level.value.lower())(message)

--- a/arclith/adapters/outbound/opentelemetry/correlation.py
+++ b/arclith/adapters/outbound/opentelemetry/correlation.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+
+type TraceMetadata = dict[str, str | bool]
+
+
+def current_trace_metadata() -> TraceMetadata:
+    try:
+        from opentelemetry.trace import get_current_span
+    except ImportError:
+        return {}
+
+    context = get_current_span().get_span_context()
+    if not context.is_valid:
+        return {}
+
+    return {
+        "trace_id": format(context.trace_id, "032x"),
+        "span_id": format(context.span_id, "016x"),
+        "trace_sampled": context.trace_flags.sampled,
+    }
+
+
+def log_record_trace_metadata(record: Any) -> TraceMetadata:
+    trace_id = getattr(record, "otelTraceID", "")
+    span_id = getattr(record, "otelSpanID", "")
+    if not _valid_injected_id(trace_id) or not _valid_injected_id(span_id):
+        return {}
+
+    metadata: TraceMetadata = {
+        "trace_id": trace_id,
+        "span_id": span_id,
+    }
+    trace_sampled = getattr(record, "otelTraceSampled", None)
+    if isinstance(trace_sampled, bool):
+        metadata["trace_sampled"] = trace_sampled
+    return metadata
+
+
+def _valid_injected_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(value) and any(char != "0" for char in value)

--- a/arclith/adapters/outbound/opentelemetry/correlation.py
+++ b/arclith/adapters/outbound/opentelemetry/correlation.py
@@ -2,6 +2,7 @@ from typing import Any
 
 
 type TraceMetadata = dict[str, str | bool]
+_HEX_DIGITS = frozenset("0123456789abcdef")
 
 
 def current_trace_metadata() -> TraceMetadata:
@@ -24,7 +25,10 @@ def current_trace_metadata() -> TraceMetadata:
 def log_record_trace_metadata(record: Any) -> TraceMetadata:
     trace_id = getattr(record, "otelTraceID", "")
     span_id = getattr(record, "otelSpanID", "")
-    if not _valid_injected_id(trace_id) or not _valid_injected_id(span_id):
+    if not _valid_injected_id(trace_id, expected_length=32) or not _valid_injected_id(
+        span_id,
+        expected_length=16,
+    ):
         return {}
 
     metadata: TraceMetadata = {
@@ -37,5 +41,10 @@ def log_record_trace_metadata(record: Any) -> TraceMetadata:
     return metadata
 
 
-def _valid_injected_id(value: Any) -> bool:
-    return isinstance(value, str) and bool(value) and any(char != "0" for char in value)
+def _valid_injected_id(value: Any, *, expected_length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == expected_length
+        and any(char != "0" for char in value)
+        and all(char.lower() in _HEX_DIGITS for char in value)
+    )

--- a/arclith/adapters/outbound/opentelemetry/fastapi.py
+++ b/arclith/adapters/outbound/opentelemetry/fastapi.py
@@ -48,26 +48,45 @@ def _configure_opentelemetry(
     if _CONFIGURATION_STATE.configured or not (settings.traces or settings.metrics):
         return
 
-    try:
-        from opentelemetry.instrumentation.logging import LoggingInstrumentor
-        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
-    except ImportError as exc:
-        raise RuntimeError(
-            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
-        ) from exc
-
-    resource = Resource.create({
-        SERVICE_NAME: settings.service_name or service_name,
-        SERVICE_VERSION: service_version,
-    })
+    resource = _build_resource(settings, service_name=service_name, service_version=service_version)
 
     if settings.traces:
         _configure_traces(settings, resource)
     if settings.metrics:
         _configure_metrics(settings, resource)
 
-    LoggingInstrumentor().instrument(set_logging_format=False)
+    _instrument_logging_correlation()
     _CONFIGURATION_STATE.configured = True
+
+
+def _build_resource(
+    settings: "OpenTelemetrySettings",
+    *,
+    service_name: str,
+    service_version: str,
+) -> Any:
+    try:
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+    except ImportError as exc:
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
+
+    return Resource.create({
+        SERVICE_NAME: settings.service_name or service_name,
+        SERVICE_VERSION: service_version,
+    })
+
+
+def _instrument_logging_correlation() -> None:
+    try:
+        from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    except ImportError as exc:
+        raise RuntimeError(
+            'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
+        ) from exc
+
+    LoggingInstrumentor().instrument(set_logging_format=False, inject_trace_context=True)
 
 
 def _configure_traces(settings: "OpenTelemetrySettings", resource: Any) -> None:

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, TypeVar, overload
 
+from arclith.adapters.outbound.opentelemetry.correlation import log_record_trace_metadata
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
@@ -52,6 +53,7 @@ class _UvicornLogInterceptHandler(logging.Handler):
         self._logger.log(
             _LEVEL_MAP.get(record.levelname, LogLevel.INFO),
             message,
+            **log_record_trace_metadata(record),
         )
 class Arclith:
     def __init__(self, config_path: str | Path) -> None:

--- a/cli/README.md
+++ b/cli/README.md
@@ -159,7 +159,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `anthropic` → `model_name`, `ANTHROPIC_API_KEY`
    - `langgraph` → `graph_name`
    - `langsmith` → `tracing`, `project`, `endpoint`, `LANGSMITH_API_KEY`
-   - `opentelemetry` → `service_name`, `endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
+   - `opentelemetry` → `service_name`, `endpoint`, `traces_endpoint`, `metrics_endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
    - `memory` → aucun paramètre
 4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `llm/*` et `agent/langgraph` sont exposés par leurs fichiers de configuration scopés
 5. **Récapitulatif** — liste des fichiers créés ou remplacés avant confirmation
@@ -224,6 +224,9 @@ jour `.env`, l'ajoute à `observability.enabled` et branche l'instrumentation Fa
 `Arclith.fastapi()` construit l'application. Il peut être activé en même temps que LangSmith.
 Le fichier `opentelemetry.yaml` ne porte pas de flag `enabled`: l'activation se fait uniquement dans
 `observability.enabled`.
+L'endpoint global est utilisé par défaut; `traces_endpoint` et `metrics_endpoint` peuvent cibler des
+routes OTLP distinctes. Pour taguer l'environnement, définir
+`OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local` dans l'environnement runtime.
 
 Parcours complet avec entité, API, LangGraph, LangSmith et LM Studio:
 [`docs/agent-quickstart.md`](../docs/agent-quickstart.md).

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -581,6 +581,8 @@ LANGSMITH_API_KEY={api_key}
             config_template="""\
 service_name: "{service_name}"
 endpoint: "{endpoint}"
+traces_endpoint: {traces_endpoint}
+metrics_endpoint: {metrics_endpoint}
 protocol: "{protocol}"
 headers_env: OTEL_EXPORTER_OTLP_HEADERS
 traces: {traces}
@@ -607,6 +609,18 @@ OTEL_EXPORTER_OTLP_HEADERS={headers}
                     kind="string",
                     prompt="OTLP endpoint",
                     default="http://localhost:4318",
+                ),
+                ParameterSpec(
+                    name="traces_endpoint",
+                    kind="string",
+                    prompt="OTLP traces endpoint",
+                    default="null",
+                ),
+                ParameterSpec(
+                    name="metrics_endpoint",
+                    kind="string",
+                    prompt="OTLP metrics endpoint",
+                    default="null",
                 ),
                 ParameterSpec(
                     name="protocol",

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -332,6 +332,8 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
         adapter_params={
             "service_name": "demo-api",
             "endpoint": "http://otel-collector:4318",
+            "traces_endpoint": "http://otel-collector:4318/custom/traces",
+            "metrics_endpoint": "http://otel-collector:4318/custom/metrics",
             "protocol": "http/protobuf",
             "traces": "true",
             "metrics": "true",
@@ -347,6 +349,8 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     )
     assert 'service_name: "demo-api"' in config
     assert 'endpoint: "http://otel-collector:4318"' in config
+    assert "traces_endpoint: http://otel-collector:4318/custom/traces" in config
+    assert "metrics_endpoint: http://otel-collector:4318/custom/metrics" in config
     assert 'protocol: "http/protobuf"' in config
     assert "headers_env: OTEL_EXPORTER_OTLP_HEADERS" in config
     assert "traces: true" in config
@@ -389,6 +393,12 @@ def test_add_observability_adapters_accumulates_enabled_backends(tmp_path: Path)
         (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
     )
     assert adapters_config["observability"]["enabled"] == ["langsmith", "opentelemetry"]
+
+    config = (project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "traces_endpoint: null" in config
+    assert "metrics_endpoint: null" in config
 
 
 def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -107,6 +107,8 @@ def test_observability_capability_catalog_declares_opentelemetry() -> None:
     assert [parameter.name for parameter in opentelemetry.parameters] == [
         "service_name",
         "endpoint",
+        "traces_endpoint",
+        "metrics_endpoint",
         "protocol",
         "traces",
         "metrics",

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -167,6 +167,8 @@ OpenTelemetry se configure avec:
 # config/adapters/outbound/opentelemetry.yaml
 service_name: "my-service"
 endpoint: "http://localhost:4318"
+traces_endpoint: null
+metrics_endpoint: null
 protocol: "http/protobuf"
 headers_env: OTEL_EXPORTER_OTLP_HEADERS
 traces: true
@@ -177,6 +179,20 @@ metrics_export_interval_millis: 60000
 
 `opentelemetry.yaml` décrit l'export OTLP. L'activation reste uniquement dans
 `config/adapters/adapters.yaml`, via `observability.enabled`.
+
+Pour renseigner l'environnement sans le coder dans l'application, définir une ressource standard au
+runtime:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local
+```
+
+Quand `instrument_fastapi` et `traces` sont actifs, `Arclith.fastapi()` installe
+l'instrumentation FastAPI après les middlewares Arclith. Les logs Arclith ajoutent `trace_id` et
+`span_id` aux métadonnées quand un span courant existe. FastMCP et LangGraph ne reçoivent pas encore
+de spans manuels par tool ou par nœud dans le framework: en local, LangSmith reste le banc de test
+agent, et OpenTelemetry couvre le processus/runtime uniquement quand il est instrumenté par le SDK ou
+par le serveur hôte.
 
 Installer l'extra avant d'activer l'adapter:
 

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -311,6 +311,12 @@ endpoint: http://127.0.0.1:4318
 service_name: todo-list-service
 ```
 
+Pour voir l'environnement dans les ressources OpenTelemetry, ajouter au runtime:
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local
+```
+
 Relancer l'API, appeler Swagger ou `curl`, puis chercher le service `todo-list-service` dans Jaeger.
 
 ## LangSmith ou OpenTelemetry ?

--- a/tests/units/adapters/outbound/test_console_logger.py
+++ b/tests/units/adapters/outbound/test_console_logger.py
@@ -23,7 +23,14 @@ def test_console_logger_enriches_metadata_with_current_trace(monkeypatch) -> Non
     )
     monkeypatch.setattr(console_logger.loguru_logger, "bind", fake_bind)
 
-    ConsoleLogger().log(LogLevel.INFO, "hello", request_id="req-1")
+    ConsoleLogger().log(
+        LogLevel.INFO,
+        "hello",
+        request_id="req-1",
+        trace_id="application-trace",
+        span_id="application-span",
+        trace_sampled=False,
+    )
 
     assert captured["message"] == "hello"
     assert captured["bind"]["meta"] == {

--- a/tests/units/adapters/outbound/test_console_logger.py
+++ b/tests/units/adapters/outbound/test_console_logger.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from arclith.adapters.outbound.console import logger as console_logger
+from arclith.adapters.outbound.console.logger import ConsoleLogger
+from arclith.domain.ports.outbound.logger import LogLevel
+
+
+def test_console_logger_enriches_metadata_with_current_trace(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class BoundLogger:
+        def info(self, message: str) -> None:
+            captured["message"] = message
+
+    def fake_bind(**kwargs: Any) -> BoundLogger:
+        captured["bind"] = kwargs
+        return BoundLogger()
+
+    monkeypatch.setattr(
+        console_logger,
+        "current_trace_metadata",
+        lambda: {"trace_id": "trace", "span_id": "span", "trace_sampled": True},
+    )
+    monkeypatch.setattr(console_logger.loguru_logger, "bind", fake_bind)
+
+    ConsoleLogger().log(LogLevel.INFO, "hello", request_id="req-1")
+
+    assert captured["message"] == "hello"
+    assert captured["bind"]["meta"] == {
+        "trace_id": "trace",
+        "span_id": "span",
+        "trace_sampled": True,
+        "request_id": "req-1",
+    }

--- a/tests/units/adapters/outbound/test_opentelemetry_correlation.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_correlation.py
@@ -27,3 +27,23 @@ def test_log_record_trace_metadata_ignores_zero_padded_span_context() -> None:
     record = SimpleNamespace(otelTraceID="0" * 32, otelSpanID="0" * 16, otelTraceSampled=False)
 
     assert log_record_trace_metadata(record) == {}
+
+
+def test_log_record_trace_metadata_ignores_malformed_trace_ids() -> None:
+    record = SimpleNamespace(
+        otelTraceID="0" * 31 + "z",
+        otelSpanID="0" * 15 + "2",
+        otelTraceSampled=True,
+    )
+
+    assert log_record_trace_metadata(record) == {}
+
+
+def test_log_record_trace_metadata_ignores_wrong_length_span_ids() -> None:
+    record = SimpleNamespace(
+        otelTraceID="0" * 31 + "1",
+        otelSpanID="0" * 16 + "2",
+        otelTraceSampled=True,
+    )
+
+    assert log_record_trace_metadata(record) == {}

--- a/tests/units/adapters/outbound/test_opentelemetry_correlation.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_correlation.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+from arclith.adapters.outbound.opentelemetry.correlation import log_record_trace_metadata
+
+
+def test_log_record_trace_metadata_reads_injected_trace_ids() -> None:
+    record = SimpleNamespace(
+        otelTraceID="0" * 31 + "1",
+        otelSpanID="0" * 15 + "2",
+        otelTraceSampled=True,
+    )
+
+    assert log_record_trace_metadata(record) == {
+        "trace_id": "0" * 31 + "1",
+        "span_id": "0" * 15 + "2",
+        "trace_sampled": True,
+    }
+
+
+def test_log_record_trace_metadata_ignores_missing_span_context() -> None:
+    record = SimpleNamespace(otelTraceID="0", otelSpanID="0", otelTraceSampled=False)
+
+    assert log_record_trace_metadata(record) == {}
+
+
+def test_log_record_trace_metadata_ignores_zero_padded_span_context() -> None:
+    record = SimpleNamespace(otelTraceID="0" * 32, otelSpanID="0" * 16, otelTraceSampled=False)
+
+    assert log_record_trace_metadata(record) == {}

--- a/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 
 from arclith.adapters.outbound.opentelemetry.fastapi import (
+    _build_resource,
     _configure_opentelemetry,
     _headers_from_env,
+    _instrument_logging_correlation,
     _resolve_endpoint,
     instrument_fastapi_app,
 )
@@ -19,6 +21,37 @@ def test_configure_opentelemetry_skips_when_exports_disabled() -> None:
     settings = OpenTelemetrySettings(traces=False, metrics=False)
 
     _configure_opentelemetry(settings, service_name="demo", service_version="1.0.0")
+
+
+def test_build_resource_adds_service_identity_and_environment(monkeypatch) -> None:
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=local")
+
+    resource = _build_resource(
+        OpenTelemetrySettings(service_name="configured-service"),
+        service_name="fallback-service",
+        service_version="1.2.3",
+    )
+
+    assert resource.attributes["service.name"] == "configured-service"
+    assert resource.attributes["service.version"] == "1.2.3"
+    assert resource.attributes["deployment.environment.name"] == "local"
+
+
+def test_instrument_logging_correlation_injects_trace_context(monkeypatch) -> None:
+    calls: list[dict[str, bool]] = []
+
+    class FakeLoggingInstrumentor:
+        def instrument(self, **kwargs: bool) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.logging.LoggingInstrumentor",
+        FakeLoggingInstrumentor,
+    )
+
+    _instrument_logging_correlation()
+
+    assert calls == [{"set_logging_format": False, "inject_trace_context": True}]
 
 
 def test_resolve_endpoint_uses_explicit_value() -> None:

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -213,6 +213,8 @@ def test_load_config_dir_opentelemetry_scoped():
         "adapters/outbound/opentelemetry.yaml": {
             "service_name": "demo-api",
             "endpoint": "http://otel-collector:4318",
+            "traces_endpoint": "http://otel-collector:4318/v1/custom-traces",
+            "metrics_endpoint": "http://otel-collector:4318/v1/custom-metrics",
             "protocol": "http/protobuf",
             "traces": True,
             "metrics": True,
@@ -226,6 +228,8 @@ def test_load_config_dir_opentelemetry_scoped():
     assert config.adapters.opentelemetry is not None
     assert config.adapters.opentelemetry.service_name == "demo-api"
     assert config.adapters.opentelemetry.endpoint == "http://otel-collector:4318"
+    assert config.adapters.opentelemetry.traces_endpoint == "http://otel-collector:4318/v1/custom-traces"
+    assert config.adapters.opentelemetry.metrics_endpoint == "http://otel-collector:4318/v1/custom-metrics"
     assert config.adapters.opentelemetry.metrics is True
     assert config.adapters.opentelemetry.metrics_export_interval_millis == 15000
 

--- a/tests/units/test_arclith_opentelemetry.py
+++ b/tests/units/test_arclith_opentelemetry.py
@@ -1,10 +1,21 @@
+import logging
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from arclith import Arclith
+from arclith.arclith import _UvicornLogInterceptHandler
 from arclith.adapters.outbound.opentelemetry import fastapi as otel_fastapi
+from arclith.domain.ports.outbound.logger import Logger, LogLevel
+
+
+class CapturingLogger(Logger):
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
+        self.records.append({"level": level, "message": message, "metadata": metadata})
 
 
 def _make_config_dir(tmp_path: Path) -> Path:
@@ -78,3 +89,25 @@ def test_fastapi_instruments_opentelemetry_after_middlewares(tmp_path: Path, mon
     Arclith(_make_config_dir(tmp_path)).fastapi()
 
     assert events == ["observability", "http", "opentelemetry"]
+
+
+def test_uvicorn_log_interceptor_keeps_injected_trace_metadata() -> None:
+    logger = CapturingLogger()
+    record = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 1, "request finished", (), None)
+    record.otelTraceID = "0" * 31 + "1"
+    record.otelSpanID = "0" * 15 + "2"
+    record.otelTraceSampled = True
+
+    _UvicornLogInterceptHandler(logger).emit(record)
+
+    assert logger.records == [
+        {
+            "level": LogLevel.INFO,
+            "message": "request finished",
+            "metadata": {
+                "trace_id": "0" * 31 + "1",
+                "span_id": "0" * 15 + "2",
+                "trace_sampled": True,
+            },
+        }
+    ]


### PR DESCRIPTION
## Summary
- Expose `traces_endpoint` and `metrics_endpoint` in the CLI OpenTelemetry adapter config while keeping `observability.enabled` as the only activation switch.
- Add OpenTelemetry log correlation metadata (`trace_id`, `span_id`, `trace_sampled`) for Arclith console logs and intercepted `uvicorn` logs when a current span exists.
- Make OpenTelemetry resource construction testable for `service.name`, `service.version`, and runtime environment attributes via `OTEL_RESOURCE_ATTRIBUTES`.
- Document FastAPI direct instrumentation, MCP/LangGraph current limits, and the local Jaeger/environment setup.

## Validation
- `uv run pytest tests/units/test_arclith_opentelemetry.py tests/units/adapters/outbound/test_opentelemetry_fastapi.py tests/units/adapters/outbound/test_opentelemetry_correlation.py tests/units/adapters/outbound/test_console_logger.py tests/units/infrastructure/test_config.py::test_load_config_dir_opentelemetry_scoped tests/units/infrastructure/test_config.py::test_opentelemetry_settings_defaults tests/units/infrastructure/test_config.py::test_opentelemetry_settings_rejects_legacy_enabled_flag`
- `cd cli && uv run pytest tests/test_add_adapter.py::test_add_opentelemetry_observability_adapter_uses_catalog_params tests/test_add_adapter.py::test_add_observability_adapters_accumulates_enabled_backends tests/test_capabilities.py::test_observability_capability_catalog_declares_opentelemetry`
- `uv run pytest`
- `cd cli && uv run pytest`
- `make docs`
- `make quality`
- OTLP HTTP smoke: local fake collector received 1030 bytes on `/v1/traces` with `application/x-protobuf`.

## Notes
- A real Jaeger container smoke was attempted with `cr.jaegertracing.io/jaegertracing/jaeger:2.20.0`, but Docker failed before container creation on local credential access. No `arclith-jaeger-issue-28` container remained. The documented Jaeger flow is covered by `make docs`; runtime OTLP export is covered by the local fake collector smoke.

Closes #28
