### PR TITLE
[CLI] Add yaml secrets capability

### DIFF
--- a/arclith/infrastructure/secret_factory.py
+++ b/arclith/infrastructure/secret_factory.py
@@ -30,7 +30,9 @@ def build_secret_resolver(raw_config: dict, base_path: Path | None = None) -> Se
             case "yaml":
                 yaml_cfg: dict = secrets.get("yaml") or {}
                 default_path = str(base_path / "secrets.yaml") if base_path else "secrets.yaml"
-                path: str = yaml_cfg.get("path", default_path)
+                path = Path(str(yaml_cfg.get("path", default_path)))
+                if base_path is not None and not path.is_absolute():
+                    path = base_path / path
                 from arclith.adapters.outbound.yaml.secret_adapter import YamlSecretAdapter
                 return YamlSecretAdapter(path=path)
             case "env":
@@ -45,4 +47,3 @@ def build_secret_resolver(raw_config: dict, base_path: Path | None = None) -> Se
         return ChainSecretAdapter([_make(n) for n in chain_names])
 
     return _make(resolver_type)
-

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -418,9 +418,13 @@ def _list_generated_files(
         gitignore = project_dir / ".gitignore"
         files.append((gitignore, "mis à jour" if gitignore.exists() else "créé"))
 
-    if adapter.has_secret_mappings():
+    if adapter.has_secret_mappings() or adapter.has_secret_config():
         secrets_file = project_dir / "config" / "secrets.yaml"
         files.append((secrets_file, "mis à jour" if secrets_file.exists() else "créé"))
+
+    if adapter.gitignore_entries:
+        gitignore = project_dir / ".gitignore"
+        files.append((gitignore, "mis à jour" if gitignore.exists() else "créé"))
 
     template_vars = _file_template_vars(project_dir, paths, adapter, params={})
     for file_template in adapter.file_templates:
@@ -475,18 +479,23 @@ def _generate(
     if adapter.has_env() and adapter.env_path:
         env_path = project_dir / adapter.env_path
         _merge_env_file(env_path, _parse_env_template(render(adapter.env_template, params)))
-        _ensure_env_is_ignored(project_dir)
+        _ensure_gitignore_entries(project_dir, (".env",))
         console.print(f"[green]✓[/green] {env_path.relative_to(project_dir)}")
 
-    if adapter.has_secret_mappings():
+    if adapter.has_secret_mappings() or adapter.has_secret_config():
         secrets_path = project_dir / "config" / "secrets.yaml"
         _merge_secrets_file(
             secrets_path,
             adapter.secret_mappings,
             resolver=adapter.secret_resolver,
+            config_template=adapter.secret_config_template,
             params=params,
         )
         console.print(f"[green]✓[/green] {secrets_path.relative_to(project_dir)}")
+
+    if adapter.gitignore_entries:
+        _ensure_gitignore_entries(project_dir, adapter.gitignore_entries)
+        console.print("[green]✓[/green] .gitignore")
 
     for file_template in adapter.file_templates:
         generated_path = project_dir / render(file_template.path, params)
@@ -561,7 +570,22 @@ def _file_template_vars(
         "package_path": package_path,
         "langgraph_entrypoint": langgraph_entrypoint,
         "graph_name": graph_name,
+        "secret_template_yaml": _secret_template_yaml(str(params.get("field_path") or "")),
     }
+
+
+def _secret_template_yaml(field_path: str) -> str:
+    keys = [key for key in field_path.split(".") if key]
+    if not keys:
+        return "# Ajouter les secrets locaux ici."
+
+    data: dict[str, Any] = {}
+    current = data
+    for key in keys[:-1]:
+        current[key] = {}
+        current = current[key]
+    current[keys[-1]] = "replace-me"
+    return yaml.safe_dump(data, sort_keys=False, allow_unicode=True).rstrip("\n")
 
 
 def _update_active_capability(project_dir: Path, capability: CapabilitySpec, adapter: AdapterSpec) -> None:
@@ -656,6 +680,7 @@ def _merge_secrets_file(
     mappings: tuple[SecretMappingSpec, ...],
     *,
     resolver: str | None = None,
+    config_template: str = "",
     params: dict[str, Any] | None = None,
 ) -> None:
     secrets_path.parent.mkdir(parents=True, exist_ok=True)
@@ -666,12 +691,20 @@ def _merge_secrets_file(
     elif not isinstance(existing_resolver, str) or not existing_resolver.strip():
         data["resolver"] = "env"
 
+    render_params = params or {}
+    if config_template:
+        rendered_config = render(config_template, render_params)
+        config_data = yaml.safe_load(rendered_config) or {}
+        if not isinstance(config_data, dict):
+            console.print("[red]✗[/red] La configuration de secrets générée doit être un mapping YAML.")
+            raise typer.Exit(1)
+        data = _deep_merge_mapping(data, config_data)
+
     existing_mappings = data.get("mappings")
     if not isinstance(existing_mappings, dict):
         existing_mappings = {}
 
     merged_mappings = dict(existing_mappings)
-    render_params = params or {}
     for mapping in mappings:
         field_path = render(mapping.field_path, render_params).strip()
         secret_key = render(mapping.secret_key, render_params).strip()
@@ -685,6 +718,17 @@ def _merge_secrets_file(
     secrets_path.write_text(rendered, encoding="utf-8")
 
 
+def _deep_merge_mapping(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    result = dict(base)
+    for key, value in override.items():
+        current = result.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            result[key] = _deep_merge_mapping(current, value)
+        else:
+            result[key] = value
+    return result
+
+
 def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
@@ -695,15 +739,17 @@ def _read_yaml_mapping(path: Path) -> dict[str, Any]:
     return {}
 
 
-def _ensure_env_is_ignored(project_dir: Path) -> None:
+def _ensure_gitignore_entries(project_dir: Path, entries: tuple[str, ...]) -> None:
     gitignore = project_dir / ".gitignore"
     if gitignore.exists():
         lines = gitignore.read_text(encoding="utf-8").splitlines()
     else:
         lines = []
-    if ".env" in {line.strip() for line in lines}:
+    existing = {line.strip() for line in lines}
+    missing = [entry for entry in entries if entry not in existing]
+    if not missing:
         return
     if lines and lines[-1].strip():
         lines.append("")
-    lines.append(".env")
+    lines.extend(missing)
     gitignore.write_text("\n".join(lines).rstrip("\n") + "\n", encoding="utf-8")

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -65,6 +65,8 @@ class AdapterSpec:
     file_templates: tuple[FileTemplateSpec, ...] = ()
     secret_mappings: tuple[SecretMappingSpec, ...] = ()
     secret_resolver: str | None = None
+    secret_config_template: str = ""
+    gitignore_entries: tuple[str, ...] = ()
     parameters: tuple[ParameterSpec, ...] = ()
     entity_scoped: bool = True
 
@@ -80,6 +82,9 @@ class AdapterSpec:
     def has_secret_mappings(self) -> bool:
         return bool(self.secret_mappings)
 
+    def has_secret_config(self) -> bool:
+        return bool(self.secret_config_template)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
@@ -91,6 +96,8 @@ class AdapterSpec:
             "file_templates": [file_template.to_dict() for file_template in self.file_templates],
             "secret_mappings": [secret_mapping.to_dict() for secret_mapping in self.secret_mappings],
             "secret_resolver": self.secret_resolver,
+            "secret_config_template": bool(self.secret_config_template),
+            "gitignore_entries": list(self.gitignore_entries),
             "parameters": [parameter.to_dict() for parameter in self.parameters],
             "entity_scoped": self.entity_scoped,
         }
@@ -374,6 +381,55 @@ SECRETS_CAPABILITY = CapabilitySpec(
                     kind="string",
                     prompt="Variable d'environnement explicite (vide = dérivée du champ)",
                     default="",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+        AdapterSpec(
+            name="yaml",
+            capability="secrets",
+            layer="outbound",
+            description="Resolver YAML local gitignoré pour POC et développement sans Vault.",
+            secret_resolver="yaml",
+            secret_config_template="""\
+yaml:
+  path: "{path}"
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="{field_path}",
+                    secret_key="{secret_key}",
+                ),
+            ),
+            file_templates=(
+                FileTemplateSpec(
+                    path="secrets.yaml.template",
+                    template="""\
+# Copiez ce fichier vers secrets.yaml pour le développement local.
+# Ne commitez jamais secrets.yaml.
+{secret_template_yaml}
+""",
+                ),
+            ),
+            gitignore_entries=("secrets.yaml",),
+            parameters=(
+                ParameterSpec(
+                    name="field_path",
+                    kind="string",
+                    prompt="Champ de configuration à alimenter",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="secret_key",
+                    kind="string",
+                    prompt="Clé descriptive du secret (ignorée par le resolver YAML)",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="path",
+                    kind="string",
+                    prompt="Chemin du fichier YAML local",
+                    default="secrets.yaml",
                 ),
             ),
             entity_scoped=False,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1196,6 +1196,65 @@ def test_add_env_secrets_adapter_requires_field_path(tmp_path: Path) -> None:
     assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
+def test_add_yaml_secrets_adapter_generates_template_and_preserves_real_secret_file(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    outbound_dir = project_dir / "config" / "adapters" / "outbound"
+    outbound_dir.mkdir(parents=True, exist_ok=True)
+    (outbound_dir / "mongodb.yaml").write_text(
+        "uri: null\n"
+        "db_name: demo\n"
+        "collection_name: null\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+    real_secret = "adapters:\n  mongodb:\n    uri: mongodb://local:27017\n"
+    (project_dir / "secrets.yaml").write_text(real_secret, encoding="utf-8")
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="yaml",
+            adapter_params={
+                "field_path": "adapters.mongodb.uri",
+                "path": "secrets.yaml",
+            },
+            yes=True,
+        )
+    config_secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    template = (project_dir / "secrets.yaml.template").read_text(encoding="utf-8")
+    gitignore = (project_dir / ".gitignore").read_text(encoding="utf-8")
+
+    assert config_secrets["resolver"] == "yaml"
+    assert config_secrets["yaml"] == {"path": "secrets.yaml"}
+    assert config_secrets["mappings"]["adapters.mongodb.uri"] == ""
+    assert (project_dir / "secrets.yaml").read_text(encoding="utf-8") == real_secret
+    assert "secrets.yaml" in gitignore.splitlines()
+    assert "mongodb://local:27017" not in template
+    assert yaml.safe_load("\n".join(template.splitlines()[2:])) == {
+        "adapters": {"mongodb": {"uri": "replace-me"}}
+    }
+
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True, text=True)
+    ignored = subprocess.run(
+        ["git", "check-ignore", "secrets.yaml"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert ignored.returncode == 0
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.mongodb is not None
+    assert arclith.config.adapters.mongodb.uri == "mongodb://local:27017"
+
+
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:
     parameter = ParameterSpec(name="multitenant", kind="boolean", prompt="multitenant", default="false")
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -52,8 +52,9 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("env",)
+    assert capability.adapter_names() == ("env", "yaml")
     env = capability.get_adapter("env")
+    yaml = capability.get_adapter("yaml")
     assert env is not None
     assert env.config_path is None
     assert env.secret_resolver == "env"
@@ -62,6 +63,12 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert env.parameters[0].required is True
     assert [mapping.field_path for mapping in env.secret_mappings] == ["{field_path}"]
     assert [mapping.secret_key for mapping in env.secret_mappings] == ["{secret_key}"]
+    assert yaml is not None
+    assert yaml.config_path is None
+    assert yaml.secret_resolver == "yaml"
+    assert yaml.gitignore_entries == ("secrets.yaml",)
+    assert [file_template.path for file_template in yaml.file_templates] == ["secrets.yaml.template"]
+    assert [parameter.name for parameter in yaml.parameters] == ["field_path", "secret_key", "path"]
 
 
 def test_observability_capability_catalog_declares_langsmith() -> None:
@@ -318,11 +325,15 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "cache.redis_url"
     ]
     secrets = payload_by_name["secrets"]
-    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env"]
+    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml"]
     env = secrets["adapters"][0]
+    yaml_adapter = secrets["adapters"][1]
     assert env["secret_resolver"] == "env"
     assert [parameter["name"] for parameter in env["parameters"]] == ["field_path", "secret_key"]
     assert env["parameters"][0]["required"] is True
+    assert yaml_adapter["secret_resolver"] == "yaml"
+    assert yaml_adapter["gitignore_entries"] == ["secrets.yaml"]
+    assert [template["path"] for template in yaml_adapter["file_templates"]] == ["secrets.yaml.template"]
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
     auth = payload_by_name["auth"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -232,10 +232,11 @@ Capacité outbound transverse pour résoudre les secrets avant validation Pydant
 Elle ne génère jamais de valeur réelle: elle ne déclare que le resolver et les mappings dans
 `config/secrets.yaml`.
 
-Adaptateur disponible:
+Adaptateurs disponibles:
 
 - `env`: lit les valeurs depuis les variables d'environnement du processus, compatible Docker,
   Kubernetes, CI/CD et plateformes cloud.
+- `yaml`: lit un fichier YAML local gitignoré pour POC et développement sans Vault.
 
 Ajouter un mapping avec une clé explicite:
 
@@ -275,6 +276,43 @@ prime toujours sur le nom dérivé, ce qui permet de garder les conventions d'é
 `arclith-cli` fusionne les nouveaux mappings dans `config/secrets.yaml` sans supprimer les mappings
 existants. Si un secret requis manque et que le champ cible n'est pas explicitement `null`, le
 chargement de configuration échoue avec un message `Secrets non résolus` qui liste le champ concerné.
+
+Pour un fallback local, utiliser `secrets/yaml` :
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter yaml \
+  --param field_path=adapters.mongodb.uri \
+  --param path=secrets.yaml \
+  --yes
+```
+
+Résultat côté configuration:
+
+```yaml
+# config/secrets.yaml
+resolver: yaml
+yaml:
+  path: secrets.yaml
+mappings:
+  adapters.mongodb.uri: ""
+```
+
+Le CLI génère aussi `secrets.yaml.template` sans valeur réelle et ajoute `secrets.yaml` à
+`.gitignore`. Copier le template localement puis renseigner la valeur sensible dans le fichier
+ignoré:
+
+```yaml
+# secrets.yaml
+adapters:
+  mongodb:
+    uri: mongodb://localhost:27017/my_service
+```
+
+Le fichier local suit le format imbriqué du `field_path`: `adapters.mongodb.uri` devient
+`adapters -> mongodb -> uri`. Le resolver YAML ignore la clé descriptive du mapping et lit toujours
+le chemin imbriqué, ce qui évite de stocker des secrets sous des noms plats non typés.
 
 ### `api`
 

--- a/tests/units/infrastructure/test_secret_factory.py
+++ b/tests/units/infrastructure/test_secret_factory.py
@@ -43,6 +43,21 @@ def test_yaml_resolver_defaults_to_secrets_yaml(tmp_path: Path) -> None:
     assert isinstance(build_secret_resolver(data, tmp_path), YamlSecretAdapter)
 
 
+def test_yaml_resolver_relative_path_uses_base_path(tmp_path: Path) -> None:
+    data = {
+        "secrets": {
+            "resolver": "yaml",
+            "mappings": {"adapters.mongodb.uri": ""},
+            "yaml": {"path": "local-secrets.yaml"},
+        }
+    }
+    from arclith.adapters.outbound.yaml.secret_adapter import YamlSecretAdapter
+    resolver = build_secret_resolver(data, tmp_path)
+
+    assert isinstance(resolver, YamlSecretAdapter)
+    assert resolver._path == tmp_path / "local-secrets.yaml"
+
+
 def test_builds_env_resolver() -> None:
     data = {
         "secrets": {


### PR DESCRIPTION
## Summary
- add secrets/yaml to the arclith-cli capability catalog
- generate config/secrets.yaml with resolver: yaml, yaml.path and templated mappings
- generate secrets.yaml.template without real secrets and add secrets.yaml to .gitignore
- resolve relative yaml.path values from the project root when loading config directories

## Validation
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- uv run pytest tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py -q
- uv run ruff check arclith/infrastructure/secret_factory.py arclith/infrastructure/secret_loader.py tests/units/infrastructure/test_secret_factory.py
- make docs
- make quality: fails on existing global coverage threshold, 307 tests passed but total coverage is 77.05 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #73
