### PR TITLE
[CLI] Add vault tenant capability

### DIFF
--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -435,6 +435,10 @@ def _list_generated_files(
         cfg = project_dir / adapter.config_path
         files.append((cfg, "remplacé ⚠" if cfg.exists() else "créé"))
 
+    for merge_template in adapter.merge_config_templates:
+        cfg = project_dir / render(merge_template.path, {})
+        files.append((cfg, "mis à jour" if cfg.exists() else "créé"))
+
     if adapter.has_env() and adapter.env_path:
         env_file = project_dir / adapter.env_path
         files.append((env_file, "mis à jour" if env_file.exists() else "créé"))
@@ -497,6 +501,11 @@ def _generate(
         cfg_path = project_dir / adapter.config_path
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
         cfg_path.write_text(render(adapter.config_template, params), encoding="utf-8")
+        console.print(f"[green]✓[/green] {cfg_path.relative_to(project_dir)}")
+
+    for merge_template in adapter.merge_config_templates:
+        cfg_path = project_dir / render(merge_template.path, params)
+        _merge_yaml_file(cfg_path, render(merge_template.template, params))
         console.print(f"[green]✓[/green] {cfg_path.relative_to(project_dir)}")
 
     if adapter.has_env() and adapter.env_path:
@@ -702,6 +711,17 @@ def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
             merged_lines.append(f"{key}={value}")
 
     env_path.write_text("\n".join(merged_lines).rstrip("\n") + "\n", encoding="utf-8")
+
+
+def _merge_yaml_file(path: Path, rendered_yaml: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _read_yaml_mapping(path)
+    update = yaml.safe_load(rendered_yaml) or {}
+    if not isinstance(update, dict):
+        console.print("[red]✗[/red] La configuration YAML générée doit être un mapping.")
+        raise typer.Exit(1)
+    merged = _deep_merge_mapping(existing, update)
+    path.write_text(yaml.safe_dump(merged, sort_keys=False, allow_unicode=True), encoding="utf-8")
 
 
 def _merge_secrets_file(

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -64,6 +64,7 @@ class AdapterSpec:
     description: str
     config_path: str | None = None
     config_template: str = ""
+    merge_config_templates: tuple[FileTemplateSpec, ...] = ()
     env_path: str | None = None
     env_template: str = ""
     file_templates: tuple[FileTemplateSpec, ...] = ()
@@ -96,6 +97,7 @@ class AdapterSpec:
             "layer": self.layer,
             "description": self.description,
             "config_path": self.config_path,
+            "merge_config_templates": [file_template.to_dict() for file_template in self.merge_config_templates],
             "env_path": self.env_path,
             "file_templates": [file_template.to_dict() for file_template in self.file_templates],
             "secret_mappings": [secret_mapping.to_dict() for secret_mapping in self.secret_mappings],
@@ -675,6 +677,69 @@ client_id: {client_id}
     ),
 )
 
+TENANT_CAPABILITY = CapabilitySpec(
+    name="tenant",
+    layer="inbound",
+    description="Résolution tenant multitenant depuis un claim JWT.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="vault",
+            capability="tenant",
+            layer="inbound",
+            description="Tenant resolver Vault KV v2 pour coordonnées par adapter.",
+            config_path="config/adapters/inbound/tenant.yaml",
+            config_template="""\
+vault_addr: "{addr}"
+vault_mount: "{mount}"
+vault_path_prefix: "{path_prefix}"
+tenant_claim: "{tenant_claim}"
+""",
+            merge_config_templates=(
+                FileTemplateSpec(
+                    path="config/adapters/inbound/cache.yaml",
+                    template="""\
+tenant_uri_ttl: {tenant_uri_ttl}
+""",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="addr",
+                    kind="string",
+                    prompt="Adresse Vault",
+                    default="http://127.0.0.1:8200",
+                ),
+                ParameterSpec(
+                    name="mount",
+                    kind="string",
+                    prompt="Mount KV v2",
+                    default="kv",
+                ),
+                ParameterSpec(
+                    name="path_prefix",
+                    kind="string",
+                    prompt="Préfixe Vault des tenants",
+                    default="rekipe/tenants",
+                ),
+                ParameterSpec(
+                    name="tenant_claim",
+                    kind="string",
+                    prompt="Claim JWT tenant",
+                    default="sub",
+                ),
+                ParameterSpec(
+                    name="tenant_uri_ttl",
+                    kind="string",
+                    prompt="TTL cache tenant en secondes",
+                    default="300",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 LLM_CAPABILITY = CapabilitySpec(
     name="llm",
     layer="outbound",
@@ -1039,6 +1104,7 @@ CAPABILITY_CATALOG = (
     API_CAPABILITY,
     MCP_CAPABILITY,
     AUTH_CAPABILITY,
+    TENANT_CAPABILITY,
     LLM_CAPABILITY,
     AGENT_CAPABILITY,
     OBSERVABILITY_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -140,7 +140,7 @@ def add_adapter(
         str,
         typer.Option(
             "--capability",
-            help="Capacité cible: repository, cache, secrets, api, mcp, auth, llm, agent ou observability",
+            help="Capacité cible: repository, cache, secrets, api, mcp, auth, tenant, llm, agent ou observability",
         ),
     ] = "repository",
     adapter: Annotated[

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -469,6 +469,63 @@ def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: P
     assert arclith.config.keycloak.client_id == "swagger-public"
 
 
+def test_add_vault_tenant_adapter_with_mongodb_multitenant_loads_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    cache_path = project_dir / "config" / "adapters" / "inbound" / "cache.yaml"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        "backend: memory\n"
+        "jwks_ttl: 1200\n"
+        "tenant_uri_ttl: 180\n",
+        encoding="utf-8",
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        adapter="mongodb",
+        activate=True,
+        db_name="fallback_db",
+        adapter_params={"collection_name": "widgets"},
+        multitenant=True,
+        yes=True,
+    )
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="tenant",
+        adapter="vault",
+        adapter_params={
+            "addr": "http://vault:8200",
+            "mount": "kv-tenants",
+            "path_prefix": "rekipe/tenants",
+            "tenant_claim": "tenant_id",
+            "tenant_uri_ttl": "45",
+        },
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+    tenant_config = (project_dir / "config" / "adapters" / "inbound" / "tenant.yaml").read_text(
+        encoding="utf-8"
+    )
+    cache_config = yaml.safe_load(cache_path.read_text(encoding="utf-8"))
+
+    assert arclith.config.adapters.repository == "mongodb"
+    assert arclith.config.adapters.mongodb is not None
+    assert arclith.config.adapters.mongodb.multitenant is True
+    assert arclith.config.tenant is not None
+    assert arclith.config.tenant.vault_addr == "http://vault:8200"
+    assert arclith.config.tenant.vault_mount == "kv-tenants"
+    assert arclith.config.tenant.vault_path_prefix == "rekipe/tenants"
+    assert arclith.config.tenant.tenant_claim == "tenant_id"
+    assert arclith.config.cache.backend == "memory"
+    assert arclith.config.cache.jwks_ttl == 1200
+    assert arclith.config.cache.tenant_uri_ttl == 45
+    assert cache_config == {"backend": "memory", "jwks_ttl": 1200, "tenant_uri_ttl": 45}
+    assert 'vault_addr: "http://vault:8200"' in tenant_config
+
+
 def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -159,6 +159,29 @@ def test_auth_capability_catalog_declares_keycloak() -> None:
     assert [parameter.name for parameter in keycloak.parameters] == ["url", "realm", "audience", "client_id"]
 
 
+def test_tenant_capability_catalog_declares_vault() -> None:
+    capability = get_capability("tenant")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("vault",)
+    vault = capability.get_adapter("vault")
+    assert vault is not None
+    assert vault.config_path == "config/adapters/inbound/tenant.yaml"
+    assert [template.path for template in vault.merge_config_templates] == [
+        "config/adapters/inbound/cache.yaml"
+    ]
+    assert vault.entity_scoped is False
+    assert [parameter.name for parameter in vault.parameters] == [
+        "addr",
+        "mount",
+        "path_prefix",
+        "tenant_claim",
+        "tenant_uri_ttl",
+    ]
+
+
 def test_llm_capability_catalog_declares_model_adapters() -> None:
     capability = get_capability("llm")
 
@@ -292,6 +315,7 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "fastmcp" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
+    assert "tenant" in encoded
     assert "llm" in encoded
     assert "lmstudio" in encoded
     assert "agent" in encoded
@@ -379,6 +403,13 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert keycloak_parameters["realm"]["default"] == "rekipe"
     assert keycloak_parameters["audience"]["default"] == "null"
     assert keycloak_parameters["client_id"]["default"] == "null"
+    tenant = payload_by_name["tenant"]
+    assert [adapter["name"] for adapter in tenant["adapters"]] == ["vault"]
+    tenant_vault = tenant["adapters"][0]
+    assert tenant_vault["config_path"] == "config/adapters/inbound/tenant.yaml"
+    assert [template["path"] for template in tenant_vault["merge_config_templates"]] == [
+        "config/adapters/inbound/cache.yaml"
+    ]
     llm = payload_by_name["llm"]
     assert [adapter["name"] for adapter in llm["adapters"]] == ["lmstudio", "openai", "anthropic"]
     openai = llm["adapters"][1]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -480,6 +480,46 @@ compatible API/MCP/probes. L'instrumentation MCP reste transverse: enregistrer l
 `mcp`, puis appeler `Arclith.instrument_mcp(mcp)` si les probes sont activées. Cette instrumentation
 ne fait pas partie de la capability `mcp/fastmcp`.
 
+### `tenant`
+
+Capacité inbound transverse pour résoudre un `TenantContext` depuis un claim JWT et Vault KV v2.
+Elle s'utilise avec un repository tenant-level, par exemple `repository/mongodb` en
+`multitenant: true`.
+
+Adapter disponible:
+
+- `vault`: configure `TenantSettings` pour `VaultTenantResolver`.
+
+```bash
+arclith-cli add-adapter \
+  --capability tenant \
+  --adapter vault \
+  --param addr=http://vault:8200 \
+  --param mount=kv \
+  --param path_prefix=rekipe/tenants \
+  --param tenant_claim=tenant_id \
+  --param tenant_uri_ttl=300 \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/adapters/inbound/tenant.yaml
+vault_addr: http://vault:8200
+vault_mount: kv
+vault_path_prefix: rekipe/tenants
+tenant_claim: tenant_id
+
+# config/adapters/inbound/cache.yaml
+tenant_uri_ttl: 300
+```
+
+`tenant_uri_ttl` est fusionné dans `cache.yaml` sans écraser `backend`, `redis_url` ni `jwks_ttl`.
+Les coordonnées sont génériques par adapter: un secret tenant peut fournir `uri`/`db_name` pour
+MongoDB, ou `bucket_name`/`endpoint_url` pour un futur adapter S3. En mode single-tenant
+(`multitenant: false`), `make_inject_tenant_uri` bypass le pipeline JWT/Vault sans erreur.
+
 ### `llm`
 
 Capacité outbound pour configurer le modèle utilisé par les interpréteurs d'intention et agents.

--- a/docs/multitenant.md
+++ b/docs/multitenant.md
@@ -59,6 +59,29 @@ En mode **single-tenant** (`multitenant: false` sur tous les adapters), le pipel
 
 ## Configuration
 
+Depuis un projet généré, la configuration minimale MongoDB multitenant + tenant Vault peut être
+posée par la CLI :
+
+```bash
+arclith-cli add-adapter \
+  --capability repository \
+  --adapter mongodb \
+  --param db_name=fallback_db \
+  --param collection_name=null \
+  --param multitenant=true \
+  --yes
+
+arclith-cli add-adapter \
+  --capability tenant \
+  --adapter vault \
+  --param addr=http://vault:8200 \
+  --param mount=kv \
+  --param path_prefix=rekipe/tenants \
+  --param tenant_claim=tenant_id \
+  --param tenant_uri_ttl=300 \
+  --yes
+```
+
 ```yaml
 adapters:
   repository: mongodb
@@ -117,8 +140,8 @@ inject_tenant = make_inject_tenant_uri(
     ),
     license_validator=RoleLicenseValidator(role=config.license.role),
     tenant_resolvers=[
-        VaultTenantResolver("mongodb",    addr=..., path_prefix=..., cache=cache),
-        VaultTenantResolver("s3_client",  addr=..., path_prefix=..., cache=cache),
+        VaultTenantResolver("mongodb", addr=..., mount=..., path_prefix=..., cache=cache),
+        VaultTenantResolver("s3_client", addr=..., mount=..., path_prefix=..., cache=cache),
     ],
 )
 ```
@@ -132,27 +155,32 @@ Pas de filtrage, pas d'hypothèse sur les clés — chaque adaptateur lit ce don
 
 ```bash
 vault kv put kv/rekipe/tenants/client-a \
-  mongodb_uri="mongodb://user:pass@mongo-a:27017" \
-  mongodb_db="client_a" \
-  s3_bucket="client-a-data" \
+  uri="mongodb://user:pass@mongo-a:27017" \
+  db_name="client_a" \
+  bucket_name="client-a-data" \
   s3_region="eu-west-1" \
   s3_endpoint="https://s3.eu-west-1.amazonaws.com"
 ```
 
-> Les clés peuvent être organisées librement. La convention de nommage (`mongodb_uri`, `s3_bucket`…)
-> est définie par le projet — arclith ne l'impose pas.
+Le préfixe `rekipe/tenants` vient de `tenant.vault_path_prefix`; `client-a` vient du claim JWT
+configuré par `tenant.tenant_claim`. `VaultTenantResolver` lit `kv/<path_prefix>/<tenant_id>` en KV
+v2, expose tous les champs tels quels, puis chaque adapter consomme sa propre tranche de
+`TenantContext`.
+
+> Les clés peuvent être organisées librement. La convention de nommage (`uri`, `db_name`,
+> `bucket_name`...) est définie par le projet et par l'adapter consommateur; arclith ne l'impose pas.
 
 Chaque adaptateur lit sa tranche :
 
 ```python
 # Dans le repository MongoDB du tenant
 coords = get_adapter_tenant_context("mongodb")
-uri = coords.get("mongodb_uri") or self._config.uri
-db  = coords.get("mongodb_db")  or self._config.db_name
+uri = coords.get("uri") or self._config.uri
+db  = coords.get("db_name") or self._config.db_name
 
 # Dans le client S3 du tenant
 coords = get_adapter_tenant_context("s3_client")
-bucket   = coords.require("s3_bucket")
+bucket   = coords.require("bucket_name")
 region   = coords.get("s3_region", "eu-west-1")
 endpoint = coords.get("s3_endpoint")
 

--- a/tests/units/adapters/inbound/test_tenant_pipeline.py
+++ b/tests/units/adapters/inbound/test_tenant_pipeline.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+
+import pytest
+
+from arclith.adapters.context import _tenant_context, get_adapter_tenant_context
+from arclith.adapters.inbound.fastapi.dependencies import make_inject_tenant_uri
+from arclith.domain.models.tenant import AdapterTenantCoords, TenantContext
+from arclith.domain.ports.outbound.tenant_resolver import TenantResolver
+from arclith.infrastructure.config import AppConfig, AdaptersSettings, MongoDBSettings, TenantSettings
+
+
+class FakeJWTDecoder:
+    def __init__(self, claims: dict[str, str]) -> None:
+        self.claims = claims
+        self.token: str | None = None
+
+    async def decode(self, token: str) -> dict[str, str]:
+        self.token = token
+        return self.claims
+
+
+class FakeTenantResolver(TenantResolver):
+    def __init__(self, adapter_name: str, params: dict[str, str]) -> None:
+        self.adapter_name = adapter_name
+        self.params = params
+        self.tenant_id: str | None = None
+
+    async def resolve(self, tenant_id: str) -> TenantContext:
+        self.tenant_id = tenant_id
+        return TenantContext(
+            adapters={self.adapter_name: AdapterTenantCoords(params=self.params)}
+        )
+
+
+@pytest.mark.asyncio
+async def test_fastapi_tenant_pipeline_bypasses_single_tenant_without_decoder() -> None:
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="mongodb",
+            mongodb=MongoDBSettings(db_name="test", multitenant=False),
+        )
+    )
+    dependency = make_inject_tenant_uri(config)
+
+    await dependency(SimpleNamespace(headers={}))
+
+
+@pytest.mark.asyncio
+async def test_fastapi_tenant_pipeline_uses_configured_claim_and_generic_resolvers() -> None:
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="mongodb",
+            mongodb=MongoDBSettings(db_name="fallback", multitenant=True),
+        ),
+        tenant=TenantSettings(
+            vault_addr="http://vault:8200",
+            vault_mount="kv",
+            vault_path_prefix="rekipe/tenants",
+            tenant_claim="tenant_id",
+        ),
+    )
+    decoder = FakeJWTDecoder({"tenant_id": "tenant-a"})
+    mongodb = FakeTenantResolver("mongodb", {"uri": "mongodb://tenant-a", "db_name": "tenant_a"})
+    s3 = FakeTenantResolver("s3", {"bucket_name": "tenant-a-assets"})
+    dependency = make_inject_tenant_uri(
+        config,
+        jwt_decoder=decoder,  # type: ignore[arg-type]
+        tenant_resolvers=[mongodb, s3],
+    )
+    token = _tenant_context.set(None)
+    try:
+        await dependency(SimpleNamespace(headers={"Authorization": "Bearer jwt-token"}))
+
+        mongodb_context = get_adapter_tenant_context("mongodb")
+        s3_context = get_adapter_tenant_context("s3")
+    finally:
+        _tenant_context.reset(token)
+
+    assert decoder.token == "jwt-token"
+    assert mongodb.tenant_id == "tenant-a"
+    assert s3.tenant_id == "tenant-a"
+    assert mongodb_context is not None
+    assert mongodb_context.params == {"uri": "mongodb://tenant-a", "db_name": "tenant_a"}
+    assert s3_context is not None
+    assert s3_context.params == {"bucket_name": "tenant-a-assets"}


### PR DESCRIPTION
## Summary
- add tenant/vault to the arclith-cli capability catalog
- generate config/adapters/inbound/tenant.yaml and merge cache.tenant_uri_ttl without overwriting cache settings
- test MongoDB multitenant plus tenant/vault CLI config loading
- add FastAPI tenant pipeline tests for single-tenant bypass and generic adapter TenantContext merge
- document KV v2 tenant structure and CLI activation

## Validation
- cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q
- cd cli && uv run ruff check arclith_cli tests
- uv run pytest tests/units/adapters/inbound/test_tenant_pipeline.py tests/units/adapters/inbound/test_dependencies.py tests/units/infrastructure/test_config.py -q
- uv run ruff check tests/units/adapters/inbound/test_tenant_pipeline.py arclith/adapters/inbound/fastapi/dependencies.py arclith/adapters/outbound/vault/tenant_adapter.py
- make docs
- make quality: fails on existing global coverage threshold, 310 tests passed but total coverage is 76.90 percent below fail-under 90 percent because HTTP middleware modules are under-covered

Closes #76
