### PR TITLE
Complete DuckDB repository CLI scaffold coverage

### DIFF
--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -60,6 +60,34 @@ def test_add_duckdb_adapter_non_interactive(tmp_path: Path) -> None:
     ).read_text(encoding="utf-8")
 
 
+def test_add_duckdb_adapter_generates_loadable_directory_config_idempotently(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            adapter="duckdb",
+            duckdb_path="data/",
+            yes=True,
+        )
+
+    from arclith import Arclith
+
+    app = Arclith(project_dir / "config")
+    duckdb_config = (project_dir / "config" / "adapters" / "outbound" / "duckdb.yaml").read_text(
+        encoding="utf-8"
+    )
+    container = (
+        project_dir / "src" / "demo_service" / "infrastructure" / "containers" / "widget_container.py"
+    ).read_text(encoding="utf-8")
+
+    assert app.config.adapters.repository == "duckdb"
+    assert app.config.adapters.duckdb is not None
+    assert app.config.adapters.duckdb.path == "data/"
+    assert duckdb_config == "multitenant: false\npath: data/\n"
+    assert container.count('register("duckdb", _build_duckdb)') == 1
+
+
 def test_add_mongodb_adapter_uses_non_interactive_params(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -203,6 +203,10 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert payload[0]["name"] == "repository"
     assert [adapter["name"] for adapter in payload[0]["adapters"]] == ["memory", "mongodb", "duckdb", "mariadb"]
     assert payload[0]["adapters"][0]["entity_scoped"] is True
+    duckdb = payload[0]["adapters"][2]
+    assert duckdb["name"] == "duckdb"
+    assert duckdb["config_path"] == "config/adapters/outbound/duckdb.yaml"
+    assert [parameter["name"] for parameter in duckdb["parameters"]] == ["path"]
     assert payload[1]["name"] == "api"
     assert [adapter["name"] for adapter in payload[1]["adapters"]] == ["fastapi"]
     assert payload[2]["name"] == "mcp"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -106,6 +106,28 @@ Activation:
 repository: mongodb
 ```
 
+`duckdb` est adapté aux développements locaux, tests d'intégration légers et démonstrations
+analytiques qui ont besoin d'un état durable sans serveur MongoDB. La CLI génère
+`config/adapters/outbound/duckdb.yaml` avec un chemin local explicite; `data/` est le défaut
+compatible avec un projet généré.
+
+Préférer `memory` pour les tests unitaires et smokes sans persistance. Préférer `mongodb` quand
+plusieurs processus ou canaux Arclith doivent partager le même état, par exemple API, MCP et agent
+LangGraph. DuckDB couvre l'entre-deux local: persistance fichier, SQL analytique et setup
+zéro service.
+
+Formats DuckDB acceptés par `DuckDBSettings`: dossier explicite avec `/`, `.csv`, `.parquet`,
+`.json` ou `.arrow`.
+
+```yaml
+# config/adapters/adapters.yaml
+repository: duckdb
+
+# config/adapters/outbound/duckdb.yaml
+multitenant: false
+path: data/
+```
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -355,9 +355,18 @@ def test_load_config_dir_raises_if_not_directory():
 
 # ── DuckDBSettings / SoftDeleteSettings ──────────────────────────────────────
 
-def test_duckdb_settings_file_path():
-    s = DuckDBSettings(path="data/entities.csv")
-    assert s.path == "data/entities.csv"
+@pytest.mark.parametrize(
+    "path",
+    [
+        "data/entities.csv",
+        "data/entities.parquet",
+        "data/entities.json",
+        "data/entities.arrow",
+    ],
+)
+def test_duckdb_settings_file_path_supported_extensions(path: str):
+    s = DuckDBSettings(path=path)
+    assert s.path == path
 
 
 def test_duckdb_settings_directory_path():
@@ -366,7 +375,7 @@ def test_duckdb_settings_directory_path():
 
 
 def test_duckdb_settings_invalid_extension():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Format '.txt' non supporté par DuckDB"):
         DuckDBSettings(path="data/file.txt")
 
 

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -375,7 +375,7 @@ def test_duckdb_settings_directory_path():
 
 
 def test_duckdb_settings_invalid_extension():
-    with pytest.raises(ValidationError, match=r"Format '.txt' non supporté par DuckDB"):
+    with pytest.raises(ValidationError, match=r"Format '\.txt' non supporté par DuckDB"):
         DuckDBSettings(path="data/file.txt")
 
 


### PR DESCRIPTION
## Summary
- Assert `repository/duckdb` exposes the `path` parameter in `capabilities --json`.
- Cover `add-adapter --adapter duckdb --path data/ --yes` with a loadable generated config and repeat generation idempotence.
- Document when to choose DuckDB versus memory and MongoDB, including supported `DuckDBSettings` path formats.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run ruff check tests/units/infrastructure/test_config.py`
- `make docs`
- `make quality`

## Divergence
- The issue-requested root command `uv run pytest cli/tests/test_capabilities.py cli/tests/test_add_adapter.py tests/units/infrastructure/test_config.py` still fails during collection before executing the CLI tests because the root uv environment does not install `arclith_cli`/CLI dependencies; the CLI tests remain runnable from `cli/`, matching the repository's split package setup.

Closes #60