### PR TITLE
[CLI] Add vault secrets capability

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -434,6 +434,51 @@ yaml:
             ),
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="vault",
+            capability="secrets",
+            layer="outbound",
+            description="Resolver HashiCorp Vault KV v2 pour secrets applicatifs.",
+            secret_resolver="vault",
+            secret_config_template="""\
+vault:
+  addr: "{addr}"
+  mount: "{mount}"
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="{field_path}",
+                    secret_key="{secret_key}",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="field_path",
+                    kind="string",
+                    prompt="Champ de configuration à alimenter",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="secret_key",
+                    kind="string",
+                    prompt="Chemin Vault relatif au mount KV v2",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="addr",
+                    kind="string",
+                    prompt="Adresse Vault",
+                    default="http://127.0.0.1:8200",
+                ),
+                ParameterSpec(
+                    name="mount",
+                    kind="string",
+                    prompt="Mount KV v2",
+                    default="kv",
+                ),
+            ),
+            entity_scoped=False,
+        ),
     ),
 )
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import typer
@@ -1253,6 +1254,82 @@ def test_add_yaml_secrets_adapter_generates_template_and_preserves_real_secret_f
 
     assert arclith.config.adapters.mongodb is not None
     assert arclith.config.adapters.mongodb.uri == "mongodb://local:27017"
+
+
+def test_add_vault_secrets_adapter_generates_safe_config_and_resolves_with_fake_hvac(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    outbound_dir = project_dir / "config" / "adapters" / "outbound"
+    outbound_dir.mkdir(parents=True, exist_ok=True)
+    (outbound_dir / "mongodb.yaml").write_text(
+        "uri: null\n"
+        "db_name: demo\n"
+        "collection_name: null\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="vault",
+            adapter_params={
+                "field_path": "adapters.mongodb.uri",
+                "secret_key": "apps/demo/mongodb",
+                "addr": "http://vault:8200",
+                "mount": "kv-app",
+            },
+            yes=True,
+        )
+    secrets_text = (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    secrets = yaml.safe_load(secrets_text)
+
+    assert secrets["resolver"] == "vault"
+    assert secrets["vault"] == {"addr": "http://vault:8200", "mount": "kv-app"}
+    assert secrets["mappings"] == {"adapters.mongodb.uri": "apps/demo/mongodb"}
+    assert "VAULT_TOKEN" not in secrets_text
+    assert "mongodb://vault:27017" not in secrets_text
+
+    fake_client = MagicMock()
+    fake_client.is_authenticated.return_value = True
+    fake_client.secrets.kv.v2.read_secret_version.return_value = {
+        "data": {"data": {"value": "mongodb://vault:27017"}}
+    }
+    fake_hvac = MagicMock()
+    fake_hvac.Client.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "hvac", fake_hvac)
+    monkeypatch.setenv("VAULT_TOKEN", "test-token")
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.mongodb is not None
+    assert arclith.config.adapters.mongodb.uri == "mongodb://vault:27017"
+    fake_hvac.Client.assert_called_with(url="http://vault:8200", token="test-token")
+    fake_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+        path="apps/demo/mongodb",
+        mount_point="kv-app",
+        raise_on_deleted_version=True,
+    )
+
+
+def test_add_vault_secrets_adapter_requires_secret_key(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="vault",
+            adapter_params={"field_path": "adapters.mongodb.uri"},
+            yes=True,
+        )
+
+    assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -52,9 +52,10 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("env", "yaml")
+    assert capability.adapter_names() == ("env", "yaml", "vault")
     env = capability.get_adapter("env")
     yaml = capability.get_adapter("yaml")
+    vault = capability.get_adapter("vault")
     assert env is not None
     assert env.config_path is None
     assert env.secret_resolver == "env"
@@ -69,6 +70,13 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert yaml.gitignore_entries == ("secrets.yaml",)
     assert [file_template.path for file_template in yaml.file_templates] == ["secrets.yaml.template"]
     assert [parameter.name for parameter in yaml.parameters] == ["field_path", "secret_key", "path"]
+    assert vault is not None
+    assert vault.config_path is None
+    assert vault.secret_resolver == "vault"
+    assert vault.entity_scoped is False
+    assert [parameter.name for parameter in vault.parameters] == ["field_path", "secret_key", "addr", "mount"]
+    assert vault.parameters[0].required is True
+    assert vault.parameters[1].required is True
 
 
 def test_observability_capability_catalog_declares_langsmith() -> None:
@@ -325,15 +333,23 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "cache.redis_url"
     ]
     secrets = payload_by_name["secrets"]
-    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml"]
+    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml", "vault"]
     env = secrets["adapters"][0]
     yaml_adapter = secrets["adapters"][1]
+    vault_adapter = secrets["adapters"][2]
     assert env["secret_resolver"] == "env"
     assert [parameter["name"] for parameter in env["parameters"]] == ["field_path", "secret_key"]
     assert env["parameters"][0]["required"] is True
     assert yaml_adapter["secret_resolver"] == "yaml"
     assert yaml_adapter["gitignore_entries"] == ["secrets.yaml"]
     assert [template["path"] for template in yaml_adapter["file_templates"]] == ["secrets.yaml.template"]
+    assert vault_adapter["secret_resolver"] == "vault"
+    assert [parameter["name"] for parameter in vault_adapter["parameters"]] == [
+        "field_path",
+        "secret_key",
+        "addr",
+        "mount",
+    ]
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
     auth = payload_by_name["auth"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -314,6 +314,55 @@ Le fichier local suit le format imbriqué du `field_path`: `adapters.mongodb.uri
 `adapters -> mongodb -> uri`. Le resolver YAML ignore la clé descriptive du mapping et lit toujours
 le chemin imbriqué, ce qui évite de stocker des secrets sous des noms plats non typés.
 
+Pour Vault KV v2, installer l'extra dans le service qui charge la configuration :
+
+```bash
+uv add "arclith[vault]"
+```
+
+Puis configurer le resolver sans token :
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter vault \
+  --param field_path=adapters.mongodb.uri \
+  --param secret_key=apps/demo/mongodb \
+  --param addr=http://vault:8200 \
+  --param mount=kv \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/secrets.yaml
+resolver: vault
+vault:
+  addr: http://vault:8200
+  mount: kv
+mappings:
+  adapters.mongodb.uri: apps/demo/mongodb
+```
+
+Le token Vault n'est jamais écrit par la CLI. Au runtime, `VaultSecretAdapter` lit `VAULT_TOKEN` ou
+`~/.vault-token`. `VAULT_ADDR` peut surcharger `secrets.vault.addr`, ce qui permet de garder le même
+fichier de configuration entre local, CI et cluster.
+
+POC local minimal :
+
+```bash
+vault server -dev
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=<root-token-dev>
+vault secrets enable -path=kv -version=2 kv
+vault kv put kv/apps/demo/mongodb value="mongodb://localhost:27017/demo"
+```
+
+Le mount `kv` doit être un engine KV v2. Avec `hvac`, Arclith lit le secret via KV v2 avec
+`mount_point=kv` et attend la valeur applicative dans le champ `value`. Pour une policy dédiée, le
+chemin de lecture Vault correspondant est `kv/data/apps/demo/mongodb`.
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.


### PR DESCRIPTION
## Summary
- add secrets/vault to the arclith-cli capability catalog
- generate safe, idempotent config/secrets.yaml with resolver: vault, vault.addr, vault.mount and mappings
- test Vault resolution with a fake hvac client, without requiring a Vault server
- document KV v2 mount setup, token handling, VAULT_ADDR override and local POC commands

## References
- https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2/setup
- https://python-hvac.org/en/stable/usage/secrets_engines/kv_v2.html

## Validation
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- uv run pytest tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py -q
- uv run ruff check arclith/adapters/outbound/vault/secret_adapter.py arclith/infrastructure/secret_factory.py tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py
- make docs
- make quality: fails on existing global coverage threshold, 307 tests passed but total coverage is 77.05 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #74
