### PR TITLE
Validate LangSmith observability wiring

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -560,6 +560,7 @@ tracing: {tracing}
 project: "{project}"
 endpoint: "{endpoint}"
 api_key_env: LANGSMITH_API_KEY
+# Définir LANGSMITH_API_KEY hors Git: .env local, env runtime ou secret manager.
 studio: langgraph
 langgraph_api_min_version: "0.11.0"
 """,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -223,7 +223,7 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
         },
         yes=True,
     )
-    captured = capsys.readouterr()
+    cli_output = capsys.readouterr()
 
     config = (project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml").read_text(
         encoding="utf-8"
@@ -246,17 +246,20 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     assert "LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com" in env
     assert "LANGSMITH_API_KEY=test-key" in env
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
-    assert "test-key" not in captured.out
-    assert "test-key" not in captured.err
+    assert "test-key" not in cli_output.out
+    assert "test-key" not in cli_output.err
     from arclith import Arclith
 
     arclith = Arclith(project_dir / "config")
+    load_output = capsys.readouterr()
 
     assert arclith.config.adapters.observability.enabled == ["langsmith"]
     assert arclith.config.adapters.langsmith is not None
     assert arclith.config.adapters.langsmith.tracing is True
     assert arclith.config.adapters.langsmith.project == "agent-tests"
     assert arclith.config.adapters.langsmith.endpoint == "https://eu.api.smith.langchain.com"
+    assert "test-key" not in load_output.out
+    assert "test-key" not in load_output.err
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "langsmith").exists()
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -204,7 +204,10 @@ def test_add_mariadb_adapter_rejects_direct_secret_params(tmp_path: Path, secret
     assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
-def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path) -> None:
+def test_add_langsmith_observability_adapter_uses_catalog_params(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text("EXISTING=value\nLANGSMITH_PROJECT=old\n", encoding="utf-8")
 
@@ -220,6 +223,7 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path)
         },
         yes=True,
     )
+    captured = capsys.readouterr()
 
     config = (project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml").read_text(
         encoding="utf-8"
@@ -228,6 +232,7 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path)
     assert 'project: "agent-tests"' in config
     assert 'endpoint: "https://eu.api.smith.langchain.com"' in config
     assert "api_key_env: LANGSMITH_API_KEY" in config
+    assert "Définir LANGSMITH_API_KEY hors Git" in config
     assert 'langgraph_api_min_version: "0.11.0"' in config
     adapters_config = yaml.safe_load(
         (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
@@ -241,6 +246,17 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(tmp_path: Path)
     assert "LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com" in env
     assert "LANGSMITH_API_KEY=test-key" in env
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
+    assert "test-key" not in captured.out
+    assert "test-key" not in captured.err
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.observability.enabled == ["langsmith"]
+    assert arclith.config.adapters.langsmith is not None
+    assert arclith.config.adapters.langsmith.tracing is True
+    assert arclith.config.adapters.langsmith.project == "agent-tests"
+    assert arclith.config.adapters.langsmith.endpoint == "https://eu.api.smith.langchain.com"
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "langsmith").exists()
 
@@ -285,8 +301,13 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
     )
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
+    config = (project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml").read_text(
+        encoding="utf-8"
+    )
     assert "LANGSMITH_API_KEY=" not in env
     assert "LANGSMITH_PROJECT=agent-tests" in env
+    assert "api_key_env: LANGSMITH_API_KEY" in config
+    assert "Définir LANGSMITH_API_KEY hors Git" in config
 
 
 def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -> None:
@@ -669,6 +690,50 @@ def test_add_observability_adapters_accumulates_enabled_backends(tmp_path: Path)
     )
     assert "traces_endpoint: null" in config
     assert "metrics_endpoint: null" in config
+
+
+def test_add_langsmith_preserves_existing_opentelemetry_activation(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="opentelemetry",
+        adapter_params={"service_name": "demo-api"},
+        yes=True,
+    )
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        adapter_params={"project": "agent-tests"},
+        yes=True,
+    )
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        adapter_params={"project": "agent-tests"},
+        yes=True,
+    )
+
+    adapters_config = yaml.safe_load(
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+    )
+    env = (project_dir / ".env").read_text(encoding="utf-8")
+    opentelemetry_config = (
+        project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml"
+    ).read_text(encoding="utf-8")
+
+    assert adapters_config["observability"]["enabled"] == ["opentelemetry", "langsmith"]
+    assert adapters_config["observability"]["enabled"].count("langsmith") == 1
+    assert adapters_config["observability"]["enabled"].count("opentelemetry") == 1
+    assert "EXISTING=value" in env
+    assert "OTEL_SERVICE_NAME=demo-api" in env
+    assert "LANGSMITH_PROJECT=agent-tests" in env
+    assert "LANGSMITH_API_KEY=" not in env
+    assert 'service_name: "demo-api"' in opentelemetry_config
 
 
 def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -40,6 +40,9 @@ def test_observability_capability_catalog_declares_langsmith() -> None:
         "endpoint",
         "api_key",
     ]
+    langsmith_parameters = {parameter.name: parameter for parameter in langsmith.parameters}
+    assert langsmith_parameters["api_key"].secret is True
+    assert langsmith_parameters["api_key"].default == ""
 
 
 def test_api_capability_catalog_declares_fastapi() -> None:
@@ -253,3 +256,7 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [adapter["name"] for adapter in payload[4]["adapters"]] == ["langgraph"]
     assert payload[5]["name"] == "observability"
     assert [adapter["name"] for adapter in payload[5]["adapters"]] == ["langsmith", "opentelemetry"]
+    langsmith = payload[5]["adapters"][0]
+    langsmith_parameters = {parameter["name"]: parameter for parameter in langsmith["parameters"]}
+    assert langsmith_parameters["api_key"]["secret"] is True
+    assert langsmith_parameters["api_key"]["default"] == ""

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -311,6 +311,13 @@ LangGraph doit lire `.env` via `langgraph.json`; `.env` contient `LANGSMITH_API_
 `LANGSMITH_TRACING`, `LANGSMITH_PROJECT` et `LANGSMITH_ENDPOINT`. La clé reste locale et ne doit pas
 être commitée.
 
+`config/adapters/outbound/langsmith.yaml` stocke seulement `api_key_env: LANGSMITH_API_KEY`: si la
+clé n'est pas passée à la CLI, aucune valeur vide n'est ajoutée à `.env`. Définir explicitement
+`LANGSMITH_API_KEY` dans `.env`, l'environnement runtime ou le secret manager avant de lancer
+`langgraph dev`, sinon les runs LangSmith ne pourront pas être envoyés. `project` nomme le workspace
+ou projet de test LangSmith, `endpoint` permet de viser l'API régionale, et `tracing` pilote
+`LANGSMITH_TRACING`.
+
 OpenTelemetry se configure avec:
 
 ```yaml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -289,6 +289,8 @@ traces via `observability/*`, sans appeler les repositories directement.
 L'adapter `observability/langsmith` demande le projet LangSmith, l'endpoint, l'activation du tracing et
 `LANGSMITH_API_KEY`. Elle génère `config/adapters/outbound/langsmith.yaml`, ajoute `langsmith` à
 `observability.enabled`, met à jour `.env`, et ajoute `.env` au `.gitignore` si besoin.
+Si la clé n'est pas passée à la CLI, définir `LANGSMITH_API_KEY` manuellement dans `.env`,
+l'environnement runtime ou un secret manager avant de lancer `langgraph dev`.
 
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
 `AppConfig.adapters.lm`. L'interpréteur d'intention applicatif consomme ensuite un `LLMPort`;


### PR DESCRIPTION
## Summary
- expose LangSmith `api_key` as a secret parameter in the JSON capability catalog
- validate generated LangSmith config loads through `Arclith`, does not log the API key, and keeps only `api_key_env` in YAML
- test adding LangSmith after OpenTelemetry twice preserves both `observability.enabled` backends without duplicates
- document LangGraph Studio project/endpoint/tracing and the explicit `LANGSMITH_API_KEY` requirement

Closes #68

## Validation
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py` (38 passed, 1 skipped because `langgraph` extra is not installed in the CLI test env)
- `cd cli && uv run ruff check tests/test_capabilities.py tests/test_add_adapter.py`
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/test_arclith_opentelemetry.py`
- `uv run ruff check tests/units/infrastructure/test_config.py tests/units/test_arclith_opentelemetry.py`
- `make docs`
- `make quality`