### PR TITLE
[CLI] Add chained secrets capability

### DIFF
--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -326,7 +326,30 @@ def _resolve_parameter(
     if parameter.required and not resolved:
         console.print(f"[red]✗[/red] Paramètre requis manquant: [bold]{parameter.name}[/bold].")
         raise typer.Exit(1)
+    _assert_allowed_parameter_value(parameter, resolved)
     return resolved
+
+
+def _assert_allowed_parameter_value(parameter: ParameterSpec, value: str) -> None:
+    if not parameter.choices:
+        return
+
+    values = _split_csv_values(value) if parameter.csv_choices else [value.strip()]
+    unknown = [item for item in values if item not in parameter.choices]
+    if not unknown:
+        return
+
+    allowed = ", ".join(parameter.choices)
+    received = ", ".join(unknown)
+    console.print(
+        f"[red]✗[/red] Valeur invalide pour [bold]{parameter.name}[/bold]: {received}. "
+        f"Valeurs: {allowed}."
+    )
+    raise typer.Exit(1)
+
+
+def _split_csv_values(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
 def _default_string_value(parameter: ParameterSpec, project_dir: Path) -> str:
@@ -571,6 +594,7 @@ def _file_template_vars(
         "langgraph_entrypoint": langgraph_entrypoint,
         "graph_name": graph_name,
         "secret_template_yaml": _secret_template_yaml(str(params.get("field_path") or "")),
+        "secret_chain_yaml": _secret_chain_yaml(str(params.get("resolvers") or "")),
     }
 
 
@@ -586,6 +610,11 @@ def _secret_template_yaml(field_path: str) -> str:
         current = current[key]
     current[keys[-1]] = "replace-me"
     return yaml.safe_dump(data, sort_keys=False, allow_unicode=True).rstrip("\n")
+
+
+def _secret_chain_yaml(resolvers: str) -> str:
+    values = _split_csv_values(resolvers or "env,vault,yaml")
+    return "".join(f"  - {value}\n" for value in values).rstrip("\n")
 
 
 def _update_active_capability(project_dir: Path, capability: CapabilitySpec, adapter: AdapterSpec) -> None:

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -16,6 +16,8 @@ class ParameterSpec:
     default_from_project_name: bool = False
     secret: bool = False
     required: bool = False
+    choices: tuple[str, ...] = ()
+    csv_choices: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -26,6 +28,8 @@ class ParameterSpec:
             "default_from_project_name": self.default_from_project_name,
             "secret": self.secret,
             "required": self.required,
+            "choices": list(self.choices),
+            "csv_choices": self.csv_choices,
         }
 
 
@@ -475,6 +479,69 @@ vault:
                     kind="string",
                     prompt="Mount KV v2",
                     default="kv",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+        AdapterSpec(
+            name="chain",
+            capability="secrets",
+            layer="outbound",
+            description="Resolver ordonné avec fallback entre env, Vault et YAML.",
+            secret_resolver="chain",
+            secret_config_template="""\
+chain:
+{secret_chain_yaml}
+vault:
+  addr: "{addr}"
+  mount: "{mount}"
+yaml:
+  path: "{path}"
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="{field_path}",
+                    secret_key="{secret_key}",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="field_path",
+                    kind="string",
+                    prompt="Champ de configuration à alimenter",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="secret_key",
+                    kind="string",
+                    prompt="Chemin Vault relatif au mount ou clé explicite",
+                    required=True,
+                ),
+                ParameterSpec(
+                    name="resolvers",
+                    kind="string",
+                    prompt="Resolvers ordonnés séparés par virgule",
+                    default="env,vault,yaml",
+                    choices=("env", "vault", "yaml"),
+                    csv_choices=True,
+                ),
+                ParameterSpec(
+                    name="addr",
+                    kind="string",
+                    prompt="Adresse Vault",
+                    default="http://127.0.0.1:8200",
+                ),
+                ParameterSpec(
+                    name="mount",
+                    kind="string",
+                    prompt="Mount KV v2",
+                    default="kv",
+                ),
+                ParameterSpec(
+                    name="path",
+                    kind="string",
+                    prompt="Chemin du fichier YAML local",
+                    default="secrets.yaml",
                 ),
             ),
             entity_scoped=False,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1332,6 +1332,63 @@ def test_add_vault_secrets_adapter_requires_secret_key(tmp_path: Path) -> None:
     assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
+def test_add_chain_secrets_adapter_preserves_mappings_and_renders_ordered_fallback(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / "config" / "secrets.yaml").write_text(
+        "resolver: env\n"
+        "mappings:\n"
+        "  adapters.lm.api_key: OPENAI_API_KEY\n",
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="chain",
+            adapter_params={
+                "field_path": "adapters.mongodb.uri",
+                "secret_key": "apps/demo/mongodb",
+                "resolvers": "env,vault,yaml",
+                "addr": "http://vault:8200",
+                "mount": "kv-app",
+                "path": "secrets.yaml",
+            },
+            yes=True,
+        )
+    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+
+    assert secrets["resolver"] == "chain"
+    assert secrets["chain"] == ["env", "vault", "yaml"]
+    assert secrets["vault"] == {"addr": "http://vault:8200", "mount": "kv-app"}
+    assert secrets["yaml"] == {"path": "secrets.yaml"}
+    assert secrets["mappings"] == {
+        "adapters.lm.api_key": "OPENAI_API_KEY",
+        "adapters.mongodb.uri": "apps/demo/mongodb",
+    }
+
+
+def test_add_chain_secrets_adapter_rejects_unknown_resolver(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="secrets",
+            adapter="chain",
+            adapter_params={
+                "field_path": "adapters.mongodb.uri",
+                "secret_key": "apps/demo/mongodb",
+                "resolvers": "env,unknown",
+            },
+            yes=True,
+        )
+
+    assert not (project_dir / "config" / "secrets.yaml").exists()
+
+
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:
     parameter = ParameterSpec(name="multitenant", kind="boolean", prompt="multitenant", default="false")
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -52,10 +52,11 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("env", "yaml", "vault")
+    assert capability.adapter_names() == ("env", "yaml", "vault", "chain")
     env = capability.get_adapter("env")
     yaml = capability.get_adapter("yaml")
     vault = capability.get_adapter("vault")
+    chain = capability.get_adapter("chain")
     assert env is not None
     assert env.config_path is None
     assert env.secret_resolver == "env"
@@ -77,6 +78,20 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert [parameter.name for parameter in vault.parameters] == ["field_path", "secret_key", "addr", "mount"]
     assert vault.parameters[0].required is True
     assert vault.parameters[1].required is True
+    assert chain is not None
+    assert chain.config_path is None
+    assert chain.secret_resolver == "chain"
+    assert chain.entity_scoped is False
+    assert [parameter.name for parameter in chain.parameters] == [
+        "field_path",
+        "secret_key",
+        "resolvers",
+        "addr",
+        "mount",
+        "path",
+    ]
+    assert chain.parameters[2].choices == ("env", "vault", "yaml")
+    assert chain.parameters[2].csv_choices is True
 
 
 def test_observability_capability_catalog_declares_langsmith() -> None:
@@ -333,10 +348,11 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "cache.redis_url"
     ]
     secrets = payload_by_name["secrets"]
-    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml", "vault"]
+    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml", "vault", "chain"]
     env = secrets["adapters"][0]
     yaml_adapter = secrets["adapters"][1]
     vault_adapter = secrets["adapters"][2]
+    chain_adapter = secrets["adapters"][3]
     assert env["secret_resolver"] == "env"
     assert [parameter["name"] for parameter in env["parameters"]] == ["field_path", "secret_key"]
     assert env["parameters"][0]["required"] is True
@@ -350,6 +366,10 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "addr",
         "mount",
     ]
+    assert chain_adapter["secret_resolver"] == "chain"
+    chain_parameters = {parameter["name"]: parameter for parameter in chain_adapter["parameters"]}
+    assert chain_parameters["resolvers"]["choices"] == ["env", "vault", "yaml"]
+    assert chain_parameters["resolvers"]["csv_choices"] is True
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
     auth = payload_by_name["auth"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -363,6 +363,51 @@ Le mount `kv` doit être un engine KV v2. Avec `hvac`, Arclith lit le secret via
 `mount_point=kv` et attend la valeur applicative dans le champ `value`. Pour une policy dédiée, le
 chemin de lecture Vault correspondant est `kv/data/apps/demo/mongodb`.
 
+Pour combiner plusieurs environnements, utiliser `secrets/chain`. L'ordre est explicite et le
+premier resolver qui retourne une valeur gagne:
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter chain \
+  --param field_path=adapters.mongodb.uri \
+  --param secret_key=apps/demo/mongodb \
+  --param resolvers=env,vault,yaml \
+  --param addr=http://vault:8200 \
+  --param mount=kv \
+  --param path=secrets.yaml \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/secrets.yaml
+resolver: chain
+chain:
+  - env
+  - vault
+  - yaml
+vault:
+  addr: http://vault:8200
+  mount: kv
+yaml:
+  path: secrets.yaml
+mappings:
+  adapters.mongodb.uri: apps/demo/mongodb
+```
+
+Profils recommandés:
+
+- local POC: `yaml`, ou `chain` avec `env,yaml` pour permettre une surcharge ponctuelle;
+- CI/CD et plateformes cloud: `env`, injecté par le système de déploiement;
+- production avec secret manager: `vault`, ou `chain` avec `env,vault` si certains secrets sont
+  injectés par la plateforme.
+
+La CLI refuse les noms inconnus dans `resolvers`; les valeurs supportées sont `env`, `vault` et
+`yaml`. Si aucun resolver ne trouve la valeur et que le champ cible n'est pas explicitement `null`,
+le chargement échoue toujours avec `Secrets non résolus` et le champ manquant.
+
 ### `api`
 
 Capacité inbound pour exposer les cas d'usage via HTTP REST.

--- a/tests/units/infrastructure/test_secret_factory.py
+++ b/tests/units/infrastructure/test_secret_factory.py
@@ -108,6 +108,18 @@ def test_builds_chain_resolver() -> None:
     assert isinstance(build_secret_resolver(data), ChainSecretAdapter)
 
 
+def test_chain_unknown_resolver_raises() -> None:
+    data = {
+        "secrets": {
+            "resolver": "chain",
+            "chain": ["env", "unknown"],
+            "mappings": {"x": "y"},
+        }
+    }
+    with pytest.raises(ValueError, match="Unknown secret resolver"):
+        build_secret_resolver(data)
+
+
 def test_chain_defaults_to_yaml_when_no_chain_key(tmp_path: Path) -> None:
     (tmp_path / "secrets.yaml").write_text("")
     data = {


### PR DESCRIPTION
## Summary
- add secrets/chain to the arclith-cli capability catalog
- validate comma-separated resolver names at CLI time
- render ordered chain config with env, vault and yaml support while preserving mappings
- document local, CI/cloud and production resolver profiles

## Validation
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- uv run pytest tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py -q
- uv run ruff check arclith/infrastructure/secret_factory.py tests/units/infrastructure/test_secret_factory.py tests/units/adapters/outbound/test_secret_adapters.py
- make docs
- make quality: fails on existing global coverage threshold, 308 tests passed but total coverage is 77.05 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #75
