### PR TITLE
Harden Anthropic LLM secret handling

### DIFF
--- a/arclith/infrastructure/lm.py
+++ b/arclith/infrastructure/lm.py
@@ -14,7 +14,7 @@ def build_pydantic_ai_model(settings: LMSettings):
             from pydantic_ai.models.anthropic import AnthropicModel
             from pydantic_ai.profiles.anthropic import AnthropicModelProfile
             from pydantic_ai.providers.anthropic import AnthropicProvider
-        except ImportError as exc:
+        except ModuleNotFoundError as exc:
             raise RuntimeError(
                 "Le provider LLM 'anthropic' requiert l'extra optionnel "
                 "`arclith[langgraph]` avec le support pydantic-ai Anthropic."
@@ -33,7 +33,7 @@ def build_pydantic_ai_model(settings: LMSettings):
     try:
         from pydantic_ai.models.openai import OpenAIChatModel, OpenAIModelProfile
         from pydantic_ai.providers.openai import OpenAIProvider
-    except ImportError as exc:
+    except ModuleNotFoundError as exc:
         raise RuntimeError(
             "Le provider LLM 'openai' requiert l'extra optionnel "
             "`arclith[langgraph]` avec le support pydantic-ai OpenAI."

--- a/arclith/infrastructure/lm.py
+++ b/arclith/infrastructure/lm.py
@@ -10,9 +10,15 @@ def build_pydantic_ai_model(settings: LMSettings):
     qui n'installent pas l'extra [langgraph].
     """
     if settings.provider == "anthropic":
-        from pydantic_ai.models.anthropic import AnthropicModel
-        from pydantic_ai.profiles.anthropic import AnthropicModelProfile
-        from pydantic_ai.providers.anthropic import AnthropicProvider
+        try:
+            from pydantic_ai.models.anthropic import AnthropicModel
+            from pydantic_ai.profiles.anthropic import AnthropicModelProfile
+            from pydantic_ai.providers.anthropic import AnthropicProvider
+        except ImportError as exc:
+            raise RuntimeError(
+                "Le provider LLM 'anthropic' requiert l'extra optionnel "
+                "`arclith[langgraph]` avec le support pydantic-ai Anthropic."
+            ) from exc
 
         return AnthropicModel(
             settings.model_name,
@@ -24,8 +30,14 @@ def build_pydantic_ai_model(settings: LMSettings):
     if not settings.base_url:
         raise ValueError("base_url is required for provider='openai'")
 
-    from pydantic_ai.models.openai import OpenAIChatModel, OpenAIModelProfile
-    from pydantic_ai.providers.openai import OpenAIProvider
+    try:
+        from pydantic_ai.models.openai import OpenAIChatModel, OpenAIModelProfile
+        from pydantic_ai.providers.openai import OpenAIProvider
+    except ImportError as exc:
+        raise RuntimeError(
+            "Le provider LLM 'openai' requiert l'extra optionnel "
+            "`arclith[langgraph]` avec le support pydantic-ai OpenAI."
+        ) from exc
 
     return OpenAIChatModel(
         settings.model_name,

--- a/cli/README.md
+++ b/cli/README.md
@@ -206,6 +206,8 @@ L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé da
 sur l'hôte. Les adapters `llm/openai` et `llm/anthropic` génèrent aussi un mapping
 `config/secrets.yaml` vers `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`; la clé réelle reste dans `.env`
 local gitignoré, l'environnement runtime ou Vault.
+Utiliser `llm/anthropic` pour Claude via le provider Anthropic; utiliser `llm/openai` pour OpenAI,
+LM Studio ou tout endpoint OpenAI-compatible avec `base_url`.
 
 L'adapter `repository/mongodb` génère `config/adapters/outbound/mongodb.yaml` avec `uri: null`, puis
 mappe `adapters.mongodb.uri` vers `MONGODB_URI` dans `config/secrets.yaml`. L'URI réelle reste dans

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -448,7 +448,7 @@ ANTHROPIC_API_KEY={api_key}
                     name="model_name",
                     kind="string",
                     prompt="Modèle Anthropic",
-                    default="claude-sonnet-4-5",
+                    default="remplacer-par-model-id-anthropic",
                 ),
                 ParameterSpec(
                     name="api_key",

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -531,6 +531,64 @@ def test_add_openai_llm_adapter_without_key_does_not_generate_fake_secret(
     assert "sk-" not in captured.err
 
 
+def test_add_anthropic_llm_adapter_generates_idempotent_secret_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / ".env").write_text(
+        "EXISTING=value\nANTHROPIC_API_KEY=existing-local-key\n",
+        encoding="utf-8",
+    )
+    (project_dir / "config" / "secrets.yaml").write_text(
+        "resolver: env\nmappings:\n  adapters.lm.api_key: ANTHROPIC_API_KEY\n",
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="llm",
+            adapter="anthropic",
+            adapter_params={
+                "model_name": "claude-dev-model",
+            },
+            yes=True,
+        )
+    captured = capsys.readouterr()
+
+    config = (project_dir / "config" / "adapters" / "outbound" / "lm.yaml").read_text(
+        encoding="utf-8"
+    )
+    env = (project_dir / ".env").read_text(encoding="utf-8")
+    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+
+    assert "provider: anthropic" in config
+    assert 'model_name: "claude-dev-model"' in config
+    assert 'api_key: ""' in config
+    assert env.count("ANTHROPIC_API_KEY=existing-local-key") == 1
+    assert "EXISTING=value" in env
+    assert secrets["resolver"] == "env"
+    assert secrets["mappings"]["adapters.lm.api_key"] == "ANTHROPIC_API_KEY"
+    assert list(secrets["mappings"]).count("adapters.lm.api_key") == 1
+    assert "llm:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "existing-local-key" not in captured.out
+    assert "existing-local-key" not in captured.err
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.lm is not None
+    assert arclith.config.adapters.lm.provider == "anthropic"
+    assert arclith.config.adapters.lm.model_name == "claude-dev-model"
+    assert arclith.config.adapters.lm.api_key == "sk-ant-test"
+
+
 def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -101,6 +101,10 @@ def test_llm_capability_catalog_declares_model_adapters() -> None:
     assert anthropic.config_path == "config/adapters/outbound/lm.yaml"
     assert anthropic.env_path == ".env"
     assert anthropic.entity_scoped is False
+    anthropic_parameters = {parameter.name: parameter for parameter in anthropic.parameters}
+    assert anthropic_parameters["model_name"].default == "remplacer-par-model-id-anthropic"
+    assert anthropic_parameters["api_key"].secret is True
+    assert anthropic_parameters["api_key"].default == ""
     assert [mapping.secret_key for mapping in anthropic.secret_mappings] == ["ANTHROPIC_API_KEY"]
 
 
@@ -240,6 +244,11 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert openai_parameters["model_name"]["default"] == "remplacer-par-model-id-openai"
     assert openai_parameters["api_key"]["secret"] is True
     assert openai_parameters["api_key"]["default"] == ""
+    anthropic = payload[3]["adapters"][2]
+    anthropic_parameters = {parameter["name"]: parameter for parameter in anthropic["parameters"]}
+    assert anthropic_parameters["model_name"]["default"] == "remplacer-par-model-id-anthropic"
+    assert anthropic_parameters["api_key"]["secret"] is True
+    assert anthropic_parameters["api_key"]["default"] == ""
     assert payload[4]["name"] == "agent"
     assert [adapter["name"] for adapter in payload[4]["adapters"]] == ["langgraph"]
     assert payload[5]["name"] == "observability"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -280,6 +280,11 @@ variable d'environnement, soit `config/secrets.yaml` est basculé vers un resolv
 resolver `env` est actif et que `OPENAI_API_KEY` manque au démarrage, `load_config_dir()` échoue avec
 un message `Secrets non résolus` qui liste `adapters.lm.api_key`.
 
+Choisir `llm/anthropic` pour utiliser les modèles Claude via le provider Anthropic. Choisir
+`llm/openai` lorsque le modèle est exposé par le protocole OpenAI-compatible: OpenAI, LM Studio,
+Ollama ou un endpoint custom via `base_url`. Anthropic ne génère pas de `base_url`; la clé réelle est
+résolue de la même façon via `ANTHROPIC_API_KEY`, l'environnement runtime ou Vault.
+
 ### `observability`
 
 Capacité outbound pour brancher l'observabilité et le banc de test agent.
@@ -464,6 +469,17 @@ arclith-cli add-adapter \
   --adapter openai \
   --param model_name="<model-id-openai>" \
   --param api_key="$OPENAI_API_KEY" \
+  --yes
+```
+
+Pour Anthropic:
+
+```bash
+arclith-cli add-adapter \
+  --capability llm \
+  --adapter anthropic \
+  --param model_name="<model-id-anthropic>" \
+  --param api_key="$ANTHROPIC_API_KEY" \
   --yes
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -294,6 +294,8 @@ LangGraph ne fait qu'orchestrer les nœuds et injecter l'adapter outbound.
 Pour `llm/openai`, choisir explicitement le modèle et garder la clé hors du dépôt: la CLI mappe
 `adapters.lm.api_key` vers `OPENAI_API_KEY` via `config/secrets.yaml`, puis la valeur réelle vient de
 `.env` local gitignoré, de l'environnement runtime ou d'un resolver Vault.
+Utiliser `llm/anthropic` pour Claude via le provider Anthropic; garder `llm/openai` pour OpenAI,
+LM Studio ou tout endpoint OpenAI-compatible avec `base_url`.
 
 Le `langgraph.json` généré pointe vers `.env` pour que le serveur local charge les variables LangSmith.
 Les tests conversationnels et traces agent se font ensuite dans LangSmith Studio.

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -647,6 +647,56 @@ def test_adapters_lm_missing_env_secret_raises_actionable_error(
         load_config_dir(config_dir)
 
 
+def test_adapters_lm_anthropic_api_key_loaded_from_env_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    config_dir = _make_config_dir({
+        "adapters/adapters.yaml": {"repository": "memory"},
+        "adapters/outbound/lm.yaml": {
+            "provider": "anthropic",
+            "model_name": "claude-dev-model",
+            "api_key": "",
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+            },
+        },
+    })
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.lm is not None
+    assert config.adapters.lm.provider == "anthropic"
+    assert config.adapters.lm.model_name == "claude-dev-model"
+    assert config.adapters.lm.api_key == "sk-ant-env"
+
+
+def test_adapters_lm_missing_anthropic_env_secret_raises_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    config_dir = _make_config_dir({
+        "adapters/adapters.yaml": {"repository": "memory"},
+        "adapters/outbound/lm.yaml": {
+            "provider": "anthropic",
+            "model_name": "claude-dev-model",
+            "api_key": "",
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+            },
+        },
+    })
+
+    with pytest.raises(RuntimeError, match="Secrets non résolus.*adapters.lm.api_key"):
+        load_config_dir(config_dir)
+
+
 def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MONGODB_URI", "mongodb://env-mongo:27017")
     config_dir = _make_config_dir({

--- a/tests/units/infrastructure/test_lm.py
+++ b/tests/units/infrastructure/test_lm.py
@@ -48,7 +48,7 @@ def test_build_anthropic_model_reports_missing_optional_provider(monkeypatch: py
         level: int = 0,
     ):
         if name.startswith("pydantic_ai.models.anthropic"):
-            raise ImportError("anthropic provider unavailable")
+            raise ModuleNotFoundError("No module named 'pydantic_ai.models.anthropic'", name=name)
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fail_anthropic_import)

--- a/tests/units/infrastructure/test_lm.py
+++ b/tests/units/infrastructure/test_lm.py
@@ -1,3 +1,5 @@
+import builtins
+
 import pytest
 
 from arclith.infrastructure.config import LMSettings
@@ -33,6 +35,27 @@ def test_build_anthropic_model():
     from pydantic_ai.models.anthropic import AnthropicModel
     assert isinstance(model, AnthropicModel)
     assert model.profile["default_structured_output_mode"] == "native"
+
+
+def test_build_anthropic_model_reports_missing_optional_provider(monkeypatch: pytest.MonkeyPatch):
+    real_import = builtins.__import__
+
+    def fail_anthropic_import(
+        name: str,
+        globals: dict | None = None,
+        locals: dict | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ):
+        if name.startswith("pydantic_ai.models.anthropic"):
+            raise ImportError("anthropic provider unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_anthropic_import)
+    settings = LMSettings(provider="anthropic", model_name="claude-dev-model", api_key="sk-ant-test")
+
+    with pytest.raises(RuntimeError, match=r"arclith\[langgraph\].*Anthropic"):
+        build_pydantic_ai_model(settings)
 
 
 def test_build_openai_model():


### PR DESCRIPTION
## Summary
- validate `llm/anthropic` catalog metadata, generated config, secret mapping, and idempotent `.env`/`config/secrets.yaml` merges
- switch the generated Anthropic model default to an explicit placeholder
- keep provider imports lazy and raise an actionable runtime error if the optional `arclith[langgraph]` provider support is missing
- document when to choose Anthropic vs OpenAI-compatible providers

Closes #66

## Design note
This builds on #65 secret-loading semantics: empty required secret fields fail clearly, while explicit `null` placeholders remain valid for existing fallback adapters. Anthropic uses the same `adapters.lm.api_key` mapping path as OpenAI, but with `ANTHROPIC_API_KEY`.

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/infrastructure/test_secret_factory.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `uv run ruff check arclith/infrastructure/lm.py tests/units/infrastructure/test_config.py tests/units/infrastructure/test_lm.py tests/units/adapters/outbound/test_pydantic_ai_llm.py`
- `make docs`
- `make quality`