### PR TITLE
Cover LM Studio CLI provider config

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -201,7 +201,9 @@ uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
-`AppConfig.adapters.lm`. Les adapters `llm/openai` et `llm/anthropic` génèrent aussi un mapping
+`AppConfig.adapters.lm`. Adapter `model_name` au modèle chargé dans LM Studio et utiliser
+`host.docker.internal` comme `base_url` si le projet tourne dans Docker alors que LM Studio tourne
+sur l'hôte. Les adapters `llm/openai` et `llm/anthropic` génèrent aussi un mapping
 `config/secrets.yaml` vers `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`.
 
 L'adapter `repository/mongodb` génère `config/adapters/outbound/mongodb.yaml` avec `uri: null`, puis

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -430,6 +430,16 @@ def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> No
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "lmstudio").exists()
 
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.lm is not None
+    assert arclith.config.adapters.lm.provider == "openai"
+    assert arclith.config.adapters.lm.model_name == "qwen/qwen3.5-9b"
+    assert arclith.config.adapters.lm.api_key == "lm-studio"
+    assert arclith.config.adapters.lm.base_url == "http://127.0.0.1:1234/v1"
+
 
 def test_add_openai_llm_adapter_generates_secret_mapping(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -258,6 +258,17 @@ base_url: "http://127.0.0.1:1234/v1"
 Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml`: le chemin
 `config/adapters/outbound/lm.yaml` est chargé directement dans `AppConfig.adapters.lm`.
 
+Pour LM Studio, `model_name` doit correspondre au modèle réellement chargé dans l'application
+locale. Le `api_key` peut rester une valeur factice comme `lm-studio` si LM Studio n'authentifie pas
+les requêtes. Les tests Arclith valident uniquement la construction du provider OpenAI-compatible;
+ils n'appellent pas de modèle réel.
+
+Choisir le `base_url` selon l'emplacement du processus qui exécute Arclith:
+
+- service lancé sur la même machine que LM Studio: `http://127.0.0.1:1234/v1`;
+- service lancé dans Docker et LM Studio sur l'hôte: `http://host.docker.internal:1234/v1`;
+- service et LM Studio dans le même réseau Docker: utiliser le nom DNS du service LM Studio.
+
 Pour OpenAI et Anthropic, la CLI génère `config/secrets.yaml` avec un resolver `env`, afin que
 `adapters.lm.api_key` soit alimenté par `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY` sans écrire la clé
 dans `lm.yaml`.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -259,7 +259,7 @@ Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml
 `config/adapters/outbound/lm.yaml` est chargé directement dans `AppConfig.adapters.lm`.
 
 Pour LM Studio, `model_name` doit correspondre au modèle réellement chargé dans l'application
-locale. Le `api_key` peut rester une valeur factice comme `lm-studio` si LM Studio n'authentifie pas
+locale. L'`api_key` peut rester une valeur factice comme `lm-studio` si LM Studio n'authentifie pas
 les requêtes. Les tests Arclith valident uniquement la construction du provider OpenAI-compatible;
 ils n'appellent pas de modèle réel.
 

--- a/tests/units/infrastructure/test_lm.py
+++ b/tests/units/infrastructure/test_lm.py
@@ -50,6 +50,24 @@ def test_build_openai_model():
     assert model.profile["supports_json_object_output"] is False
 
 
+def test_build_lmstudio_openai_compatible_model_without_network_call():
+    settings = LMSettings(
+        provider="openai",
+        model_name="local-model",
+        api_key="lm-studio",
+        base_url="http://127.0.0.1:1234/v1",
+    )
+
+    model = build_pydantic_ai_model(settings)
+
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    assert isinstance(model, OpenAIChatModel)
+    assert model.profile["default_structured_output_mode"] == "native"
+    assert model.profile["supports_json_schema_output"] is True
+    assert model.profile["supports_json_object_output"] is False
+
+
 def test_build_openai_model_requires_base_url():
     settings = LMSettings(provider="openai", model_name="gpt-4o", api_key="sk-x")
     with pytest.raises(ValueError, match="base_url is required"):


### PR DESCRIPTION
## Summary
- validate that `llm/lmstudio` generated config loads through `Arclith`
- cover the OpenAI-compatible LM Studio factory path without making a network/model call
- document LM Studio `model_name`, fake local `api_key`, and host vs Docker `base_url` values

Closes #64

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `uv run ruff check tests/units/infrastructure/test_config.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `make docs`
- `make quality`