### PR TITLE
Cover FastAPI CLI runtime configuration

### DIFF
--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -289,24 +289,37 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
 
 def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config" / "adapters" / "inbound" / "fastapi.yaml"
 
-    for _ in range(2):
-        add_adapter_cmd(
-            project_dir=project_dir,
-            capability_name="api",
-            adapter="fastapi",
-            adapter_params={
-                "host": "127.0.0.1",
-                "port": "8080",
-                "reload": "false",
-            },
-            yes=True,
-        )
-
-    config = (project_dir / "config" / "adapters" / "inbound" / "fastapi.yaml").read_text(
-        encoding="utf-8"
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="api",
+        adapter="fastapi",
+        adapter_params={
+            "host": "127.0.0.1",
+            "port": "8080",
+            "reload": "false",
+        },
+        yes=True,
     )
-    assert config == "host: 127.0.0.1\nport: 8080\nreload: false\n"
+    first_config = config_path.read_text(encoding="utf-8")
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="api",
+        adapter="fastapi",
+        adapter_params={
+            "host": "127.0.0.1",
+            "port": "8080",
+            "reload": "false",
+        },
+        yes=True,
+    )
+    second_config = config_path.read_text(encoding="utf-8")
+    config = yaml.safe_load(second_config)
+
+    assert second_config == first_config
+    assert config == {"host": "127.0.0.1", "port": 8080, "reload": False}
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -290,29 +290,39 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
 def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 
-    add_adapter_cmd(
-        project_dir=project_dir,
-        capability_name="api",
-        adapter="fastapi",
-        adapter_params={
-            "host": "127.0.0.1",
-            "port": "8080",
-            "reload": "false",
-        },
-        yes=True,
-    )
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="api",
+            adapter="fastapi",
+            adapter_params={
+                "host": "127.0.0.1",
+                "port": "8080",
+                "reload": "false",
+            },
+            yes=True,
+        )
 
     config = (project_dir / "config" / "adapters" / "inbound" / "fastapi.yaml").read_text(
         encoding="utf-8"
     )
-    assert "host: 127.0.0.1" in config
-    assert "port: 8080" in config
-    assert "reload: false" in config
+    assert config == "host: 127.0.0.1\nport: 8080\nreload: false\n"
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "fastapi").exists()
+    assert not (package_root / "adapters" / "inbound" / "fastapi").exists()
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+    app = arclith.fastapi()
+
+    assert arclith.config.api.host == "127.0.0.1"
+    assert arclith.config.api.port == 8080
+    assert arclith.config.api.reload is False
+    assert app.title == arclith.config.app.name
 
 
 def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -> None:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -183,6 +183,23 @@ reload: true
 Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml`: le chemin
 `config/adapters/inbound/fastapi.yaml` est chargé directement dans `AppConfig.api`.
 
+La CLI configure uniquement le runtime FastAPI. Les routers métier restent dans le projet généré et
+doivent traduire HTTP vers les ports inbound ou les use cases applicatifs, jamais vers un repository
+concret. Le branchement attendu est donc:
+
+```python
+from arclith import Arclith
+from my_service.adapters.inbound.fastapi.routes import router
+
+arclith = Arclith("config")
+app = arclith.fastapi()
+app.include_router(router)
+```
+
+Le module `routes` appartient au projet consommateur: il construit ou injecte ses use cases, puis
+appelle les ports applicatifs. `arclith-cli add-adapter --capability api --adapter fastapi` ne
+génère pas ces routes pour éviter de mélanger transport HTTP et logique métier.
+
 ### `mcp`
 
 Capacité inbound pour exposer les cas d'usage via MCP.


### PR DESCRIPTION
## Summary
- Cover `api/fastapi` add-adapter idempotence with `--param port=8080` and `reload=false`.
- Assert generated FastAPI config loads into `AppConfig.api` and can build `Arclith(...).fastapi()`.
- Document the expected project-owned router wiring to inbound ports/use cases, not concrete repositories.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `make docs`
- `make quality`

Closes #62