### PR TITLE
Map MariaDB repository secrets in CLI scaffold

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -152,6 +152,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `mongodb` → `db_name`, `collection_name`, `multitenant`
    - `duckdb` → `path`
    - `mariadb` → `host`, `port`, `database`, `user`, `driver`, `table_prefix`
+     (`url` et `password` sont mappés via `config/secrets.yaml`)
    - `fastapi` → `host`, `port`, `reload`
    - `fastmcp` → `host`, `port`
    - `lmstudio` → `model_name`, `base_url`, `api_key`
@@ -328,4 +329,6 @@ observability:
     - opentelemetry
 ```
 
-Pour MariaDB, ne committez pas le mot de passe. Mappez `adapters.mariadb.password` ou `adapters.mariadb.url` via `config/secrets.yaml`, un resolver `env` ou Vault.
+Pour MariaDB, ne committez pas le mot de passe ni l'URL complète si elle contient des identifiants.
+La CLI mappe `adapters.mariadb.password` vers `MARIADB_PASSWORD` et `adapters.mariadb.url` vers
+`MARIADB_URL` dans `config/secrets.yaml`; remplacer le resolver `env` par Vault selon l'environnement.

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -197,12 +197,12 @@ path: {path}
             description="Repository MariaDB async optionnel, pilote par SQLAlchemy et asyncmy.",
             config_path="config/adapters/outbound/mariadb.yaml",
             config_template="""\
-url: null   # a mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complete
+url: null   # à mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complète
 host: {host}
 port: {port}
 database: {database}
 user: {user}
-password: null   # a mapper via config/secrets.yaml ou resolver env/vault
+password: null   # à mapper via config/secrets.yaml ou resolver env/vault
 driver: {driver}
 table_prefix: "{table_prefix}"
 multitenant: false

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -197,6 +197,7 @@ path: {path}
             description="Repository MariaDB async optionnel, pilote par SQLAlchemy et asyncmy.",
             config_path="config/adapters/outbound/mariadb.yaml",
             config_template="""\
+url: null   # a mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complete
 host: {host}
 port: {port}
 database: {database}
@@ -206,6 +207,16 @@ driver: {driver}
 table_prefix: "{table_prefix}"
 multitenant: false
 """,
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="adapters.mariadb.url",
+                    secret_key="MARIADB_URL",
+                ),
+                SecretMappingSpec(
+                    field_path="adapters.mariadb.password",
+                    secret_key="MARIADB_PASSWORD",
+                ),
+            ),
             parameters=(
                 ParameterSpec(
                     name="host",

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -171,7 +171,35 @@ def test_add_mariadb_adapter_uses_catalog_params(tmp_path: Path) -> None:
     assert "host: mariadb.local" in mariadb_config
     assert "port: 3307" in mariadb_config
     assert "database: demo_shared" in mariadb_config
+    assert "url: null" in mariadb_config
+    assert "password: null" in mariadb_config
     assert 'table_prefix: "todo_"' in mariadb_config
+
+    secrets = (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    assert "resolver: env" in secrets
+    assert "adapters.mariadb.url: MARIADB_URL" in secrets
+    assert "adapters.mariadb.password: MARIADB_PASSWORD" in secrets
+    assert "secret-password" not in mariadb_config
+    assert "secret-password" not in secrets
+
+
+@pytest.mark.parametrize("secret_param", ["password", "url"])
+def test_add_mariadb_adapter_rejects_direct_secret_params(tmp_path: Path, secret_param: str) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            adapter="mariadb",
+            adapter_params={
+                "database": "demo_shared",
+                secret_param: "secret-password",
+            },
+            yes=True,
+        )
+
+    assert not (project_dir / "config" / "adapters" / "outbound" / "mariadb.yaml").exists()
+    assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
 def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -160,6 +160,14 @@ def test_repository_adapter_specs_include_config_and_parameters() -> None:
     assert [parameter.name for parameter in duckdb.parameters] == ["path"]
     assert mariadb is not None
     assert mariadb.config_path == "config/adapters/outbound/mariadb.yaml"
+    assert [mapping.field_path for mapping in mariadb.secret_mappings] == [
+        "adapters.mariadb.url",
+        "adapters.mariadb.password",
+    ]
+    assert [mapping.secret_key for mapping in mariadb.secret_mappings] == [
+        "MARIADB_URL",
+        "MARIADB_PASSWORD",
+    ]
     assert [parameter.name for parameter in mariadb.parameters] == [
         "host",
         "port",
@@ -207,6 +215,16 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert duckdb["name"] == "duckdb"
     assert duckdb["config_path"] == "config/adapters/outbound/duckdb.yaml"
     assert [parameter["name"] for parameter in duckdb["parameters"]] == ["path"]
+    mariadb = payload[0]["adapters"][3]
+    assert mariadb["name"] == "mariadb"
+    assert [mapping["field_path"] for mapping in mariadb["secret_mappings"]] == [
+        "adapters.mariadb.url",
+        "adapters.mariadb.password",
+    ]
+    assert [mapping["secret_key"] for mapping in mariadb["secret_mappings"]] == [
+        "MARIADB_URL",
+        "MARIADB_PASSWORD",
+    ]
     assert payload[1]["name"] == "api"
     assert [adapter["name"] for adapter in payload[1]["adapters"]] == ["fastapi"]
     assert payload[2]["name"] == "mcp"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -128,6 +128,41 @@ multitenant: false
 path: data/
 ```
 
+`mariadb` est l'option SQL serveur. Il reste un adapter repository optionnel: installer
+`arclith[mariadb]` uniquement dans les services qui l'utilisent. Le package de base et les tests
+sans extra ne doivent pas importer SQLAlchemy ou `asyncmy`.
+
+La CLI génère la configuration non secrète dans `config/adapters/outbound/mariadb.yaml` et ajoute
+les mappings secrets dans `config/secrets.yaml`. Ne pas passer ni écrire de mot de passe réel dans
+`mariadb.yaml`; utiliser `MARIADB_PASSWORD` ou `MARIADB_URL`, ou remplacer le resolver `env` par
+`vault` selon l'environnement.
+
+```yaml
+# config/adapters/adapters.yaml
+repository: mariadb
+
+# config/adapters/outbound/mariadb.yaml
+url: null
+host: 127.0.0.1
+port: 3306
+database: my_service
+user: app
+password: null
+driver: asyncmy
+table_prefix: ""
+multitenant: false
+
+# config/secrets.yaml
+resolver: env
+mappings:
+  adapters.mariadb.url: MARIADB_URL
+  adapters.mariadb.password: MARIADB_PASSWORD
+```
+
+En single-tenant, `database` est requis quand `url` n'est pas fourni par les secrets. En
+multitenant, le contexte tenant peut fournir `url`, `database`, `user`, `password`, `host`, `port`,
+`driver` ou `table_prefix`.
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -418,8 +418,15 @@ def test_mariadb_settings_with_database():
     assert settings.table_prefix == "app_"
 
 
+def test_mariadb_settings_with_url_only():
+    settings = MariaDBSettings(url="mysql+asyncmy://app@localhost:3306/demo")
+
+    assert settings.url == "mysql+asyncmy://app@localhost:3306/demo"
+    assert settings.database is None
+
+
 def test_mariadb_settings_requires_url_or_database():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="database est requis quand url n'est pas configure"):
         MariaDBSettings()
 
 
@@ -446,7 +453,7 @@ def test_mongodb_requires_section():
 
 
 def test_mariadb_requires_section():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"repository=mariadb mais aucune section \[adapters.mariadb\]"):
         AppConfig.model_validate({"adapters": {"repository": "mariadb"}})
 
 
@@ -639,3 +646,35 @@ def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.Monkey
     assert config.adapters.mongodb is not None
     assert config.adapters.mongodb.uri == "mongodb://env-mongo:27017"
     assert config.adapters.mongodb.db_name == "demo_shared"
+
+
+def test_adapters_mariadb_url_and_password_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MARIADB_URL", "mysql+asyncmy://env-app@db:3306/env_demo")
+    monkeypatch.setenv("MARIADB_PASSWORD", "env-password")
+    config_dir = _make_config_dir({
+        "adapters/adapters.yaml": {"repository": "mariadb"},
+        "adapters/outbound/mariadb.yaml": {
+            "url": None,
+            "host": "127.0.0.1",
+            "port": 3306,
+            "database": "demo_shared",
+            "user": "app",
+            "password": None,
+            "driver": "asyncmy",
+            "table_prefix": "",
+            "multitenant": False,
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "adapters.mariadb.url": "MARIADB_URL",
+                "adapters.mariadb.password": "MARIADB_PASSWORD",
+            },
+        },
+    })
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.mariadb is not None
+    assert config.adapters.mariadb.url == "mysql+asyncmy://env-app@db:3306/env_demo"
+    assert config.adapters.mariadb.password == "env-password"

--- a/tests/units/infrastructure/test_repository_factory.py
+++ b/tests/units/infrastructure/test_repository_factory.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
@@ -72,3 +75,43 @@ def test_mariadb_returns_mariadb_repository(logger):
     ))
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, MariaDBRepository)
+
+
+def test_import_arclith_does_not_require_mariadb_extra():
+    script = """
+import importlib.abc
+import sys
+
+
+class BlockMariaDBExtras(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "sqlalchemy" or fullname.startswith("sqlalchemy."):
+            raise ModuleNotFoundError(fullname)
+        if fullname == "asyncmy" or fullname.startswith("asyncmy."):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+
+sys.meta_path.insert(0, BlockMariaDBExtras())
+
+import arclith
+from arclith.domain.models.entity import Entity
+from arclith.infrastructure.repository_factory import default_repository_registry
+
+
+class SmokeItem(Entity):
+    pass
+
+
+default_repository_registry(SmokeItem)
+print(arclith.__name__)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "arclith"


### PR DESCRIPTION
## Summary
- Generate MariaDB repository config with non-secret `url: null` and `password: null` placeholders.
- Map `adapters.mariadb.url` and `adapters.mariadb.password` to `MARIADB_URL` and `MARIADB_PASSWORD` in `config/secrets.yaml`.
- Cover direct secret param rejection, env secret loading, clear single-tenant validation errors, and import smoke without MariaDB extras.
- Document MariaDB secret mapping in the capability docs and CLI README.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/infrastructure/test_repository_factory.py tests/units/adapters/outbound/test_mariadb_config.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py arclith_cli/capabilities.py`
- `uv run ruff check tests/units/infrastructure/test_config.py tests/units/infrastructure/test_repository_factory.py`
- `make docs`
- `make quality`

Closes #61