### PR TITLE
Complete MongoDB repository scaffold

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -132,7 +132,7 @@ arclith-cli add-adapter
 Mode direct, utile pour CI, scripts de migration ou commandes reproductibles :
 
 ```bash
-arclith-cli add-adapter --adapter mongodb --entity Recipe --db-name my_recipe_service --yes
+arclith-cli add-adapter --adapter mongodb --entity Recipe --db-name my_recipe_service --param collection_name=recipes --yes
 arclith-cli add-adapter --adapter duckdb --all-entities --path data/ --no-activate --yes
 arclith-cli add-adapter --adapter mariadb --entity Recipe --param database=my_recipe_service --param user=app --yes
 arclith-cli add-adapter --capability api --adapter fastapi --param port=8080 --yes
@@ -149,7 +149,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
 1. **Type d'adapter** — selon la capacité : `memory` · `mongodb` · `duckdb` · `mariadb` · `fastapi` · `fastmcp` · `lmstudio` · `openai` · `anthropic` · `langgraph` · `langsmith` · `opentelemetry`
 2. **Entité(s) cible(s)** — détectées automatiquement pour les adapters entity-scoped ; ignorées pour les transports globaux, `llm/*`, `agent/langgraph` et les adapters d'observability
 3. **Paramètres** — questions spécifiques à l'adapter :
-   - `mongodb` → `db_name`, `multitenant`
+   - `mongodb` → `db_name`, `collection_name`, `multitenant`
    - `duckdb` → `path`
    - `mariadb` → `host`, `port`, `database`, `user`, `driver`, `table_prefix`
    - `fastapi` → `host`, `port`, `reload`
@@ -202,6 +202,10 @@ uv run langgraph dev --no-browser --allow-blocking --port 2024
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
 `AppConfig.adapters.lm`. Les adapters `llm/openai` et `llm/anthropic` génèrent aussi un mapping
 `config/secrets.yaml` vers `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`.
+
+L'adapter `repository/mongodb` génère `config/adapters/outbound/mongodb.yaml` avec `uri: null`, puis
+mappe `adapters.mongodb.uri` vers `MONGODB_URI` dans `config/secrets.yaml`. L'URI réelle reste dans
+l'environnement, un fichier local de secrets ou Vault selon le resolver choisi.
 
 L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet ne modifie ensuite que ce fichier pour

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -139,15 +139,29 @@ REPOSITORY_CAPABILITY = CapabilitySpec(
             description="Repository MongoDB async avec configuration single-tenant ou multitenant.",
             config_path="config/adapters/outbound/mongodb.yaml",
             config_template="""\
-multitenant: {multitenant}   # true = URI + db_name resolus par requete via JWT -> Vault
-db_name: {db_name}   # uri -> secrets.yaml ou Vault (fallback single-tenant)
+uri: null   # single-tenant: mappez adapters.mongodb.uri via config/secrets.yaml, env ou Vault
+db_name: {db_name}   # fallback multitenant si le secret tenant ne fournit pas db_name
+collection_name: {collection_name}   # null = nom derive de la classe entite
+multitenant: {multitenant}   # true = uri/db_name resolus par requete via JWT -> VaultTenantResolver
 """,
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="adapters.mongodb.uri",
+                    secret_key="MONGODB_URI",
+                ),
+            ),
             parameters=(
                 ParameterSpec(
                     name="db_name",
                     kind="string",
                     prompt="db_name",
                     default_from_project_name=True,
+                ),
+                ParameterSpec(
+                    name="collection_name",
+                    kind="string",
+                    prompt="collection_name",
+                    default="null",
                 ),
                 ParameterSpec(
                     name="multitenant",

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -141,8 +141,8 @@ REPOSITORY_CAPABILITY = CapabilitySpec(
             config_template="""\
 uri: null   # single-tenant: mappez adapters.mongodb.uri via config/secrets.yaml, env ou Vault
 db_name: {db_name}   # fallback multitenant si le secret tenant ne fournit pas db_name
-collection_name: {collection_name}   # null = nom derive de la classe entite
-multitenant: {multitenant}   # true = uri/db_name resolus par requete via JWT -> VaultTenantResolver
+collection_name: {collection_name}   # null = nom dérivé de la classe entité
+multitenant: {multitenant}   # true = uri/db_name résolus par requête via JWT -> VaultTenantResolver
 """,
             secret_mappings=(
                 SecretMappingSpec(

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -69,6 +69,7 @@ def test_add_mongodb_adapter_uses_non_interactive_params(tmp_path: Path) -> None
         entity_names=["Widget"],
         activate=False,
         db_name="demo_shared",
+        adapter_params={"collection_name": "widgets"},
         multitenant=True,
         yes=True,
     )
@@ -76,11 +77,40 @@ def test_add_mongodb_adapter_uses_non_interactive_params(tmp_path: Path) -> None
     mongodb_config = (project_dir / "config" / "adapters" / "outbound" / "mongodb.yaml").read_text(
         encoding="utf-8"
     )
+    assert "uri: null" in mongodb_config
     assert "multitenant: true" in mongodb_config
     assert "db_name: demo_shared" in mongodb_config
+    assert "collection_name: widgets" in mongodb_config
+    secrets = (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    assert "resolver: env" in secrets
+    assert "adapters.mongodb.uri: MONGODB_URI" in secrets
+    assert "mongodb://" not in secrets
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
+
+
+def test_add_mongodb_adapter_generates_loadable_single_tenant_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        adapter="mongodb",
+        entity_names=["Widget"],
+        db_name="demo_shared",
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    app = Arclith(project_dir / "config")
+
+    assert app.config.adapters.repository == "mongodb"
+    assert app.config.adapters.mongodb is not None
+    assert app.config.adapters.mongodb.uri is None
+    assert app.config.adapters.mongodb.db_name == "demo_shared"
+    assert app.config.adapters.mongodb.collection_name is None
+    assert app.config.adapters.mongodb.multitenant is False
 
 
 def test_add_mariadb_adapter_uses_catalog_params(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -152,7 +152,9 @@ def test_repository_adapter_specs_include_config_and_parameters() -> None:
 
     assert mongodb is not None
     assert mongodb.config_path == "config/adapters/outbound/mongodb.yaml"
-    assert [parameter.name for parameter in mongodb.parameters] == ["db_name", "multitenant"]
+    assert [parameter.name for parameter in mongodb.parameters] == ["db_name", "collection_name", "multitenant"]
+    assert [mapping.field_path for mapping in mongodb.secret_mappings] == ["adapters.mongodb.uri"]
+    assert [mapping.secret_key for mapping in mongodb.secret_mappings] == ["MONGODB_URI"]
     assert duckdb is not None
     assert duckdb.config_path == "config/adapters/outbound/duckdb.yaml"
     assert [parameter.name for parameter in duckdb.parameters] == ["path"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -68,6 +68,38 @@ processus Python possède son propre stockage mémoire; une API, un serveur MCP 
 séparément ne partagent donc pas leur état. Utiliser un repository persistant pour les scénarios
 multi-processus.
 
+`mongodb` est le choix standard quand plusieurs processus doivent partager le même état, par exemple
+API, MCP et agent LangGraph. La CLI génère `config/adapters/outbound/mongodb.yaml` et mappe
+`adapters.mongodb.uri` vers `MONGODB_URI` dans `config/secrets.yaml` avec le resolver `env`. L'URI
+réelle reste hors Git: exporter `MONGODB_URI`, remplacer le resolver par `vault`, ou utiliser un
+resolver `chain` selon l'environnement.
+
+Single-tenant:
+
+```yaml
+# config/adapters/adapters.yaml
+repository: mongodb
+
+# config/adapters/outbound/mongodb.yaml
+uri: null
+db_name: my_service
+collection_name: null
+multitenant: false
+```
+
+Multitenant:
+
+```yaml
+# config/adapters/outbound/mongodb.yaml
+uri: null
+db_name: fallback_db
+collection_name: null
+multitenant: true
+```
+
+En multitenant, `VaultTenantResolver` fournit `uri` et peut fournir `db_name` pour la requête
+courante. `db_name` reste un fallback si le secret tenant ne le porte pas.
+
 Activation:
 
 ```yaml

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -432,7 +432,7 @@ def test_duckdb_requires_section():
 
 
 def test_mongodb_requires_section():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"repository=mongodb mais aucune section \[adapters.mongodb\]"):
         AppConfig.model_validate({"adapters": {"repository": "mongodb"}})
 
 
@@ -605,3 +605,28 @@ def test_adapters_lm_api_key_loaded_from_env_mapping(monkeypatch: pytest.MonkeyP
 
     assert config.adapters.lm is not None
     assert config.adapters.lm.api_key == "sk-openai"
+
+
+def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MONGODB_URI", "mongodb://env-mongo:27017")
+    config_dir = _make_config_dir({
+        "adapters/adapters.yaml": {"repository": "mongodb"},
+        "adapters/outbound/mongodb.yaml": {
+            "uri": None,
+            "db_name": "demo_shared",
+            "collection_name": None,
+            "multitenant": False,
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "adapters.mongodb.uri": "MONGODB_URI",
+            },
+        },
+    })
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.mongodb is not None
+    assert config.adapters.mongodb.uri == "mongodb://env-mongo:27017"
+    assert config.adapters.mongodb.db_name == "demo_shared"

--- a/tests/units/infrastructure/test_repository_factory.py
+++ b/tests/units/infrastructure/test_repository_factory.py
@@ -42,10 +42,12 @@ def test_mongodb_returns_mongodb_repository(logger):
     from arclith.adapters.outbound.mongodb.repository import MongoDBRepository
     config = AppConfig(adapters = AdaptersSettings(
         repository = "mongodb",
-        mongodb = MongoDBSettings(uri = "mongodb://localhost:27017", db_name = "test"),
+        mongodb = MongoDBSettings(db_name = "test", collection_name = "items"),
     ))
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, MongoDBRepository)
+    assert repo._config.uri is None
+    assert repo._config.collection_name == "items"
 
 
 def test_duckdb_returns_duckdb_repository(logger, tmp_path):


### PR DESCRIPTION
## Summary

- Extend the `repository/mongodb` CLI capability with explicit `uri`, `db_name`, `collection_name`, and `multitenant` generated config.
- Generate `config/secrets.yaml` mapping `adapters.mongodb.uri` to `MONGODB_URI` through the existing env secret resolver, without writing a MongoDB URI in clear text.
- Cover generated single-tenant config loading, multitenant parameters, env secret injection, and the useful missing-section validation error.
- Document single-tenant, multitenant, and multi-process API/MCP/LangGraph sharing behavior.

## Notes

The generated MongoDB config intentionally keeps `uri: null`. `AppConfig` can load the generated project without a real secret, and runtime environments can provide the URI via `MONGODB_URI`, a local secrets file, Vault, or a resolver chain.

Closes #59

## Validation

- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py` — 32 passed
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/infrastructure/test_repository_factory.py` — 74 passed
- Manual smoke: `arclith-cli init`, `add-entity`, `add-adapter --capability repository --adapter mongodb --entity Widget --db-name mongo_smoke --param collection_name=widgets --yes`, then `Arclith('config')` loaded `repository == 'mongodb'` with `uri is None`
- `cd cli && uv run ruff check arclith_cli/capabilities.py tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run ruff check tests/units/infrastructure/test_config.py tests/units/infrastructure/test_repository_factory.py`
- `make docs`
- `make quality` — 285 passed, coverage 90.49%
