### PR TITLE
[CLI] Add Keycloak auth capability

### DIFF
--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -202,7 +202,8 @@ class Arclith:
         Adds ``components.securitySchemes.keycloak`` so Swagger UI shows an
         "Authorize" button that triggers the PKCE flow against Keycloak.
         Endpoints using ``make_require_auth`` / ``HTTPBearer`` also expose
-        the ``bearerAuth`` scheme automatically via FastAPI introspection.
+        the same runtime bearer dependency; the OpenAPI schema is rewritten so
+        Swagger UI presents only the Keycloak OAuth2 flow.
         """
         kc = self.config.keycloak
         if kc is None:
@@ -234,8 +235,8 @@ class Arclith:
 
             # Replace HTTPBearer with keycloak in route security so Swagger UI
             # only shows the OAuth2 scheme (no confusing empty HTTPBearer field).
-            # The server still accepts any valid Bearer token — HTTPBearer stays
-            # in securitySchemes for programmatic clients.
+            # The server still accepts any valid Bearer token at runtime because
+            # HTTPBearer remains the FastAPI dependency implementation.
             for path_item in schema.get("paths", {}).values():
                 for operation in path_item.values():
                     if not isinstance(operation, dict):

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -417,6 +417,55 @@ port: {port}
     ),
 )
 
+AUTH_CAPABILITY = CapabilitySpec(
+    name="auth",
+    layer="inbound",
+    description="Authentification JWT Keycloak mutualisée FastAPI et FastMCP.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="keycloak",
+            capability="auth",
+            layer="inbound",
+            description="JWT RS256 via JWKS Keycloak et Swagger UI OAuth2 PKCE.",
+            config_path="config/adapters/inbound/keycloak.yaml",
+            config_template="""\
+url: "{url}"
+realm: "{realm}"
+audience: {audience}
+client_id: {client_id}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="url",
+                    kind="string",
+                    prompt="URL Keycloak",
+                    default="http://localhost:8080",
+                ),
+                ParameterSpec(
+                    name="realm",
+                    kind="string",
+                    prompt="Realm Keycloak",
+                    default="rekipe",
+                ),
+                ParameterSpec(
+                    name="audience",
+                    kind="string",
+                    prompt="Audience JWT attendue",
+                    default="null",
+                ),
+                ParameterSpec(
+                    name="client_id",
+                    kind="string",
+                    prompt="Client public Swagger UI PKCE",
+                    default="null",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 LLM_CAPABILITY = CapabilitySpec(
     name="llm",
     layer="outbound",
@@ -779,6 +828,7 @@ CAPABILITY_CATALOG = (
     CACHE_CAPABILITY,
     API_CAPABILITY,
     MCP_CAPABILITY,
+    AUTH_CAPABILITY,
     LLM_CAPABILITY,
     AGENT_CAPABILITY,
     OBSERVABILITY_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -138,7 +138,7 @@ def version() -> None:
 def add_adapter(
     capability: Annotated[
         str,
-        typer.Option("--capability", help="Capacité cible: repository, cache, api, mcp, llm, agent ou observability"),
+        typer.Option("--capability", help="Capacité cible: repository, cache, api, mcp, auth, llm, agent ou observability"),
     ] = "repository",
     adapter: Annotated[
         str | None,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -426,6 +426,48 @@ def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -
     ]
 
 
+def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="auth",
+            adapter="keycloak",
+            adapter_params={
+                "url": "https://auth.example.test",
+                "realm": "rekipe",
+                "audience": "rekipe-api",
+                "client_id": "swagger-public",
+            },
+            yes=True,
+        )
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert config == {
+        "url": "https://auth.example.test",
+        "realm": "rekipe",
+        "audience": "rekipe-api",
+        "client_id": "swagger-public",
+    }
+    assert "auth:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    package_root = project_dir / "src" / "demo_service"
+    assert not (package_root / "adapters" / "inbound" / "keycloak").exists()
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.keycloak is not None
+    assert arclith.config.keycloak.url == "https://auth.example.test"
+    assert arclith.config.keycloak.realm == "rekipe"
+    assert arclith.config.keycloak.audience == "rekipe-api"
+    assert arclith.config.keycloak.client_id == "swagger-public"
+
+
 def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -97,6 +97,20 @@ def test_mcp_capability_catalog_declares_fastmcp() -> None:
     assert [parameter.name for parameter in fastmcp.parameters] == ["host", "port"]
 
 
+def test_auth_capability_catalog_declares_keycloak() -> None:
+    capability = get_capability("auth")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("keycloak",)
+    keycloak = capability.get_adapter("keycloak")
+    assert keycloak is not None
+    assert keycloak.config_path == "config/adapters/inbound/keycloak.yaml"
+    assert keycloak.entity_scoped is False
+    assert [parameter.name for parameter in keycloak.parameters] == ["url", "realm", "audience", "client_id"]
+
+
 def test_llm_capability_catalog_declares_model_adapters() -> None:
     capability = get_capability("llm")
 
@@ -226,6 +240,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "fastapi" in encoded
     assert "mcp" in encoded
     assert "fastmcp" in encoded
+    assert "auth" in encoded
+    assert "keycloak" in encoded
     assert "llm" in encoded
     assert "lmstudio" in encoded
     assert "agent" in encoded
@@ -283,6 +299,13 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     ]
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
+    auth = payload_by_name["auth"]
+    assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]
+    keycloak_parameters = {parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]}
+    assert keycloak_parameters["url"]["default"] == "http://localhost:8080"
+    assert keycloak_parameters["realm"]["default"] == "rekipe"
+    assert keycloak_parameters["audience"]["default"] == "null"
+    assert keycloak_parameters["client_id"]["default"] == "null"
     llm = payload_by_name["llm"]
     assert [adapter["name"] for adapter in llm["adapters"]] == ["lmstudio", "openai", "anthropic"]
     openai = llm["adapters"][1]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -47,13 +47,40 @@ config.yaml (keycloak / tenant / license / cache)
 
 ## Configuration
 
-```yaml
-# config.yaml
+Depuis un projet généré par `arclith-cli`, la configuration Keycloak peut être
+ajoutée sans toucher aux routers ni aux tools :
 
-keycloak:
-  url: http://keycloak:8080        # URL de base Keycloak
-  realm: rekipe                    # Realm cible
-  audience: rekipe-api             # Vérification aud dans le JWT (null = désactivé)
+```bash
+arclith-cli add-adapter \
+  --capability auth \
+  --adapter keycloak \
+  --param url=http://keycloak:8080 \
+  --param realm=rekipe \
+  --param audience=rekipe-api \
+  --param client_id=swagger-public \
+  --yes
+```
+
+Le CLI génère `config/adapters/inbound/keycloak.yaml`, chargé comme section
+`keycloak` par `Arclith("config")`. `audience` valide les tokens reçus par
+l'API ou les tools MCP. `client_id` sert uniquement au client public Swagger UI
+OAuth2 PKCE ; il peut différer de l'audience si le realm sépare clients front,
+Swagger et services machine-to-machine.
+
+```yaml
+# config/adapters/inbound/keycloak.yaml
+
+url: http://keycloak:8080        # URL de base Keycloak
+realm: rekipe                    # Realm cible
+audience: rekipe-api             # Vérification aud dans le JWT (null = désactivé)
+client_id: swagger-public        # Client public Swagger UI OAuth2 PKCE
+```
+
+Les autres sections restent dans leurs fichiers de configuration dédiés ou dans
+un `config.yaml` consolidé selon le mode de déploiement :
+
+```yaml
+# config.yaml consolidé
 
 license:
   role: rekipe:licensed            # Realm role requis — omis = pas de vérification licence
@@ -319,7 +346,7 @@ async def my_endpoint(
 
 **Avantages de `Depends` :**
 
-1. **Swagger UI** — `HTTPBearer` est automatiquement détecté par FastAPI, le bouton "Authorize" apparaît.
+1. **Swagger UI** — avec `config.keycloak`, le bouton "Authorize" expose le schéma OAuth2 PKCE Keycloak.
 2. **Typage complet** — `Annotated[dict, Depends(...)]` est visible par mypy/pyright.
 3. **Composabilité** — plusieurs `Depends` peuvent se chaîner (`inject_tenant` dépend lui-même du JWT).
 4. **Testabilité** — `app.dependency_overrides[require_auth] = lambda: {"sub": "test-user"}` pour les tests.
@@ -342,20 +369,22 @@ app.dependency_overrides[require_auth] = lambda: {"sub": "test-user-id"}
 Quand `config.keycloak` est présent, `Arclith.fastapi()` :
 1. Injecte le schéma OAuth2 PKCE dans l'OpenAPI spec (`/openapi.json`)
 2. Pré-configure `swagger_ui_init_oauth` avec `clientId` et PKCE
-3. Ajoute `bearerAuth` via `_http_bearer` (détecté automatiquement par FastAPI)
+3. Remplace le schéma `HTTPBearer` généré par FastAPI par le seul schéma
+   `keycloak` pour éviter un champ bearer vide et confus dans Swagger UI
 
-Le bouton **"Authorize"** apparaît dans Swagger UI (`/docs`). Deux options :
+Le bouton **"Authorize"** apparaît dans Swagger UI (`/docs`) avec un seul schéma
+`keycloak (OAuth2, authorizationCode)`.
 
-**Option A — OAuth2 PKCE (recommandé en dev)** :
+**Option A — OAuth2 PKCE (recommandé en dev et démonstration)** :
 1. Cliquer "Authorize"
 2. Sélectionner le schéma `keycloak (OAuth2, authorizationCode)`
 3. Scopes : `openid profile`
 4. Keycloak redirige → login → token automatiquement injecté
 
-**Option B — Bearer manuel** :
-1. Obtenir un token via `curl` ou Postman
-2. Cliquer "Authorize" → `bearerAuth (HTTP, Bearer)`
-3. Coller le token JWT brut (sans `Bearer `)
+**Option B — bearer machine-to-machine hors Swagger UI** :
+Swagger UI reste volontairement en OAuth2 PKCE. Les clients techniques, tests
+automatisés, MCP HTTP/SSE et appels Postman/curl utilisent le même pipeline
+serveur avec `Authorization: Bearer <access_token>`.
 
 ```bash
 # Obtenir un token Keycloak (client_credentials pour M2M)
@@ -363,6 +392,9 @@ curl -s -X POST \
   "http://keycloak:8080/realms/rekipe/protocol/openid-connect/token" \
   -d "grant_type=client_credentials&client_id=my-service&client_secret=$SECRET" \
   | jq -r .access_token
+
+# Appeler une route protégée avec ce token
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/v1/recipes
 ```
 
 ---

--- a/tests/units/test_arclith_auth.py
+++ b/tests/units/test_arclith_auth.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+from fastapi import Depends
+
+from arclith import Arclith
+
+
+def test_auth_dependency_requires_keycloak_config(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    arclith = Arclith(config_dir)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        arclith.auth_dependency()
+
+    message = str(exc_info.value)
+    assert "config.keycloak est requis" in message
+    assert "Ajouter la section keycloak" in message
+
+
+def test_fastapi_keycloak_openapi_uses_oauth2_pkce_without_http_bearer(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    keycloak_dir = config_dir / "adapters" / "inbound"
+    keycloak_dir.mkdir(parents=True)
+    (keycloak_dir / "keycloak.yaml").write_text(
+        "url: https://auth.example.test\n"
+        "realm: rekipe\n"
+        "audience: rekipe-api\n"
+        "client_id: swagger-public\n",
+        encoding="utf-8",
+    )
+    arclith = Arclith(config_dir)
+    require_auth = arclith.auth_dependency()
+    app = arclith.fastapi()
+
+    @app.get("/private", dependencies=[Depends(require_auth)])
+    async def private_endpoint() -> dict[str, str]:
+        return {"status": "ok"}
+
+    schema = app.openapi()
+    security_schemes = schema["components"]["securitySchemes"]
+    keycloak = security_schemes["keycloak"]
+
+    assert "HTTPBearer" not in security_schemes
+    assert keycloak["type"] == "oauth2"
+    assert keycloak["flows"]["authorizationCode"]["authorizationUrl"] == (
+        "https://auth.example.test/realms/rekipe/protocol/openid-connect/auth"
+    )
+    assert keycloak["flows"]["authorizationCode"]["tokenUrl"] == (
+        "https://auth.example.test/realms/rekipe/protocol/openid-connect/token"
+    )
+    assert schema["paths"]["/private"]["get"]["security"] == [
+        {"keycloak": ["openid", "profile"]}
+    ]
+    assert app.swagger_ui_init_oauth["clientId"] == "swagger-public"
+    assert app.swagger_ui_init_oauth["usePkceWithAuthorizationCodeGrant"] is True


### PR DESCRIPTION
## Summary
- add auth/keycloak to the arclith-cli capability catalog
- generate config/adapters/inbound/keycloak.yaml as a loadable Keycloak config
- document Swagger OAuth2 PKCE and M2M bearer-token usage without exposing a confusing HTTPBearer scheme
- add runtime tests for the auth_dependency missing-config error and Keycloak OpenAPI patch

## Validation
- uv run pytest tests/units/test_arclith_auth.py tests/units/infrastructure/test_config.py -q
- uv run ruff check arclith/arclith.py tests/units/test_arclith_auth.py
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- make docs
- make quality: fails on existing global coverage threshold, 306 tests passed but total coverage is 77 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #71
