### PR TITLE
[CLI] Add env secrets capability

### DIFF
--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -318,8 +318,15 @@ def _resolve_parameter(
     resolved = provided_value.strip() if isinstance(provided_value, str) else ""
     string_default = _default_string_value(parameter, project_dir)
     if not resolved and prompt_missing:
-        resolved = Prompt.ask(f"  {parameter.prompt}", default=string_default, password=parameter.secret).strip()
-    return resolved or string_default
+        prompt_kwargs: dict[str, Any] = {"password": parameter.secret}
+        if string_default:
+            prompt_kwargs["default"] = string_default
+        resolved = Prompt.ask(f"  {parameter.prompt}", **prompt_kwargs).strip()
+    resolved = resolved or string_default
+    if parameter.required and not resolved:
+        console.print(f"[red]✗[/red] Paramètre requis manquant: [bold]{parameter.name}[/bold].")
+        raise typer.Exit(1)
+    return resolved
 
 
 def _default_string_value(parameter: ParameterSpec, project_dir: Path) -> str:
@@ -473,7 +480,12 @@ def _generate(
 
     if adapter.has_secret_mappings():
         secrets_path = project_dir / "config" / "secrets.yaml"
-        _merge_secrets_file(secrets_path, adapter.secret_mappings)
+        _merge_secrets_file(
+            secrets_path,
+            adapter.secret_mappings,
+            resolver=adapter.secret_resolver,
+            params=params,
+        )
         console.print(f"[green]✓[/green] {secrets_path.relative_to(project_dir)}")
 
     for file_template in adapter.file_templates:
@@ -639,11 +651,19 @@ def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
     env_path.write_text("\n".join(merged_lines).rstrip("\n") + "\n", encoding="utf-8")
 
 
-def _merge_secrets_file(secrets_path: Path, mappings: tuple[SecretMappingSpec, ...]) -> None:
+def _merge_secrets_file(
+    secrets_path: Path,
+    mappings: tuple[SecretMappingSpec, ...],
+    *,
+    resolver: str | None = None,
+    params: dict[str, Any] | None = None,
+) -> None:
     secrets_path.parent.mkdir(parents=True, exist_ok=True)
     data = _read_yaml_mapping(secrets_path)
-    resolver = data.get("resolver")
-    if not isinstance(resolver, str) or not resolver.strip():
+    existing_resolver = data.get("resolver")
+    if resolver is not None:
+        data["resolver"] = resolver
+    elif not isinstance(existing_resolver, str) or not existing_resolver.strip():
         data["resolver"] = "env"
 
     existing_mappings = data.get("mappings")
@@ -651,8 +671,14 @@ def _merge_secrets_file(secrets_path: Path, mappings: tuple[SecretMappingSpec, .
         existing_mappings = {}
 
     merged_mappings = dict(existing_mappings)
+    render_params = params or {}
     for mapping in mappings:
-        merged_mappings[mapping.field_path] = mapping.secret_key
+        field_path = render(mapping.field_path, render_params).strip()
+        secret_key = render(mapping.secret_key, render_params).strip()
+        if not field_path:
+            console.print("[red]✗[/red] Un mapping de secret doit cibler un champ non vide.")
+            raise typer.Exit(1)
+        merged_mappings[field_path] = secret_key
     data["mappings"] = merged_mappings
 
     rendered = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -15,6 +15,7 @@ class ParameterSpec:
     default: str | bool | None = None
     default_from_project_name: bool = False
     secret: bool = False
+    required: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -24,6 +25,7 @@ class ParameterSpec:
             "default": self.default,
             "default_from_project_name": self.default_from_project_name,
             "secret": self.secret,
+            "required": self.required,
         }
 
 
@@ -62,6 +64,7 @@ class AdapterSpec:
     env_template: str = ""
     file_templates: tuple[FileTemplateSpec, ...] = ()
     secret_mappings: tuple[SecretMappingSpec, ...] = ()
+    secret_resolver: str | None = None
     parameters: tuple[ParameterSpec, ...] = ()
     entity_scoped: bool = True
 
@@ -87,6 +90,7 @@ class AdapterSpec:
             "env_path": self.env_path,
             "file_templates": [file_template.to_dict() for file_template in self.file_templates],
             "secret_mappings": [secret_mapping.to_dict() for secret_mapping in self.secret_mappings],
+            "secret_resolver": self.secret_resolver,
             "parameters": [parameter.to_dict() for parameter in self.parameters],
             "entity_scoped": self.entity_scoped,
         }
@@ -333,6 +337,43 @@ REDIS_URL={redis_url}
                     kind="string",
                     prompt="TTL tenant en secondes",
                     default="300",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
+SECRETS_CAPABILITY = CapabilitySpec(
+    name="secrets",
+    layer="outbound",
+    description="Résolution de secrets avant validation de la configuration Arclith.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="env",
+            capability="secrets",
+            layer="outbound",
+            description="Resolver de secrets depuis les variables d'environnement Docker, CI/CD ou Kubernetes.",
+            secret_resolver="env",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="{field_path}",
+                    secret_key="{secret_key}",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="field_path",
+                    kind="string",
+                    prompt="Champ de configuration à alimenter",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="secret_key",
+                    kind="string",
+                    prompt="Variable d'environnement explicite (vide = dérivée du champ)",
+                    default="",
                 ),
             ),
             entity_scoped=False,
@@ -826,6 +867,7 @@ OTEL_EXPORTER_OTLP_HEADERS={headers}
 CAPABILITY_CATALOG = (
     REPOSITORY_CAPABILITY,
     CACHE_CAPABILITY,
+    SECRETS_CAPABILITY,
     API_CAPABILITY,
     MCP_CAPABILITY,
     AUTH_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -138,7 +138,10 @@ def version() -> None:
 def add_adapter(
     capability: Annotated[
         str,
-        typer.Option("--capability", help="Capacité cible: repository, cache, api, mcp, auth, llm, agent ou observability"),
+        typer.Option(
+            "--capability",
+            help="Capacité cible: repository, cache, secrets, api, mcp, auth, llm, agent ou observability",
+        ),
     ] = "repository",
     adapter: Annotated[
         str | None,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1096,6 +1096,106 @@ def test_add_cache_redis_adapter_generates_secret_mapping(
     assert app.config.cache.tenant_uri_ttl == 120
 
 
+def test_add_env_secrets_adapter_preserves_existing_mappings_and_uses_explicit_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / "config" / "secrets.yaml").write_text(
+        "resolver: yaml\n"
+        "mappings:\n"
+        "  adapters.lm.api_key: OPENAI_API_KEY\n",
+        encoding="utf-8",
+    )
+    outbound_dir = project_dir / "config" / "adapters" / "outbound"
+    outbound_dir.mkdir(parents=True, exist_ok=True)
+    (outbound_dir / "mongodb.yaml").write_text(
+        "uri: null\n"
+        "db_name: demo\n"
+        "collection_name: null\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="env",
+            adapter_params={
+                "field_path": "adapters.mongodb.uri",
+                "secret_key": "MONGODB_URI",
+            },
+            yes=True,
+        )
+    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+
+    assert secrets["resolver"] == "env"
+    assert secrets["mappings"] == {
+        "adapters.lm.api_key": "OPENAI_API_KEY",
+        "adapters.mongodb.uri": "MONGODB_URI",
+    }
+
+    monkeypatch.setenv("MONGODB_URI", "mongodb://env:27017")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.mongodb is not None
+    assert arclith.config.adapters.mongodb.uri == "mongodb://env:27017"
+
+
+def test_add_env_secrets_adapter_allows_derived_env_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    outbound_dir = project_dir / "config" / "adapters" / "outbound"
+    outbound_dir.mkdir(parents=True, exist_ok=True)
+    (outbound_dir / "mongodb.yaml").write_text(
+        "uri: null\n"
+        "db_name: demo\n"
+        "collection_name: null\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="secrets",
+        adapter="env",
+        adapter_params={"field_path": "adapters.mongodb.uri"},
+        yes=True,
+    )
+    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+
+    assert secrets["resolver"] == "env"
+    assert secrets["mappings"]["adapters.mongodb.uri"] == ""
+
+    monkeypatch.setenv("ADAPTERS_MONGODB_URI", "mongodb://derived:27017")
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.mongodb is not None
+    assert arclith.config.adapters.mongodb.uri == "mongodb://derived:27017"
+
+
+def test_add_env_secrets_adapter_requires_field_path(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="env",
+            yes=True,
+        )
+
+    assert not (project_dir / "config" / "secrets.yaml").exists()
+
+
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:
     parameter = ParameterSpec(name="multitenant", kind="boolean", prompt="multitenant", default="false")
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -46,6 +46,24 @@ def test_cache_capability_catalog_declares_memory_adapter() -> None:
     assert [mapping.secret_key for mapping in redis.secret_mappings] == ["REDIS_URL"]
 
 
+def test_secrets_capability_catalog_declares_env_adapter() -> None:
+    capability = get_capability("secrets")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("env",)
+    env = capability.get_adapter("env")
+    assert env is not None
+    assert env.config_path is None
+    assert env.secret_resolver == "env"
+    assert env.entity_scoped is False
+    assert [parameter.name for parameter in env.parameters] == ["field_path", "secret_key"]
+    assert env.parameters[0].required is True
+    assert [mapping.field_path for mapping in env.secret_mappings] == ["{field_path}"]
+    assert [mapping.secret_key for mapping in env.secret_mappings] == ["{secret_key}"]
+
+
 def test_observability_capability_catalog_declares_langsmith() -> None:
     capability = get_capability("observability")
 
@@ -236,6 +254,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "mongodb" in encoded
     assert "cache" in encoded
     assert "redis" in encoded
+    assert "secrets" in encoded
+    assert "env" in encoded
     assert "api" in encoded
     assert "fastapi" in encoded
     assert "mcp" in encoded
@@ -297,6 +317,12 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [mapping["field_path"] for mapping in cache["adapters"][1]["secret_mappings"]] == [
         "cache.redis_url"
     ]
+    secrets = payload_by_name["secrets"]
+    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env"]
+    env = secrets["adapters"][0]
+    assert env["secret_resolver"] == "env"
+    assert [parameter["name"] for parameter in env["parameters"]] == ["field_path", "secret_key"]
+    assert env["parameters"][0]["required"] is True
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
     auth = payload_by_name["auth"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -226,6 +226,56 @@ services:
 Depuis un service lancé dans le même réseau Compose, utiliser `REDIS_URL=redis://redis:6379`. Depuis
 un processus lancé sur l'hôte, utiliser `REDIS_URL=redis://127.0.0.1:6379`.
 
+### `secrets`
+
+Capacité outbound transverse pour résoudre les secrets avant validation Pydantic de `AppConfig`.
+Elle ne génère jamais de valeur réelle: elle ne déclare que le resolver et les mappings dans
+`config/secrets.yaml`.
+
+Adaptateur disponible:
+
+- `env`: lit les valeurs depuis les variables d'environnement du processus, compatible Docker,
+  Kubernetes, CI/CD et plateformes cloud.
+
+Ajouter un mapping avec une clé explicite:
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter env \
+  --param field_path=adapters.mongodb.uri \
+  --param secret_key=MONGODB_URI \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/secrets.yaml
+resolver: env
+mappings:
+  adapters.mongodb.uri: MONGODB_URI
+```
+
+Ajouter un mapping avec un nom dérivé:
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter env \
+  --param field_path=adapters.mongodb.uri \
+  --yes
+```
+
+Dans ce cas, la valeur du mapping reste vide et `EnvSecretAdapter` dérive le nom d'environnement
+depuis le chemin de champ: `adapters.mongodb.uri` devient `ADAPTERS_MONGODB_URI`. Une clé explicite
+prime toujours sur le nom dérivé, ce qui permet de garder les conventions d'écosystème comme
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MONGODB_URI`, `MARIADB_URL` ou `REDIS_URL`.
+
+`arclith-cli` fusionne les nouveaux mappings dans `config/secrets.yaml` sans supprimer les mappings
+existants. Si un secret requis manque et que le champ cible n'est pas explicitement `null`, le
+chargement de configuration échoue avec un message `Secrets non résolus` qui liste le champ concerné.
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.

--- a/tests/units/infrastructure/test_secret_factory.py
+++ b/tests/units/infrastructure/test_secret_factory.py
@@ -157,7 +157,7 @@ def test_resolve_no_mappings_returns_original() -> None:
 def test_resolve_raises_on_unresolved_secret() -> None:
     data = {"secrets": {"mappings": {"adapters.mongodb.uri": "p"}}}
     resolver = _make_resolver({"adapters.mongodb.uri": None})
-    with pytest.raises(RuntimeError, match="Secrets non résolus"):
+    with pytest.raises(RuntimeError, match="adapters.mongodb.uri"):
         resolve_dict_secrets(data, resolver)
 
 


### PR DESCRIPTION
## Summary
- add secrets/env to the arclith-cli capability catalog
- allow templated secret mappings with required CLI parameters
- merge config/secrets.yaml mappings idempotently while configuring resolver: env
- document explicit env keys and derived names such as ADAPTERS_MONGODB_URI and OPENAI_API_KEY

## Validation
- uv run pytest tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py -q
- uv run ruff check arclith/infrastructure/secret_factory.py arclith/infrastructure/secret_loader.py tests/units/infrastructure/test_secret_factory.py
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- make docs
- make quality: fails on existing global coverage threshold, 306 tests passed but total coverage is 77 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #72
