### PR TITLE
Add Redis cache capability to CLI

### DIFF
--- a/arclith/adapters/outbound/redis/cache_adapter.py
+++ b/arclith/adapters/outbound/redis/cache_adapter.py
@@ -5,8 +5,10 @@ class RedisCacheAdapter(CachePort):
     def __init__(self, url: str) -> None:
         try:
             from redis.asyncio import Redis  # type: ignore[import-untyped]
-        except ImportError:
-            raise ImportError("Package redis manquant : uv add 'arclith[cache]'")
+        except ModuleNotFoundError as exc:
+            if exc.name is not None and not exc.name.startswith("redis"):
+                raise
+            raise ModuleNotFoundError("Package redis manquant : uv add 'arclith[cache]'") from None
         self._client = Redis.from_url(url, decode_responses=True)
 
     async def get(self, key: str) -> str | None:
@@ -17,4 +19,3 @@ class RedisCacheAdapter(CachePort):
 
     async def delete(self, key: str) -> None:
         await self._client.delete(key)
-

--- a/arclith/adapters/outbound/redis/cache_adapter.py
+++ b/arclith/adapters/outbound/redis/cache_adapter.py
@@ -6,7 +6,7 @@ class RedisCacheAdapter(CachePort):
         try:
             from redis.asyncio import Redis  # type: ignore[import-untyped]
         except ModuleNotFoundError as exc:
-            if exc.name is not None and not exc.name.startswith("redis"):
+            if exc.name != "redis":
                 raise
             raise ModuleNotFoundError("Package redis manquant : uv add 'arclith[cache]'") from None
         self._client = Redis.from_url(url, decode_responses=True)

--- a/cli/README.md
+++ b/cli/README.md
@@ -156,7 +156,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `mariadb` → `host`, `port`, `database`, `user`, `driver`, `table_prefix`
      (`url` et `password` sont mappés via `config/secrets.yaml`)
    - `cache/memory` → `jwks_ttl`, `tenant_uri_ttl`
-   - `cache/redis` → `REDIS_URL`, `jwks_ttl`, `tenant_uri_ttl`
+   - `cache/redis` → `redis_url`, `jwks_ttl`, `tenant_uri_ttl`
    - `fastapi` → `host`, `port`, `reload`
    - `fastmcp` → `host`, `port`
    - `lmstudio` → `model_name`, `base_url`, `api_key`

--- a/cli/README.md
+++ b/cli/README.md
@@ -142,6 +142,7 @@ arclith-cli add-adapter --capability agent --adapter langgraph --param graph_nam
 arclith-cli add-adapter --capability observability --adapter langsmith
 arclith-cli add-adapter --capability observability --adapter opentelemetry --param service_name=my_recipe_service --yes
 arclith-cli add-adapter --capability cache --adapter memory --yes
+arclith-cli add-adapter --capability cache --adapter redis --param redis_url=redis://redis:6379 --yes
 arclith-cli add-adapter --capability repository --adapter memory --entity Recipe --yes
 ```
 
@@ -155,6 +156,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `mariadb` → `host`, `port`, `database`, `user`, `driver`, `table_prefix`
      (`url` et `password` sont mappés via `config/secrets.yaml`)
    - `cache/memory` → `jwks_ttl`, `tenant_uri_ttl`
+   - `cache/redis` → `REDIS_URL`, `jwks_ttl`, `tenant_uri_ttl`
    - `fastapi` → `host`, `port`, `reload`
    - `fastmcp` → `host`, `port`
    - `lmstudio` → `model_name`, `base_url`, `api_key`
@@ -329,6 +331,14 @@ config/
 tenant. Ce cache est strictement local au processus Python: il suffit pour le développement, les
 tests et un worker unique. Passer à Redis dès qu'il faut partager le cache entre plusieurs workers,
 réplicas, ou processus séparés API/MCP/agent.
+
+`cache/redis` génère le même fichier avec `backend: redis`, mappe `cache.redis_url` vers
+`REDIS_URL` dans `config/secrets.yaml` et écrit la valeur fournie dans `.env` local gitignoré.
+Installer l'extra avant de lancer le service:
+
+```bash
+uv add "arclith[cache]"
+```
 
 Pour changer l'adapter actif sans passer par le wizard :
 

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -292,6 +292,51 @@ tenant_uri_ttl: {tenant_uri_ttl}
             ),
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="redis",
+            capability="cache",
+            layer="outbound",
+            description="Cache Redis partagé pour déploiements multi-worker ou multi-réplicas.",
+            config_path="config/adapters/inbound/cache.yaml",
+            config_template="""\
+backend: redis
+redis_url: ""
+jwks_ttl: {jwks_ttl}
+tenant_uri_ttl: {tenant_uri_ttl}
+""",
+            env_path=".env",
+            env_template="""\
+REDIS_URL={redis_url}
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="cache.redis_url",
+                    secret_key="REDIS_URL",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="redis_url",
+                    kind="string",
+                    prompt="REDIS_URL",
+                    default="redis://127.0.0.1:6379",
+                    secret=True,
+                ),
+                ParameterSpec(
+                    name="jwks_ttl",
+                    kind="string",
+                    prompt="TTL JWKS en secondes",
+                    default="3600",
+                ),
+                ParameterSpec(
+                    name="tenant_uri_ttl",
+                    kind="string",
+                    prompt="TTL tenant en secondes",
+                    default="300",
+                ),
+            ),
+            entity_scoped=False,
+        ),
     ),
 )
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1001,6 +1001,59 @@ def test_add_cache_memory_adapter_generates_loadable_config(tmp_path: Path) -> N
     assert isinstance(app._cache, MemoryCacheAdapter)
 
 
+def test_add_cache_redis_adapter_generates_secret_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="cache",
+        adapter="redis",
+        adapter_params={
+            "redis_url": "redis://cache:6379/0",
+            "jwks_ttl": "900",
+            "tenant_uri_ttl": "120",
+        },
+        yes=True,
+    )
+    captured = capsys.readouterr()
+
+    cache_config = (project_dir / "config" / "adapters" / "inbound" / "cache.yaml").read_text(
+        encoding="utf-8"
+    )
+    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    env = (project_dir / ".env").read_text(encoding="utf-8")
+
+    assert cache_config == 'backend: redis\nredis_url: ""\njwks_ttl: 900\ntenant_uri_ttl: 120\n'
+    assert secrets["resolver"] == "env"
+    assert secrets["mappings"]["cache.redis_url"] == "REDIS_URL"
+    assert "EXISTING=value" in env
+    assert "REDIS_URL=redis://cache:6379/0" in env
+    assert "cache:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "redis://cache:6379/0" not in cache_config
+    assert "redis://cache:6379/0" not in (project_dir / "config" / "secrets.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "redis://cache:6379/0" not in captured.out
+    assert "redis://cache:6379/0" not in captured.err
+
+    monkeypatch.setenv("REDIS_URL", "redis://cache:6379/0")
+    from arclith import Arclith
+
+    app = Arclith(project_dir / "config")
+
+    assert app.config.cache.backend == "redis"
+    assert app.config.cache.redis_url == "redis://cache:6379/0"
+    assert app.config.cache.jwks_ttl == 900
+    assert app.config.cache.tenant_uri_ttl == 120
+
+
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:
     parameter = ParameterSpec(name="multitenant", kind="boolean", prompt="multitenant", default="false")
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -28,13 +28,22 @@ def test_cache_capability_catalog_declares_memory_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("memory",)
+    assert capability.adapter_names() == ("memory", "redis")
     memory = capability.get_adapter("memory")
+    redis = capability.get_adapter("redis")
     assert memory is not None
     assert memory.capability == "cache"
     assert memory.config_path == "config/adapters/inbound/cache.yaml"
     assert memory.entity_scoped is False
     assert [parameter.name for parameter in memory.parameters] == ["jwks_ttl", "tenant_uri_ttl"]
+    assert redis is not None
+    assert redis.capability == "cache"
+    assert redis.config_path == "config/adapters/inbound/cache.yaml"
+    assert redis.env_path == ".env"
+    assert redis.entity_scoped is False
+    assert [parameter.name for parameter in redis.parameters] == ["redis_url", "jwks_ttl", "tenant_uri_ttl"]
+    assert [mapping.field_path for mapping in redis.secret_mappings] == ["cache.redis_url"]
+    assert [mapping.secret_key for mapping in redis.secret_mappings] == ["REDIS_URL"]
 
 
 def test_observability_capability_catalog_declares_langsmith() -> None:
@@ -212,6 +221,7 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "repository" in encoded
     assert "mongodb" in encoded
     assert "cache" in encoded
+    assert "redis" in encoded
     assert "api" in encoded
     assert "fastapi" in encoded
     assert "mcp" in encoded
@@ -254,12 +264,22 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "MARIADB_PASSWORD",
     ]
     cache = payload_by_name["cache"]
-    assert [adapter["name"] for adapter in cache["adapters"]] == ["memory"]
+    assert [adapter["name"] for adapter in cache["adapters"]] == ["memory", "redis"]
     assert cache["adapters"][0]["capability"] == "cache"
     assert cache["adapters"][0]["entity_scoped"] is False
     assert [parameter["name"] for parameter in cache["adapters"][0]["parameters"]] == [
         "jwks_ttl",
         "tenant_uri_ttl",
+    ]
+    assert cache["adapters"][1]["capability"] == "cache"
+    assert cache["adapters"][1]["entity_scoped"] is False
+    assert [parameter["name"] for parameter in cache["adapters"][1]["parameters"]] == [
+        "redis_url",
+        "jwks_ttl",
+        "tenant_uri_ttl",
+    ]
+    assert [mapping["field_path"] for mapping in cache["adapters"][1]["secret_mappings"]] == [
+        "cache.redis_url"
     ]
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -55,7 +55,7 @@ arclith-cli capabilities --json
 
 Capacité outbound pour la persistance des entités métier derrière un port repository.
 
-Adapters disponibles:
+Adaptateurs disponibles:
 
 - `memory`: stockage volatile pour dev, tests et smoke locaux;
 - `mongodb`: repository async MongoDB, single-tenant ou multitenant;
@@ -169,7 +169,7 @@ Capacité outbound transverse pour le cache technique utilisé par JWT JWKS, ide
 résolution tenant. Elle n'est pas liée aux entités métier et ne doit pas être confondue avec
 `repository/memory`, qui stocke les entités derrière un port repository.
 
-Adapters disponibles:
+Adaptateurs disponibles:
 
 - `memory`: cache local par processus pour développement, tests, smokes locaux et worker unique.
 - `redis`: cache partagé pour workers multiples, réplicas Kubernetes ou processus API/MCP/agent

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -169,9 +169,11 @@ Capacité outbound transverse pour le cache technique utilisé par JWT JWKS, ide
 résolution tenant. Elle n'est pas liée aux entités métier et ne doit pas être confondue avec
 `repository/memory`, qui stocke les entités derrière un port repository.
 
-Adapter disponible:
+Adapters disponibles:
 
 - `memory`: cache local par processus pour développement, tests, smokes locaux et worker unique.
+- `redis`: cache partagé pour workers multiples, réplicas Kubernetes ou processus API/MCP/agent
+  séparés.
 
 Configuration runtime:
 
@@ -182,6 +184,21 @@ jwks_ttl: 3600
 tenant_uri_ttl: 300
 ```
 
+Redis:
+
+```yaml
+# config/adapters/inbound/cache.yaml
+backend: redis
+redis_url: ""
+jwks_ttl: 3600
+tenant_uri_ttl: 300
+
+# config/secrets.yaml
+resolver: env
+mappings:
+  cache.redis_url: REDIS_URL
+```
+
 Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml`: le chemin
 `config/adapters/inbound/cache.yaml` est chargé directement dans `AppConfig.cache`.
 
@@ -189,6 +206,25 @@ Cette capacité n'a pas de clé d'activation dans `config/adapters/adapters.yaml
 agent LangGraph ou plusieurs workers lancés séparément ne partagent donc pas les JWKS, réponses
 idempotentes ou coordonnées tenant mises en cache. Passer à Redis dès qu'il faut un cache partagé
 entre workers, réplicas ou processus API/MCP/agent.
+
+Installer l'extra Redis dans les services qui activent `cache/redis`:
+
+```bash
+uv add "arclith[cache]"
+```
+
+Exemple Docker Compose local:
+
+```yaml
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+```
+
+Depuis un service lancé dans le même réseau Compose, utiliser `REDIS_URL=redis://redis:6379`. Depuis
+un processus lancé sur l'hôte, utiliser `REDIS_URL=redis://127.0.0.1:6379`.
 
 ### `api`
 
@@ -471,6 +507,12 @@ arclith-cli add-adapter \
 arclith-cli add-adapter \
   --capability cache \
   --adapter memory \
+  --yes
+
+arclith-cli add-adapter \
+  --capability cache \
+  --adapter redis \
+  --param redis_url=redis://redis:6379 \
   --yes
 
 arclith-cli add-adapter \

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -169,6 +169,22 @@ def test_load_config_dir_cache_scoped():
     assert config.cache.tenant_uri_ttl == 180
 
 
+def test_load_config_dir_redis_cache_scoped():
+    path = _make_config_dir({
+        "adapters/inbound/cache.yaml": {
+            "backend": "redis",
+            "redis_url": "redis://cache:6379/0",
+            "jwks_ttl": 900,
+            "tenant_uri_ttl": 120,
+        }
+    })
+    config = load_config_dir(path)
+    assert config.cache.backend == "redis"
+    assert config.cache.redis_url == "redis://cache:6379/0"
+    assert config.cache.jwks_ttl == 900
+    assert config.cache.tenant_uri_ttl == 120
+
+
 def test_load_config_dir_mongodb_scoped():
     path = _make_config_dir({
         "adapters/adapters.yaml": {"repository": "mongodb"},
@@ -766,3 +782,47 @@ def test_adapters_mariadb_url_and_password_loaded_from_env_mapping(monkeypatch: 
     assert config.adapters.mariadb is not None
     assert config.adapters.mariadb.url == "mysql+asyncmy://env-app@db:3306/env_demo"
     assert config.adapters.mariadb.password == "env-password"
+
+
+def test_cache_redis_url_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("REDIS_URL", "redis://cache:6379/0")
+    config_dir = _make_config_dir({
+        "adapters/inbound/cache.yaml": {
+            "backend": "redis",
+            "redis_url": "",
+            "jwks_ttl": 900,
+            "tenant_uri_ttl": 120,
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "cache.redis_url": "REDIS_URL",
+            },
+        },
+    })
+
+    config = load_config_dir(config_dir)
+
+    assert config.cache.backend == "redis"
+    assert config.cache.redis_url == "redis://cache:6379/0"
+
+
+def test_cache_missing_redis_env_secret_raises_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    config_dir = _make_config_dir({
+        "adapters/inbound/cache.yaml": {
+            "backend": "redis",
+            "redis_url": "",
+        },
+        "secrets.yaml": {
+            "resolver": "env",
+            "mappings": {
+                "cache.redis_url": "REDIS_URL",
+            },
+        },
+    })
+
+    with pytest.raises(RuntimeError, match="Secrets non résolus.*cache.redis_url"):
+        load_config_dir(config_dir)

--- a/tests/units/test_arclith_cache.py
+++ b/tests/units/test_arclith_cache.py
@@ -1,7 +1,12 @@
+import builtins
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from arclith import Arclith
 from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
+from arclith.adapters.outbound.redis.cache_adapter import RedisCacheAdapter
 
 
 def test_arclith_cache_uses_memory_backend(tmp_path: Path) -> None:
@@ -21,3 +26,73 @@ def test_arclith_cache_uses_memory_backend(tmp_path: Path) -> None:
     assert arclith.config.cache.jwks_ttl == 1200
     assert arclith.config.cache.tenant_uri_ttl == 180
     assert isinstance(arclith._cache, MemoryCacheAdapter)
+
+
+def test_arclith_cache_uses_redis_backend_without_real_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    cache_dir = config_dir / "adapters" / "inbound"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "cache.yaml").write_text(
+        "backend: redis\n"
+        "redis_url: redis://cache:6379/0\n"
+        "jwks_ttl: 900\n"
+        "tenant_uri_ttl: 120\n",
+        encoding="utf-8",
+    )
+
+    class FakeRedis:
+        url: str | None = None
+        decode_responses: bool | None = None
+
+        @classmethod
+        def from_url(cls, url: str, *, decode_responses: bool) -> object:
+            cls.url = url
+            cls.decode_responses = decode_responses
+            return object()
+
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict | None = None,
+        locals: dict | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "redis.asyncio":
+            return SimpleNamespace(Redis=FakeRedis)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    arclith = Arclith(config_dir)
+
+    assert arclith.config.cache.backend == "redis"
+    assert isinstance(arclith._cache, RedisCacheAdapter)
+    assert FakeRedis.url == "redis://cache:6379/0"
+    assert FakeRedis.decode_responses is True
+
+
+def test_redis_cache_adapter_missing_extra_has_actionable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict | None = None,
+        locals: dict | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "redis.asyncio":
+            raise ModuleNotFoundError("No module named 'redis'", name="redis")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError, match=r"arclith\[cache\]"):
+        RedisCacheAdapter("redis://cache:6379/0")


### PR DESCRIPTION
## Summary
- add cache/redis to the CLI capability catalog with REDIS_URL secret mapping
- generate loadable cache config for Redis without requiring a real Redis server in tests
- document multi-worker and local Docker Compose Redis usage
- tighten Redis optional import error to point to arclith[cache]

## Note
The generated cache config keeps config/adapters/inbound/cache.yaml because the current loader maps that scoped file to AppConfig.cache. The Redis URL is kept out of YAML and mapped through cache.redis_url -> REDIS_URL.

## Validation
- uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q from cli/
- uv run pytest tests/units/infrastructure/test_config.py tests/units/test_arclith_cache.py -q
- uv run pytest tests/units/test_arclith_cache.py -q
- uv run ruff check arclith_cli tests from cli/
- uv run ruff check arclith/adapters/outbound/redis/cache_adapter.py tests/units/test_arclith_cache.py
- make docs
- make quality

Closes #70