### PR TITLE
Harden OpenAI LLM secret handling

### DIFF
--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -339,16 +339,13 @@ def _build_merged_dict(config_dir: Path) -> dict:
 
 
 def _resolve_secrets(data: dict, base_path: Path) -> dict:
-    from contextlib import suppress
-
     from arclith.infrastructure.secret_factory import build_secret_resolver
     from arclith.infrastructure.secret_loader import resolve_dict_secrets
 
     resolver = build_secret_resolver(data, base_path)
-    if resolver:
-        with suppress(Exception):
-            data = resolve_dict_secrets(data, resolver)
-    return data
+    if resolver is None:
+        return data
+    return resolve_dict_secrets(data, resolver)
 
 
 # ── Public loaders ────────────────────────────────────────────────────────────

--- a/arclith/infrastructure/secret_loader.py
+++ b/arclith/infrastructure/secret_loader.py
@@ -29,7 +29,7 @@ def resolve_dict_secrets(data: dict, resolver: "SecretResolver") -> dict:
         value = resolver.get(field_path, secret_key)
         if value is not None:
             _set_nested(result, field_path, value)
-        else:
+        elif not _has_explicit_null(result, field_path):
             missing.append(field_path)
 
     if missing:
@@ -41,6 +41,15 @@ def resolve_dict_secrets(data: dict, resolver: "SecretResolver") -> dict:
     return result
 
 
+def _has_explicit_null(data: dict, path: str) -> bool:
+    current: object = data
+    for key in path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return False
+        current = current[key]
+    return current is None
+
+
 def _set_nested(data: dict, path: str, value: str) -> None:
     keys = path.split(".")
     current = data
@@ -49,4 +58,3 @@ def _set_nested(data: dict, path: str, value: str) -> None:
             current[key] = {}
         current = current[key]
     current[keys[-1]] = value
-

--- a/cli/README.md
+++ b/cli/README.md
@@ -204,7 +204,8 @@ L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé da
 `AppConfig.adapters.lm`. Adapter `model_name` au modèle chargé dans LM Studio et utiliser
 `host.docker.internal` comme `base_url` si le projet tourne dans Docker alors que LM Studio tourne
 sur l'hôte. Les adapters `llm/openai` et `llm/anthropic` génèrent aussi un mapping
-`config/secrets.yaml` vers `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`.
+`config/secrets.yaml` vers `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`; la clé réelle reste dans `.env`
+local gitignoré, l'environnement runtime ou Vault.
 
 L'adapter `repository/mongodb` génère `config/adapters/outbound/mongodb.yaml` avec `uri: null`, puis
 mappe `adapters.mongodb.uri` vers `MONGODB_URI` dans `config/secrets.yaml`. L'URI réelle reste dans

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -404,7 +404,7 @@ OPENAI_API_KEY={api_key}
                     name="model_name",
                     kind="string",
                     prompt="Modèle OpenAI",
-                    default="gpt-4o-mini",
+                    default="remplacer-par-model-id-openai",
                 ),
                 ParameterSpec(
                     name="base_url",

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -441,7 +441,11 @@ def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> No
     assert arclith.config.adapters.lm.base_url == "http://127.0.0.1:1234/v1"
 
 
-def test_add_openai_llm_adapter_generates_secret_mapping(tmp_path: Path) -> None:
+def test_add_openai_llm_adapter_generates_secret_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
 
@@ -456,6 +460,7 @@ def test_add_openai_llm_adapter_generates_secret_mapping(tmp_path: Path) -> None
         },
         yes=True,
     )
+    captured = capsys.readouterr()
 
     config = (project_dir / "config" / "adapters" / "outbound" / "lm.yaml").read_text(
         encoding="utf-8"
@@ -476,6 +481,54 @@ def test_add_openai_llm_adapter_generates_secret_mapping(tmp_path: Path) -> None
     assert "llm:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
+    assert "sk-test" not in captured.out
+    assert "sk-test" not in captured.err
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.lm is not None
+    assert arclith.config.adapters.lm.provider == "openai"
+    assert arclith.config.adapters.lm.model_name == "gpt-4o-mini"
+    assert arclith.config.adapters.lm.api_key == "sk-test"
+    assert arclith.config.adapters.lm.base_url == "https://api.openai.com/v1"
+
+
+def test_add_openai_llm_adapter_without_key_does_not_generate_fake_secret(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="llm",
+        adapter="openai",
+        adapter_params={
+            "model_name": "custom-openai-model",
+            "base_url": "https://api.openai.com/v1",
+        },
+        yes=True,
+    )
+    captured = capsys.readouterr()
+
+    env = (project_dir / ".env").read_text(encoding="utf-8")
+    config = (project_dir / "config" / "adapters" / "outbound" / "lm.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "EXISTING=value" in env
+    assert "OPENAI_API_KEY=" not in env
+    assert "sk-" not in env
+    assert 'api_key: ""' in config
+    assert "adapters.lm.api_key: OPENAI_API_KEY" in (
+        project_dir / "config" / "secrets.yaml"
+    ).read_text(encoding="utf-8")
+    assert "sk-" not in captured.out
+    assert "sk-" not in captured.err
 
 
 def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -91,6 +91,10 @@ def test_llm_capability_catalog_declares_model_adapters() -> None:
     assert openai.config_path == "config/adapters/outbound/lm.yaml"
     assert openai.env_path == ".env"
     assert openai.entity_scoped is False
+    openai_parameters = {parameter.name: parameter for parameter in openai.parameters}
+    assert openai_parameters["model_name"].default == "remplacer-par-model-id-openai"
+    assert openai_parameters["api_key"].secret is True
+    assert openai_parameters["api_key"].default == ""
     assert [mapping.field_path for mapping in openai.secret_mappings] == ["adapters.lm.api_key"]
 
     assert anthropic is not None
@@ -231,6 +235,11 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [adapter["name"] for adapter in payload[2]["adapters"]] == ["fastmcp"]
     assert payload[3]["name"] == "llm"
     assert [adapter["name"] for adapter in payload[3]["adapters"]] == ["lmstudio", "openai", "anthropic"]
+    openai = payload[3]["adapters"][1]
+    openai_parameters = {parameter["name"]: parameter for parameter in openai["parameters"]}
+    assert openai_parameters["model_name"]["default"] == "remplacer-par-model-id-openai"
+    assert openai_parameters["api_key"]["secret"] is True
+    assert openai_parameters["api_key"]["default"] == ""
     assert payload[4]["name"] == "agent"
     assert [adapter["name"] for adapter in payload[4]["adapters"]] == ["langgraph"]
     assert payload[5]["name"] == "observability"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -273,6 +273,13 @@ Pour OpenAI et Anthropic, la CLI génère `config/secrets.yaml` avec un resolver
 `adapters.lm.api_key` soit alimenté par `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY` sans écrire la clé
 dans `lm.yaml`.
 
+Pour OpenAI, `model_name` est un placeholder généré par défaut: passer explicitement le modèle
+souhaité via `--param model_name=...`. La clé réelle ne doit pas être commitée: soit elle est passée
+à la CLI pour être fusionnée dans `.env` local gitignoré, soit elle est fournie au runtime par
+variable d'environnement, soit `config/secrets.yaml` est basculé vers un resolver Vault. Si le
+resolver `env` est actif et que `OPENAI_API_KEY` manque au démarrage, `load_config_dir()` échoue avec
+un message `Secrets non résolus` qui liste `adapters.lm.api_key`.
+
 ### `observability`
 
 Capacité outbound pour brancher l'observabilité et le banc de test agent.
@@ -455,7 +462,7 @@ Pour OpenAI:
 arclith-cli add-adapter \
   --capability llm \
   --adapter openai \
-  --param model_name=gpt-4o-mini \
+  --param model_name="<model-id-openai>" \
   --param api_key="$OPENAI_API_KEY" \
   --yes
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -291,6 +291,10 @@ L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé da
 `AppConfig.adapters.lm`. L'interpréteur d'intention applicatif consomme ensuite un `LLMPort`;
 LangGraph ne fait qu'orchestrer les nœuds et injecter l'adapter outbound.
 
+Pour `llm/openai`, choisir explicitement le modèle et garder la clé hors du dépôt: la CLI mappe
+`adapters.lm.api_key` vers `OPENAI_API_KEY` via `config/secrets.yaml`, puis la valeur réelle vient de
+`.env` local gitignoré, de l'environnement runtime ou d'un resolver Vault.
+
 Le `langgraph.json` généré pointe vers `.env` pour que le serveur local charge les variables LangSmith.
 Les tests conversationnels et traces agent se font ensuite dans LangSmith Studio.
 

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -623,6 +623,30 @@ def test_adapters_lm_api_key_loaded_from_env_mapping(monkeypatch: pytest.MonkeyP
     assert config.adapters.lm.api_key == "sk-openai"
 
 
+def test_adapters_lm_missing_env_secret_raises_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config_dir = _make_config_dir({
+        "adapters/adapters.yaml": {"repository": "memory"},
+        "adapters/outbound/lm.yaml": {
+            "provider": "openai",
+            "model_name": "gpt-4o-mini",
+            "api_key": "",
+            "base_url": "https://api.openai.com/v1",
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "adapters.lm.api_key": "OPENAI_API_KEY",
+            },
+        },
+    })
+
+    with pytest.raises(RuntimeError, match="Secrets non résolus.*adapters.lm.api_key"):
+        load_config_dir(config_dir)
+
+
 def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MONGODB_URI", "mongodb://env-mongo:27017")
     config_dir = _make_config_dir({

--- a/tests/units/infrastructure/test_secret_factory.py
+++ b/tests/units/infrastructure/test_secret_factory.py
@@ -161,9 +161,21 @@ def test_resolve_raises_on_unresolved_secret() -> None:
         resolve_dict_secrets(data, resolver)
 
 
+def test_resolve_keeps_null_placeholder_when_secret_is_unresolved() -> None:
+    data = {
+        "adapters": {"mongodb": {"uri": None, "db_name": "fallback"}},
+        "secrets": {"mappings": {"adapters.mongodb.uri": "MONGODB_URI"}},
+    }
+    resolver = _make_resolver({"adapters.mongodb.uri": None})
+
+    result = resolve_dict_secrets(data, resolver)
+
+    assert result["adapters"]["mongodb"]["uri"] is None
+    assert result["adapters"]["mongodb"]["db_name"] == "fallback"
+
+
 def test_resolve_creates_intermediate_dicts() -> None:
     data = {"secrets": {"mappings": {"a.b.c": "p"}}}
     resolver = _make_resolver({"a.b.c": "deep-value"})
     result = resolve_dict_secrets(data, resolver)
     assert result["a"]["b"]["c"] == "deep-value"
-


### PR DESCRIPTION
## Summary
- expose `llm/openai` api_key as a JSON secret parameter and switch the default model to an explicit placeholder
- validate generated OpenAI config loading through `Arclith` without logging the API key or inventing a fake `sk-...` secret
- let unresolved required secrets fail with an actionable runtime error while preserving existing `null` fallback placeholders such as MongoDB URI
- document `.env`, runtime env, and Vault paths for OpenAI secrets

Closes #65

## Design note
`config/secrets.yaml` mappings now stay strict for absent or empty fields such as `adapters.lm.api_key`, but a YAML value explicitly set to `null` remains an optional placeholder so existing local fallback configs keep loading.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/infrastructure/test_secret_factory.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `uv run ruff check arclith/infrastructure/config.py arclith/infrastructure/secret_loader.py tests/units/infrastructure/test_config.py tests/units/infrastructure/test_secret_factory.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `make docs`
- `make quality`