### PR TITLE
Add memory cache capability to CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -141,18 +141,20 @@ arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name=q
 arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=recipe_agent --yes
 arclith-cli add-adapter --capability observability --adapter langsmith
 arclith-cli add-adapter --capability observability --adapter opentelemetry --param service_name=my_recipe_service --yes
+arclith-cli add-adapter --capability cache --adapter memory --yes
 arclith-cli add-adapter --capability repository --adapter memory --entity Recipe --yes
 ```
 
 **Étapes du wizard :**
 
 1. **Type d'adapter** — selon la capacité : `memory` · `mongodb` · `duckdb` · `mariadb` · `fastapi` · `fastmcp` · `lmstudio` · `openai` · `anthropic` · `langgraph` · `langsmith` · `opentelemetry`
-2. **Entité(s) cible(s)** — détectées automatiquement pour les adapters entity-scoped ; ignorées pour les transports globaux, `llm/*`, `agent/langgraph` et les adapters d'observability
+2. **Entité(s) cible(s)** — détectées automatiquement pour les adapters entity-scoped ; ignorées pour les transports globaux, `cache/*`, `llm/*`, `agent/langgraph` et les adapters d'observability
 3. **Paramètres** — questions spécifiques à l'adapter :
    - `mongodb` → `db_name`, `collection_name`, `multitenant`
    - `duckdb` → `path`
    - `mariadb` → `host`, `port`, `database`, `user`, `driver`, `table_prefix`
      (`url` et `password` sont mappés via `config/secrets.yaml`)
+   - `cache/memory` → `jwks_ttl`, `tenant_uri_ttl`
    - `fastapi` → `host`, `port`, `reload`
    - `fastmcp` → `host`, `port`
    - `lmstudio` → `model_name`, `base_url`, `api_key`
@@ -161,13 +163,13 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `langgraph` → `graph_name`
    - `langsmith` → `tracing`, `project`, `endpoint`, `LANGSMITH_API_KEY`
    - `opentelemetry` → `service_name`, `endpoint`, `traces_endpoint`, `metrics_endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
-   - `memory` → aucun paramètre
-4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `llm/*` et `agent/langgraph` sont exposés par leurs fichiers de configuration scopés
+   - `repository/memory` → aucun paramètre
+4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `cache/*`, `llm/*` et `agent/langgraph` sont exposés par leurs fichiers de configuration scopés
 5. **Récapitulatif** — liste des fichiers créés ou remplacés avant confirmation
 
 | Option | Défaut | Description |
 |--------|--------|-------------|
-| `--capability` | `repository` | Capacité cible du catalogue standardisé (`repository`, `api`, `mcp`, `llm`, `agent`, `observability`) |
+| `--capability` | `repository` | Capacité cible du catalogue standardisé (`repository`, `cache`, `api`, `mcp`, `llm`, `agent`, `observability`) |
 | `--adapter` / `-a` | interactif | Adapter du catalogue : `memory`, `mongodb`, `duckdb`, `mariadb`, `fastapi`, `fastmcp`, `lmstudio`, `openai`, `anthropic`, `langgraph`, `langsmith`, `opentelemetry` |
 | `--entity` / `-e` | auto si une seule entité | Entité cible, liste séparée par virgule acceptée |
 | `--all-entities` | `false` | Génère l'adapter pour toutes les entités détectées |
@@ -322,6 +324,11 @@ config/
       license.yaml                # license: { role }
       cache.yaml                  # cache: { backend, redis_url, … }
 ```
+
+`cache/memory` génère `config/adapters/inbound/cache.yaml` avec `backend: memory` et les TTL JWKS /
+tenant. Ce cache est strictement local au processus Python: il suffit pour le développement, les
+tests et un worker unique. Passer à Redis dès qu'il faut partager le cache entre plusieurs workers,
+réplicas, ou processus séparés API/MCP/agent.
 
 Pour changer l'adapter actif sans passer par le wizard :
 

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -259,6 +259,42 @@ multitenant: false
     ),
 )
 
+CACHE_CAPABILITY = CapabilitySpec(
+    name="cache",
+    layer="outbound",
+    description="Cache transverse pour JWT JWKS, idempotency et résolution tenant.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="memory",
+            capability="cache",
+            layer="outbound",
+            description="Cache local par processus pour dev, tests et exécution mono-worker.",
+            config_path="config/adapters/inbound/cache.yaml",
+            config_template="""\
+backend: memory
+jwks_ttl: {jwks_ttl}
+tenant_uri_ttl: {tenant_uri_ttl}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="jwks_ttl",
+                    kind="string",
+                    prompt="TTL JWKS en secondes",
+                    default="3600",
+                ),
+                ParameterSpec(
+                    name="tenant_uri_ttl",
+                    kind="string",
+                    prompt="TTL tenant en secondes",
+                    default="300",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 API_CAPABILITY = CapabilitySpec(
     name="api",
     layer="inbound",
@@ -695,6 +731,7 @@ OTEL_EXPORTER_OTLP_HEADERS={headers}
 
 CAPABILITY_CATALOG = (
     REPOSITORY_CAPABILITY,
+    CACHE_CAPABILITY,
     API_CAPABILITY,
     MCP_CAPABILITY,
     LLM_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -138,7 +138,7 @@ def version() -> None:
 def add_adapter(
     capability: Annotated[
         str,
-        typer.Option("--capability", help="Capacité cible: repository, api, mcp, llm, agent ou observability"),
+        typer.Option("--capability", help="Capacité cible: repository, cache, api, mcp, llm, agent ou observability"),
     ] = "repository",
     adapter: Annotated[
         str | None,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -838,6 +838,19 @@ def test_add_transport_adapter_rejects_entity_selection(tmp_path: Path) -> None:
         )
 
 
+def test_add_cache_adapter_rejects_entity_selection(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="cache",
+            adapter="memory",
+            entity_names=["Widget"],
+            yes=True,
+        )
+
+
 def test_add_adapter_rejects_unknown_catalog_param(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 
@@ -957,6 +970,35 @@ def test_add_memory_adapter_interactive_wizard_activates_memory(tmp_path: Path) 
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
+
+
+def test_add_cache_memory_adapter_generates_loadable_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="cache",
+        adapter="memory",
+        adapter_params={
+            "jwks_ttl": "1200",
+            "tenant_uri_ttl": "180",
+        },
+        yes=True,
+    )
+
+    from arclith import Arclith
+    from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
+
+    cache_config = (project_dir / "config" / "adapters" / "inbound" / "cache.yaml").read_text(
+        encoding="utf-8"
+    )
+    app = Arclith(project_dir / "config")
+
+    assert cache_config == "backend: memory\njwks_ttl: 1200\ntenant_uri_ttl: 180\n"
+    assert app.config.cache.backend == "memory"
+    assert app.config.cache.jwks_ttl == 1200
+    assert app.config.cache.tenant_uri_ttl == 180
+    assert isinstance(app._cache, MemoryCacheAdapter)
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -22,6 +22,21 @@ def test_repository_capability_catalog_declares_standard_adapters() -> None:
     assert memory.parameters == ()
 
 
+def test_cache_capability_catalog_declares_memory_adapter() -> None:
+    capability = get_capability("cache")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("memory",)
+    memory = capability.get_adapter("memory")
+    assert memory is not None
+    assert memory.capability == "cache"
+    assert memory.config_path == "config/adapters/inbound/cache.yaml"
+    assert memory.entity_scoped is False
+    assert [parameter.name for parameter in memory.parameters] == ["jwks_ttl", "tenant_uri_ttl"]
+
+
 def test_observability_capability_catalog_declares_langsmith() -> None:
     capability = get_capability("observability")
 
@@ -196,6 +211,7 @@ def test_capability_catalog_is_json_serializable() -> None:
 
     assert "repository" in encoded
     assert "mongodb" in encoded
+    assert "cache" in encoded
     assert "api" in encoded
     assert "fastapi" in encoded
     assert "mcp" in encoded
@@ -219,14 +235,15 @@ def test_capabilities_command_outputs_json_catalog() -> None:
 
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload[0]["name"] == "repository"
-    assert [adapter["name"] for adapter in payload[0]["adapters"]] == ["memory", "mongodb", "duckdb", "mariadb"]
-    assert payload[0]["adapters"][0]["entity_scoped"] is True
-    duckdb = payload[0]["adapters"][2]
+    payload_by_name = {capability["name"]: capability for capability in payload}
+    repository = payload_by_name["repository"]
+    assert [adapter["name"] for adapter in repository["adapters"]] == ["memory", "mongodb", "duckdb", "mariadb"]
+    assert repository["adapters"][0]["entity_scoped"] is True
+    duckdb = repository["adapters"][2]
     assert duckdb["name"] == "duckdb"
     assert duckdb["config_path"] == "config/adapters/outbound/duckdb.yaml"
     assert [parameter["name"] for parameter in duckdb["parameters"]] == ["path"]
-    mariadb = payload[0]["adapters"][3]
+    mariadb = repository["adapters"][3]
     assert mariadb["name"] == "mariadb"
     assert [mapping["field_path"] for mapping in mariadb["secret_mappings"]] == [
         "adapters.mariadb.url",
@@ -236,27 +253,32 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "MARIADB_URL",
         "MARIADB_PASSWORD",
     ]
-    assert payload[1]["name"] == "api"
-    assert [adapter["name"] for adapter in payload[1]["adapters"]] == ["fastapi"]
-    assert payload[2]["name"] == "mcp"
-    assert [adapter["name"] for adapter in payload[2]["adapters"]] == ["fastmcp"]
-    assert payload[3]["name"] == "llm"
-    assert [adapter["name"] for adapter in payload[3]["adapters"]] == ["lmstudio", "openai", "anthropic"]
-    openai = payload[3]["adapters"][1]
+    cache = payload_by_name["cache"]
+    assert [adapter["name"] for adapter in cache["adapters"]] == ["memory"]
+    assert cache["adapters"][0]["capability"] == "cache"
+    assert cache["adapters"][0]["entity_scoped"] is False
+    assert [parameter["name"] for parameter in cache["adapters"][0]["parameters"]] == [
+        "jwks_ttl",
+        "tenant_uri_ttl",
+    ]
+    assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
+    assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
+    llm = payload_by_name["llm"]
+    assert [adapter["name"] for adapter in llm["adapters"]] == ["lmstudio", "openai", "anthropic"]
+    openai = llm["adapters"][1]
     openai_parameters = {parameter["name"]: parameter for parameter in openai["parameters"]}
     assert openai_parameters["model_name"]["default"] == "remplacer-par-model-id-openai"
     assert openai_parameters["api_key"]["secret"] is True
     assert openai_parameters["api_key"]["default"] == ""
-    anthropic = payload[3]["adapters"][2]
+    anthropic = llm["adapters"][2]
     anthropic_parameters = {parameter["name"]: parameter for parameter in anthropic["parameters"]}
     assert anthropic_parameters["model_name"]["default"] == "remplacer-par-model-id-anthropic"
     assert anthropic_parameters["api_key"]["secret"] is True
     assert anthropic_parameters["api_key"]["default"] == ""
-    assert payload[4]["name"] == "agent"
-    assert [adapter["name"] for adapter in payload[4]["adapters"]] == ["langgraph"]
-    assert payload[5]["name"] == "observability"
-    assert [adapter["name"] for adapter in payload[5]["adapters"]] == ["langsmith", "opentelemetry"]
-    langsmith = payload[5]["adapters"][0]
+    assert [adapter["name"] for adapter in payload_by_name["agent"]["adapters"]] == ["langgraph"]
+    observability = payload_by_name["observability"]
+    assert [adapter["name"] for adapter in observability["adapters"]] == ["langsmith", "opentelemetry"]
+    langsmith = observability["adapters"][0]
     langsmith_parameters = {parameter["name"]: parameter for parameter in langsmith["parameters"]}
     assert langsmith_parameters["api_key"]["secret"] is True
     assert langsmith_parameters["api_key"]["default"] == ""

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -163,6 +163,33 @@ En single-tenant, `database` est requis quand `url` n'est pas fourni par les sec
 multitenant, le contexte tenant peut fournir `url`, `database`, `user`, `password`, `host`, `port`,
 `driver` ou `table_prefix`.
 
+### `cache`
+
+Capacité outbound transverse pour le cache technique utilisé par JWT JWKS, idempotency et
+résolution tenant. Elle n'est pas liée aux entités métier et ne doit pas être confondue avec
+`repository/memory`, qui stocke les entités derrière un port repository.
+
+Adapter disponible:
+
+- `memory`: cache local par processus pour développement, tests, smokes locaux et worker unique.
+
+Configuration runtime:
+
+```yaml
+# config/adapters/inbound/cache.yaml
+backend: memory
+jwks_ttl: 3600
+tenant_uri_ttl: 300
+```
+
+Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml`: le chemin
+`config/adapters/inbound/cache.yaml` est chargé directement dans `AppConfig.cache`.
+
+`memory` garde les entrées uniquement dans le processus Python courant. Une API, un serveur MCP, un
+agent LangGraph ou plusieurs workers lancés séparément ne partagent donc pas les JWKS, réponses
+idempotentes ou coordonnées tenant mises en cache. Passer à Redis dès qu'il faut un cache partagé
+entre workers, réplicas ou processus API/MCP/agent.
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.
@@ -439,6 +466,11 @@ arclith-cli add-adapter \
   --capability mcp \
   --adapter fastmcp \
   --param port=8081 \
+  --yes
+
+arclith-cli add-adapter \
+  --capability cache \
+  --adapter memory \
   --yes
 
 arclith-cli add-adapter \

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -155,6 +155,20 @@ def test_load_config_dir_mcp_via_fastmcp_alias():
     assert config.mcp.port == 8888
 
 
+def test_load_config_dir_cache_scoped():
+    path = _make_config_dir({
+        "adapters/inbound/cache.yaml": {
+            "backend": "memory",
+            "jwks_ttl": 1200,
+            "tenant_uri_ttl": 180,
+        }
+    })
+    config = load_config_dir(path)
+    assert config.cache.backend == "memory"
+    assert config.cache.jwks_ttl == 1200
+    assert config.cache.tenant_uri_ttl == 180
+
+
 def test_load_config_dir_mongodb_scoped():
     path = _make_config_dir({
         "adapters/adapters.yaml": {"repository": "mongodb"},

--- a/tests/units/test_arclith_cache.py
+++ b/tests/units/test_arclith_cache.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from arclith import Arclith
+from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
+
+
+def test_arclith_cache_uses_memory_backend(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    cache_dir = config_dir / "adapters" / "inbound"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "cache.yaml").write_text(
+        "backend: memory\n"
+        "jwks_ttl: 1200\n"
+        "tenant_uri_ttl: 180\n",
+        encoding="utf-8",
+    )
+
+    arclith = Arclith(config_dir)
+
+    assert arclith.config.cache.backend == "memory"
+    assert arclith.config.cache.jwks_ttl == 1200
+    assert arclith.config.cache.tenant_uri_ttl == 180
+    assert isinstance(arclith._cache, MemoryCacheAdapter)


### PR DESCRIPTION
## Summary
- add the transverse cache/memory capability distinct from repository/memory
- generate config/adapters/inbound/cache.yaml with memory backend and JWKS/tenant TTLs
- document process-local memory cache limits and when to move to Redis

## Note
The generated cache config keeps the existing config/adapters/inbound/cache.yaml path because the current config loader already maps that scoped file to AppConfig.cache.

## Validation
- uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q from cli/
- uv run pytest tests/units/infrastructure/test_config.py tests/units/test_arclith_cache.py -q
- uv run ruff check arclith_cli tests from cli/
- uv run ruff check cli/arclith_cli/capabilities.py cli/arclith_cli/main.py cli/tests/test_capabilities.py cli/tests/test_add_adapter.py tests/units/infrastructure/test_config.py tests/units/test_arclith_cache.py
- make docs
- make quality

Closes #69