### PR TITLE
[CLI] Add explicit console logger capability

### DIFF
--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -68,7 +68,14 @@ class Arclith:
     @cached_property
     def logger(self) -> Logger:
         from arclith.adapters.outbound.console.logger import ConsoleLogger
-        return ConsoleLogger()
+
+        if self.config.adapters.logger == "console":
+            return ConsoleLogger()
+
+        raise ValueError(
+            f"logger={self.config.adapters.logger} non supporte. "
+            "Adapters logger supportes: console"
+        )
     @overload
     def repository(
         self,

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -129,6 +129,7 @@ _REPOSITORY_CONFIG_SECTIONS: dict[str, str] = {
     "duckdb": "duckdb",
     "mariadb": "mariadb",
 }
+_LOGGER_ADAPTERS = {"console"}
 _OBSERVABILITY_CONFIG_SECTIONS: dict[ObservabilityAdapter, str] = {
     "langsmith": "langsmith",
     "opentelemetry": "opentelemetry",
@@ -147,7 +148,7 @@ class SoftDeleteSettings(BaseModel):
 
 
 class AdaptersSettings(BaseModel):
-    logger: Literal["console"] = "console"
+    logger: str = "console"
     repository: str = "memory"
     observability: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
     mongodb: MongoDBSettings | None = None
@@ -168,6 +169,14 @@ class AdaptersSettings(BaseModel):
                 return self.mariadb.multitenant if self.mariadb else False
             case _:
                 return False
+
+    @field_validator("logger")
+    @classmethod
+    def must_be_supported_logger_adapter(cls, v: str) -> str:
+        if v not in _LOGGER_ADAPTERS:
+            supported = ", ".join(sorted(_LOGGER_ADAPTERS))
+            raise ValueError(f"logger={v} non supporte. Adapters logger supportes: {supported}")
+        return v
 
     @model_validator(mode="after")
     def validate_repository_config(self) -> "AdaptersSettings":

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -357,6 +357,22 @@ REDIS_URL={redis_url}
     ),
 )
 
+LOGGER_CAPABILITY = CapabilitySpec(
+    name="logger",
+    layer="outbound",
+    description="Logger applicatif partagé par les use cases et adapters.",
+    activation_config_key="logger",
+    adapters=(
+        AdapterSpec(
+            name="console",
+            capability="logger",
+            layer="outbound",
+            description="Logger console Loguru enrichi avec les métadonnées OpenTelemetry courantes.",
+            entity_scoped=False,
+        ),
+    ),
+)
+
 SECRETS_CAPABILITY = CapabilitySpec(
     name="secrets",
     layer="outbound",
@@ -1128,6 +1144,7 @@ OTEL_EXPORTER_OTLP_HEADERS={headers}
 CAPABILITY_CATALOG = (
     REPOSITORY_CAPABILITY,
     CACHE_CAPABILITY,
+    LOGGER_CAPABILITY,
     SECRETS_CAPABILITY,
     API_CAPABILITY,
     MCP_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -141,7 +141,7 @@ def add_adapter(
         typer.Option(
             "--capability",
             help=(
-                "Capacité cible: repository, cache, secrets, api, mcp, auth, tenant, "
+                "Capacité cible: repository, cache, logger, secrets, api, mcp, auth, tenant, "
                 "license, llm, agent ou observability"
             ),
         ),

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1184,6 +1184,30 @@ def test_add_cache_redis_adapter_generates_secret_mapping(
     assert app.config.cache.tenant_uri_ttl == 120
 
 
+def test_add_console_logger_adapter_generates_explicit_default_selector(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    adapters_path = project_dir / "config" / "adapters" / "adapters.yaml"
+    adapters_path.write_text("repository: memory\nobservability:\n  enabled: []\n", encoding="utf-8")
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="logger",
+        adapter="console",
+        yes=True,
+    )
+
+    from arclith import Arclith
+    from arclith.adapters.outbound.console.logger import ConsoleLogger
+
+    arclith = Arclith(project_dir / "config")
+    package_root = project_dir / "src" / "demo_service"
+
+    assert "logger: console" in adapters_path.read_text(encoding="utf-8")
+    assert arclith.config.adapters.logger == "console"
+    assert isinstance(arclith.logger, ConsoleLogger)
+    assert not (package_root / "adapters" / "outbound" / "console").exists()
+
+
 def test_add_env_secrets_adapter_preserves_existing_mappings_and_uses_explicit_key(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -46,6 +46,20 @@ def test_cache_capability_catalog_declares_memory_adapter() -> None:
     assert [mapping.secret_key for mapping in redis.secret_mappings] == ["REDIS_URL"]
 
 
+def test_logger_capability_catalog_declares_console_adapter() -> None:
+    capability = get_capability("logger")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key == "logger"
+    assert capability.adapter_names() == ("console",)
+    console = capability.get_adapter("console")
+    assert console is not None
+    assert console.config_path is None
+    assert console.entity_scoped is False
+    assert console.parameters == ()
+
+
 def test_secrets_capability_catalog_declares_env_adapter() -> None:
     capability = get_capability("secrets")
 
@@ -321,6 +335,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "mongodb" in encoded
     assert "cache" in encoded
     assert "redis" in encoded
+    assert "logger" in encoded
+    assert "console" in encoded
     assert "secrets" in encoded
     assert "env" in encoded
     assert "api" in encoded
@@ -387,6 +403,11 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [mapping["field_path"] for mapping in cache["adapters"][1]["secret_mappings"]] == [
         "cache.redis_url"
     ]
+    logger = payload_by_name["logger"]
+    assert logger["activation_config_key"] == "logger"
+    assert [adapter["name"] for adapter in logger["adapters"]] == ["console"]
+    assert logger["adapters"][0]["entity_scoped"] is False
+    assert logger["adapters"][0]["config_path"] is None
     secrets = payload_by_name["secrets"]
     assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml", "vault", "chain"]
     env = secrets["adapters"][0]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -163,6 +163,42 @@ En single-tenant, `database` est requis quand `url` n'est pas fourni par les sec
 multitenant, le contexte tenant peut fournir `url`, `database`, `user`, `password`, `host`, `port`,
 `driver` ou `table_prefix`.
 
+### `logger`
+
+Capacité outbound pour le logger applicatif partagé par les use cases et les adapters. L'adapter
+actuel reste volontairement unique: `console`. Il est explicite dans le catalogue pour garder le
+contrat remplaçable plus tard sans changer les ports applicatifs.
+
+Adapter disponible:
+
+- `console`: logger Loguru vers `stderr`, derrière le port `Logger`.
+
+```bash
+arclith-cli add-adapter \
+  --capability logger \
+  --adapter console \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/adapters/adapters.yaml
+logger: console
+```
+
+`Arclith.logger` respecte `config.adapters.logger`; toute valeur inconnue est rejetée avec la liste
+des adapters supportés. Le format console actuel est:
+
+```text
+YYYY-MM-DD HH:mm:ss | <emoji> <LEVEL> | <message> | <metadata>
+```
+
+Quand OpenTelemetry est actif et qu'un span courant existe, `ConsoleLogger` ajoute `trace_id`,
+`span_id` et `trace_sampled` aux métadonnées. Le logger console ne fournit pas encore de sortie JSON,
+de rotation ou d'export externe: ces variantes devront être ajoutées comme nouveaux adapters du même
+catalogue.
+
 ### `cache`
 
 Capacité outbound transverse pour le cache technique utilisé par JWT JWKS, idempotency et

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -35,6 +35,11 @@ def test_custom_repository_adapter_name_is_allowed():
     assert config.adapters.multitenant is False
 
 
+def test_unknown_logger_adapter_is_rejected():
+    with pytest.raises(ValidationError, match="logger=custom non supporte"):
+        AppConfig.model_validate({"adapters": {"logger": "custom"}})
+
+
 def test_default_retention_is_none():
     assert AppConfig().soft_delete.retention_days is None
 

--- a/tests/units/test_arclith_logger.py
+++ b/tests/units/test_arclith_logger.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from arclith import Arclith
+from arclith.adapters.outbound.console.logger import ConsoleLogger
+
+
+def test_arclith_logger_uses_configured_console_adapter(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config" / "adapters"
+    config_dir.mkdir(parents=True)
+    (config_dir / "adapters.yaml").write_text(
+        "logger: console\n"
+        "repository: memory\n"
+        "observability:\n"
+        "  enabled: []\n",
+        encoding="utf-8",
+    )
+
+    arclith = Arclith(tmp_path / "config")
+    logger = arclith.logger
+
+    assert isinstance(logger, ConsoleLogger)
+    assert arclith.logger is logger


### PR DESCRIPTION
## Summary
- add `logger/console` to the CLI capability catalog and JSON export
- make `Arclith.logger` select the configured console adapter and reject unknown logger adapters clearly
- document console log format, OpenTelemetry correlation metadata, and current limits

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 59 passed, 1 skipped
- `uv run pytest tests/units/infrastructure/test_config.py tests/units/test_arclith_logger.py tests/units/adapters/outbound/test_console_logger.py -q` -> 83 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check arclith tests/units/infrastructure/test_config.py tests/units/test_arclith_logger.py tests/units/adapters/outbound/test_console_logger.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- `make quality` -> ruff, bandit, mypy and 319 tests passed; Coverage fails globally at 77.03% < 90

Closes #78