### PR TITLE
Cover FastMCP CLI runtime configuration

### DIFF
--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -340,6 +340,7 @@ def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -
 
 def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config" / "adapters" / "inbound" / "fastmcp.yaml"
 
     add_adapter_cmd(
         project_dir=project_dir,
@@ -351,17 +352,52 @@ def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -
         },
         yes=True,
     )
+    first_config = config_path.read_text(encoding="utf-8")
 
-    config = (project_dir / "config" / "adapters" / "inbound" / "fastmcp.yaml").read_text(
-        encoding="utf-8"
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="mcp",
+        adapter="fastmcp",
+        adapter_params={
+            "host": "127.0.0.1",
+            "port": "9001",
+        },
+        yes=True,
     )
-    assert "host: 127.0.0.1" in config
-    assert "port: 9001" in config
+    second_config = config_path.read_text(encoding="utf-8")
+    config = yaml.safe_load(second_config)
+
+    assert second_config == first_config
+    assert config == {"host": "127.0.0.1", "port": 9001}
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "fastmcp").exists()
+    assert not (package_root / "adapters" / "inbound" / "fastmcp").exists()
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+    arclith.fastmcp("demo-service")
+
+    class FakeMcp:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def run(self, **kwargs: object) -> None:
+            self.calls.append(kwargs)
+
+    fake_mcp = FakeMcp()
+    arclith.run_mcp_sse(fake_mcp)
+    arclith.run_mcp_http(fake_mcp)
+
+    assert arclith.config.mcp.host == "127.0.0.1"
+    assert arclith.config.mcp.port == 9001
+    assert fake_mcp.calls == [
+        {"transport": "sse", "host": "127.0.0.1", "port": 9001},
+        {"transport": "streamable-http", "host": "127.0.0.1", "port": 9001},
+    ]
 
 
 def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> None:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -220,6 +220,21 @@ port: 8001
 Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml`: le chemin
 `config/adapters/inbound/fastmcp.yaml` est chargé directement dans `AppConfig.mcp`.
 
+FastMCP expose les mêmes use cases que l'API, via tools/resources/prompts définis dans le projet
+consommateur. Les tools MCP appellent les ports inbound ou use cases applicatifs; ils ne doivent pas
+contourner l'application pour appeler un repository concret.
+
+Transports supportés par Arclith:
+
+- `run_mcp_sse(mcp)`: lance FastMCP avec `transport="sse"`, `host` et `port` depuis `AppConfig.mcp`;
+- `run_mcp_http(mcp)`: lance FastMCP avec `transport="streamable-http"`, `host` et `port` depuis
+  `AppConfig.mcp`.
+
+`stdio` n'a pas de runner Arclith: utiliser SSE ou streamable HTTP pour garder un déploiement
+compatible API/MCP/probes. L'instrumentation MCP reste transverse: enregistrer les tools sur
+`mcp`, puis appeler `Arclith.instrument_mcp(mcp)` si les probes sont activées. Cette instrumentation
+ne fait pas partie de la capability `mcp/fastmcp`.
+
 ### `llm`
 
 Capacité outbound pour configurer le modèle utilisé par les interpréteurs d'intention et agents.


### PR DESCRIPTION
## Summary
- Cover `mcp/fastmcp` add-adapter idempotence and YAML-parsed config values.
- Assert generated config loads into `AppConfig.mcp`, can instantiate `Arclith(...).fastmcp(...)`, and routes SSE/HTTP runners with configured host/port.
- Document FastMCP use-case sharing with API, supported Arclith transports, and `instrument_mcp`/probes as separate transverse wiring.

## Design note
- No `transport` parameter was added to `mcp/fastmcp`: Arclith already exposes transport explicitly through `run_mcp_sse()` and `run_mcp_http()`, while `fastmcp.yaml` owns shared runtime host/port.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `make docs`
- `make quality`

Closes #63