### PR TITLE
Validate LangGraph agent scaffold

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -514,6 +514,8 @@ class AgentState(TypedDict, total=False):
 arclith = Arclith("config")
 
 
+# Template minimal volontaire: remplacer AgentState, run_agent et les edges par
+# l'état, les noeuds et les transitions propres au projet.
 async def run_agent(state: AgentState) -> AgentState:
     return state
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1,3 +1,5 @@
+import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -681,7 +683,7 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     )
 
     package_root = project_dir / "src" / "demo_service"
-    langgraph_json = (project_dir / "langgraph.json").read_text(encoding="utf-8")
+    langgraph_json = json.loads((project_dir / "langgraph.json").read_text(encoding="utf-8"))
     langgraph_config = (project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml").read_text(
         encoding="utf-8"
     )
@@ -690,7 +692,11 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     assert (project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml").exists()
     assert (package_root / "adapters" / "inbound" / "langgraph" / "__init__.py").exists()
     assert agent_file.exists()
-    assert '"todo_agent": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"' in langgraph_json
+    assert langgraph_json["graphs"] == {
+        "todo_agent": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+    }
+    assert langgraph_json["dependencies"] == ["."]
+    assert langgraph_json["env"] == ".env"
     adapters_yaml = (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
@@ -698,10 +704,44 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     assert "agent:" not in adapters_yaml
     assert 'name: "todo_agent"' in langgraph_config
     assert 'entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"' in langgraph_config
-    assert "agent = arclith.langgraph(AgentState, register_agent, name=\"todo_agent\")" in agent_file.read_text(
-        encoding="utf-8"
-    )
+    generated_agent = agent_file.read_text(encoding="utf-8")
+    assert "Template minimal volontaire" in generated_agent
+    assert "agent = arclith.langgraph(AgentState, register_agent, name=\"todo_agent\")" in generated_agent
     assert not (package_root / "adapters" / "outbound" / "langgraph").exists()
+
+
+@pytest.mark.asyncio
+async def test_add_langgraph_agent_adapter_generates_compilable_minimal_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("langgraph.graph")
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="agent",
+        adapter="langgraph",
+        adapter_params={"graph_name": "todo_agent"},
+        yes=True,
+    )
+
+    agent_file = project_dir / "src" / "demo_service" / "adapters" / "inbound" / "langgraph" / "agent.py"
+    monkeypatch.chdir(project_dir)
+    monkeypatch.syspath_prepend(str(project_dir / "src"))
+    spec = importlib.util.spec_from_file_location(
+        "demo_service.adapters.inbound.langgraph.agent",
+        agent_file,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        assert await module.agent.ainvoke({"messages": []}) == {"messages": []}
+    finally:
+        sys.modules.pop(spec.name, None)
 
 
 def test_add_non_entity_adapter_rejects_entity_selection(tmp_path: Path) -> None:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -375,6 +375,12 @@ les transitions et les appels aux cas d'usage applicatifs. Arclith garde le câb
 chargement de configuration, création du `StateGraph`, compilation, entrypoint Studio et lecture de
 `.env`.
 
+Le flux cible reste: humain ou canal conversationnel -> LangGraph Agent Server -> `agent.py` ->
+ports applicatifs -> use cases. Un LLM se branche derrière `LLMPort` via `config/adapters/outbound/lm.yaml`;
+l'observabilité se branche via `observability.enabled` (`langsmith`, `opentelemetry`, ou les deux).
+Les nodes LangGraph ne doivent pas appeler les repositories directement: ils traduisent l'intention,
+préparent des commandes ou DTO, puis appellent les ports et use cases du projet.
+
 ## Ajouter un adapter
 
 Le chemin standard est:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -282,6 +282,9 @@ L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/
 pour définir l'état, les nœuds et les transitions de son agent. Comme `fastapi` et `fastmcp`,
 LangGraph est configuré par son nom produit dans `AppConfig.langgraph`, sans clé générique
 `adapters.agent`.
+Le flux attendu est: utilisateur ou canal conversationnel -> LangGraph Agent Server -> `agent.py` ->
+ports et use cases applicatifs. Les nodes peuvent utiliser un `LLMPort` configuré par `llm/*` et les
+traces via `observability/*`, sans appeler les repositories directement.
 
 L'adapter `observability/langsmith` demande le projet LangSmith, l'endpoint, l'activation du tracing et
 `LANGSMITH_API_KEY`. Elle génère `config/adapters/outbound/langsmith.yaml`, ajoute `langsmith` à


### PR DESCRIPTION
## Summary
- make the generated `agent.py` explicitly state that project code must complete state, nodes, and transitions
- validate generated `langgraph.json` as structured JSON and assert the package entrypoint, `.env`, and dependency settings
- add an import/compile smoke for the generated minimal agent with `pytest.importorskip("langgraph.graph")`
- document the human/channel -> LangGraph Agent Server -> ports/use cases flow, plus LLMPort and observability wiring

Closes #67

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py` (37 passed, 1 skipped because `langgraph` extra is not installed in the CLI test env)
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run --extra all pytest tests/units/test_arclith_langgraph.py`
- `make docs`
- `make quality`