### PR TITLE
Test repository memory adapter scaffold

### DIFF
--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -484,6 +486,103 @@ def test_add_memory_adapter_rejects_unknown_catalog_param(tmp_path: Path) -> Non
             adapter_params={"unused": "value"},
             yes=True,
         )
+
+
+def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(tmp_path: Path) -> None:
+    project_dir = tmp_path / "memory-service"
+
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "init",
+            "memory-service",
+            "--dir",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"init failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    result = subprocess.run(
+        ["arclith-cli", "add-entity", "Widget"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "add-adapter",
+            "--capability",
+            "repository",
+            "--adapter",
+            "memory",
+            "--entity",
+            "Widget",
+            "--yes",
+        ],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"add-adapter failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    package_root = project_dir / "src" / "memory_service"
+    assert (package_root / "adapters" / "outbound" / "memory" / "repositories" / "widget_repository.py").exists()
+    assert (package_root / "adapters" / "outbound" / "memory" / "repository.py").exists()
+    assert not (project_dir / "config" / "adapters" / "outbound" / "memory.yaml").exists()
+
+    adapters_config = yaml.safe_load(
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+    )
+    assert adapters_config["repository"] == "memory"
+
+    load_result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from arclith import Arclith\n"
+                "app = Arclith('config')\n"
+                "assert app.config.adapters.repository == 'memory'\n"
+                "print(app.config.adapters.repository)\n"
+            ),
+        ],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert load_result.returncode == 0, (
+        f"Arclith config load failed:\nSTDOUT:\n{load_result.stdout}\nSTDERR:\n{load_result.stderr}"
+    )
+    assert load_result.stdout.strip() == "memory"
+
+
+def test_add_memory_adapter_interactive_wizard_activates_memory(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    result = subprocess.run(
+        ["arclith-cli", "add-adapter"],
+        cwd=project_dir,
+        input="1\ny\ny\n",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"wizard failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    package_root = project_dir / "src" / "demo_service"
+    assert (package_root / "adapters" / "outbound" / "memory" / "repositories" / "widget_repository.py").exists()
+    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -15,6 +15,11 @@ def test_repository_capability_catalog_declares_standard_adapters() -> None:
     assert capability.layer == "outbound"
     assert capability.activation_config_key == "repository"
     assert repository_adapter_names() == ("memory", "mongodb", "duckdb", "mariadb")
+    memory = capability.get_adapter("memory")
+    assert memory is not None
+    assert memory.entity_scoped is True
+    assert memory.config_path is None
+    assert memory.parameters == ()
 
 
 def test_observability_capability_catalog_declares_langsmith() -> None:
@@ -195,6 +200,7 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     payload = json.loads(result.stdout)
     assert payload[0]["name"] == "repository"
     assert [adapter["name"] for adapter in payload[0]["adapters"]] == ["memory", "mongodb", "duckdb", "mariadb"]
+    assert payload[0]["adapters"][0]["entity_scoped"] is True
     assert payload[1]["name"] == "api"
     assert [adapter["name"] for adapter in payload[1]["adapters"]] == ["fastapi"]
     assert payload[2]["name"] == "mcp"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -62,6 +62,12 @@ Adapters disponibles:
 - `duckdb`: repository fichier local pour SQL analytique et démos sans serveur;
 - `mariadb`: repository MariaDB async optionnel, avec stockage générique JSON par entité.
 
+`memory` reste le chemin zéro dépendance pour les tests, les use cases et les smokes locaux. Il
+n'ajoute aucun fichier de configuration dédié: l'activation se limite à `repository: memory`. Chaque
+processus Python possède son propre stockage mémoire; une API, un serveur MCP et un agent lancés
+séparément ne partagent donc pas leur état. Utiliser un repository persistant pour les scénarios
+multi-processus.
+
 Activation:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Assert `repository/memory` stays entity-scoped in the CLI capability catalog, with no dedicated config file or adapter parameters.
- Add CLI coverage for `arclith-cli init`, `add-entity`, `add-adapter --capability repository --adapter memory --yes`, and `Arclith('config')` loading `repository: memory`.
- Add an interactive wizard test for selecting the memory repository adapter.
- Document that `memory` is per-process and not suitable for shared API/MCP/agent state.

## Divergence noted

The issue lists `uv run pytest cli/tests/test_capabilities.py cli/tests/test_add_adapter.py` from the repository root. In the current repository layout, the CLI package owns `cli/pyproject.toml`; the root environment does not install CLI dependencies such as `typer`, so that root command fails during collection with `ModuleNotFoundError: No module named 'typer'`. I ran the equivalent command from `arclith/cli`, which is the package context used by `arclith-cli`.

Closes #58

## Validation

- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py` — 31 passed
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- Manual smoke: `arclith-cli init`, `add-entity`, `add-adapter --capability repository --adapter memory --entity Widget --yes`, then `Arclith('config')` loaded `repository == 'memory'`
- `make docs`
- `make quality` — 284 passed, coverage 90.49%
