### PR TITLE
[CLI] Add role license capability

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -740,6 +740,34 @@ tenant_uri_ttl: {tenant_uri_ttl}
     ),
 )
 
+LICENSE_CAPABILITY = CapabilitySpec(
+    name="license",
+    layer="inbound",
+    description="Validation d'accès par rôle realm Keycloak.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="role",
+            capability="license",
+            layer="inbound",
+            description="Vérifie un rôle dans realm_access.roles via RoleLicenseValidator.",
+            config_path="config/adapters/inbound/license.yaml",
+            config_template="""\
+role: "{role}"
+""",
+            parameters=(
+                ParameterSpec(
+                    name="role",
+                    kind="string",
+                    prompt="Rôle realm Keycloak requis",
+                    default="rekipe:licensed",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 LLM_CAPABILITY = CapabilitySpec(
     name="llm",
     layer="outbound",
@@ -1105,6 +1133,7 @@ CAPABILITY_CATALOG = (
     MCP_CAPABILITY,
     AUTH_CAPABILITY,
     TENANT_CAPABILITY,
+    LICENSE_CAPABILITY,
     LLM_CAPABILITY,
     AGENT_CAPABILITY,
     OBSERVABILITY_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -140,7 +140,10 @@ def add_adapter(
         str,
         typer.Option(
             "--capability",
-            help="Capacité cible: repository, cache, secrets, api, mcp, auth, tenant, llm, agent ou observability",
+            help=(
+                "Capacité cible: repository, cache, secrets, api, mcp, auth, tenant, "
+                "license, llm, agent ou observability"
+            ),
         ),
     ] = "repository",
     adapter: Annotated[

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -526,6 +526,36 @@ def test_add_vault_tenant_adapter_with_mongodb_multitenant_loads_config(tmp_path
     assert 'vault_addr: "http://vault:8200"' in tenant_config
 
 
+def test_add_role_license_adapter_generates_loadable_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config" / "adapters" / "inbound" / "license.yaml"
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="license",
+            adapter="role",
+            adapter_params={"role": "rekipe:premium"},
+            yes=True,
+        )
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert config == {"role": "rekipe:premium"}
+    assert "license:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    package_root = project_dir / "src" / "demo_service"
+    assert not (package_root / "adapters" / "inbound" / "role").exists()
+    assert not (package_root / "adapters" / "outbound" / "role").exists()
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.license is not None
+    assert arclith.config.license.role == "rekipe:premium"
+
+
 def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -182,6 +182,20 @@ def test_tenant_capability_catalog_declares_vault() -> None:
     ]
 
 
+def test_license_capability_catalog_declares_role() -> None:
+    capability = get_capability("license")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("role",)
+    role = capability.get_adapter("role")
+    assert role is not None
+    assert role.config_path == "config/adapters/inbound/license.yaml"
+    assert role.entity_scoped is False
+    assert [parameter.name for parameter in role.parameters] == ["role"]
+
+
 def test_llm_capability_catalog_declares_model_adapters() -> None:
     capability = get_capability("llm")
 
@@ -316,6 +330,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
+    assert "license" in encoded
+    assert "role" in encoded
     assert "llm" in encoded
     assert "lmstudio" in encoded
     assert "agent" in encoded
@@ -410,6 +426,14 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [template["path"] for template in tenant_vault["merge_config_templates"]] == [
         "config/adapters/inbound/cache.yaml"
     ]
+    license_capability = payload_by_name["license"]
+    assert [adapter["name"] for adapter in license_capability["adapters"]] == ["role"]
+    role_parameters = {
+        parameter["name"]: parameter
+        for parameter in license_capability["adapters"][0]["parameters"]
+    }
+    assert license_capability["adapters"][0]["config_path"] == "config/adapters/inbound/license.yaml"
+    assert role_parameters["role"]["default"] == "rekipe:licensed"
     llm = payload_by_name["llm"]
     assert [adapter["name"] for adapter in llm["adapters"]] == ["lmstudio", "openai", "anthropic"]
     openai = llm["adapters"][1]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -76,6 +76,31 @@ audience: rekipe-api             # Vérification aud dans le JWT (null = désact
 client_id: swagger-public        # Client public Swagger UI OAuth2 PKCE
 ```
 
+La licence par rôle Keycloak se configure aussi sans changer les routers FastAPI
+ni les tools MCP :
+
+```bash
+arclith-cli add-adapter \
+  --capability license \
+  --adapter role \
+  --param role=rekipe:licensed \
+  --yes
+```
+
+Le CLI génère `config/adapters/inbound/license.yaml`, chargé comme section
+`license` par `Arclith("config")`.
+
+```yaml
+# config/adapters/inbound/license.yaml
+role: rekipe:licensed
+```
+
+Si `config.license` existe, `Arclith.auth_dependency()` ajoute automatiquement
+`RoleLicenseValidator(config.license.role)` au pipeline partagé FastAPI/MCP. Si
+la section est absente, seul le JWT est vérifié. Un token absent ou invalide
+reste une erreur `401`, tandis qu'un token valide sans le rôle demandé retourne
+`403`.
+
 Les autres sections restent dans leurs fichiers de configuration dédiés ou dans
 un `config.yaml` consolidé selon le mode de déploiement :
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -520,6 +520,35 @@ Les coordonnées sont génériques par adapter: un secret tenant peut fournir `u
 MongoDB, ou `bucket_name`/`endpoint_url` pour un futur adapter S3. En mode single-tenant
 (`multitenant: false`), `make_inject_tenant_uri` bypass le pipeline JWT/Vault sans erreur.
 
+### `license`
+
+Capacité inbound transverse pour valider un realm role Keycloak après décodage JWT. Elle ne génère
+pas de router FastAPI ni de tool MCP: `Arclith.auth_dependency()` applique la même règle aux deux
+transports quand `config.license` est présent.
+
+Adapter disponible:
+
+- `role`: configure `LicenseSettings.role` et utilise `RoleLicenseValidator`.
+
+```bash
+arclith-cli add-adapter \
+  --capability license \
+  --adapter role \
+  --param role=rekipe:licensed \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/adapters/inbound/license.yaml
+role: rekipe:licensed
+```
+
+L'absence de `config/adapters/inbound/license.yaml` désactive la vérification de licence sans
+changer les routes. Les erreurs restent séparées: `401` pour une authentification manquante ou
+invalide, `403` pour un token valide sans le rôle configuré.
+
 ### `llm`
 
 Capacité outbound pour configurer le modèle utilisé par les interpréteurs d'intention et agents.

--- a/tests/units/adapters/inbound/test_license_validator.py
+++ b/tests/units/adapters/inbound/test_license_validator.py
@@ -1,0 +1,19 @@
+from arclith.adapters.inbound.license.validator import RoleLicenseValidator
+
+
+def test_role_license_validator_accepts_configured_realm_role() -> None:
+    validator = RoleLicenseValidator("rekipe:licensed")
+
+    assert validator.validate({"realm_access": {"roles": ["rekipe:licensed"]}}) is True
+
+
+def test_role_license_validator_rejects_missing_realm_role() -> None:
+    validator = RoleLicenseValidator("rekipe:licensed")
+
+    assert validator.validate({"realm_access": {"roles": ["rekipe:trial"]}}) is False
+
+
+def test_role_license_validator_rejects_absent_realm_access() -> None:
+    validator = RoleLicenseValidator("rekipe:licensed")
+
+    assert validator.validate({"sub": "user-1"}) is False

--- a/tests/units/test_arclith_auth.py
+++ b/tests/units/test_arclith_auth.py
@@ -1,9 +1,33 @@
 from pathlib import Path
 
 import pytest
-from fastapi import Depends
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
 
 from arclith import Arclith
+from arclith.adapters.inbound.jwt.decoder import JWTDecoder
+
+
+def _write_keycloak_config(config_dir: Path) -> None:
+    keycloak_dir = config_dir / "adapters" / "inbound"
+    keycloak_dir.mkdir(parents=True, exist_ok=True)
+    (keycloak_dir / "keycloak.yaml").write_text(
+        "url: https://auth.example.test\n"
+        "realm: rekipe\n"
+        "audience: rekipe-api\n"
+        "client_id: swagger-public\n",
+        encoding="utf-8",
+    )
+
+
+def _write_license_config(config_dir: Path, *, role: str = "rekipe:licensed") -> None:
+    license_dir = config_dir / "adapters" / "inbound"
+    license_dir.mkdir(parents=True, exist_ok=True)
+    (license_dir / "license.yaml").write_text(f"role: {role}\n", encoding="utf-8")
+
+
+def _bearer_credentials() -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
 
 
 def test_auth_dependency_requires_keycloak_config(tmp_path: Path) -> None:
@@ -23,15 +47,7 @@ def test_fastapi_keycloak_openapi_uses_oauth2_pkce_without_http_bearer(
     tmp_path: Path,
 ) -> None:
     config_dir = tmp_path / "config"
-    keycloak_dir = config_dir / "adapters" / "inbound"
-    keycloak_dir.mkdir(parents=True)
-    (keycloak_dir / "keycloak.yaml").write_text(
-        "url: https://auth.example.test\n"
-        "realm: rekipe\n"
-        "audience: rekipe-api\n"
-        "client_id: swagger-public\n",
-        encoding="utf-8",
-    )
+    _write_keycloak_config(config_dir)
     arclith = Arclith(config_dir)
     require_auth = arclith.auth_dependency()
     app = arclith.fastapi()
@@ -57,3 +73,76 @@ def test_fastapi_keycloak_openapi_uses_oauth2_pkce_without_http_bearer(
     ]
     assert app.swagger_ui_init_oauth["clientId"] == "swagger-public"
     assert app.swagger_ui_init_oauth["usePkceWithAuthorizationCodeGrant"] is True
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_accepts_configured_license_role(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_keycloak_config(config_dir)
+    _write_license_config(config_dir)
+    claims = {"realm_access": {"roles": ["rekipe:licensed"]}}
+
+    async def decode(self: JWTDecoder, token: str) -> dict:
+        return claims
+
+    monkeypatch.setattr(JWTDecoder, "decode", decode)
+    require_auth = Arclith(config_dir).auth_dependency()
+
+    assert await require_auth(_bearer_credentials()) == claims
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_rejects_missing_license_role_with_403(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_keycloak_config(config_dir)
+    _write_license_config(config_dir)
+
+    async def decode(self: JWTDecoder, token: str) -> dict:
+        return {"realm_access": {"roles": ["rekipe:trial"]}}
+
+    monkeypatch.setattr(JWTDecoder, "decode", decode)
+    require_auth = Arclith(config_dir).auth_dependency()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_auth(_bearer_credentials())
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_skips_license_check_when_license_config_is_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_keycloak_config(config_dir)
+    claims = {"realm_access": {"roles": []}}
+
+    async def decode(self: JWTDecoder, token: str) -> dict:
+        return claims
+
+    monkeypatch.setattr(JWTDecoder, "decode", decode)
+    require_auth = Arclith(config_dir).auth_dependency()
+
+    assert await require_auth(_bearer_credentials()) == claims
+
+
+@pytest.mark.asyncio
+async def test_auth_dependency_keeps_401_for_missing_credentials(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "config"
+    _write_keycloak_config(config_dir)
+    _write_license_config(config_dir)
+    require_auth = Arclith(config_dir).auth_dependency()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_auth(None)
+
+    assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary
- add the `license/role` capability to generate `config/adapters/inbound/license.yaml`
- document Keycloak realm-role licensing for FastAPI and MCP auth dependencies
- cover CLI catalog/export/generation plus runtime 401/403 license behavior

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 57 passed, 1 skipped
- `uv run pytest tests/units/test_arclith_auth.py tests/units/adapters/inbound/test_license_validator.py -q` -> 9 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check tests/units/test_arclith_auth.py tests/units/adapters/inbound/test_license_validator.py arclith/adapters/inbound/license/validator.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- `make quality` -> ruff, bandit, mypy and 317 tests passed; Coverage fails globally at 76.90% < 90

Closes #77