### PR TITLE
[CLI] Add probe server capability

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -644,6 +644,48 @@ port: {port}
     ),
 )
 
+PROBE_CAPABILITY = CapabilitySpec(
+    name="probe",
+    layer="inbound",
+    description="Serveur de probes health, readiness, info et metrics.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="server",
+            capability="probe",
+            layer="inbound",
+            description="Serveur HTTP transverse exposant /health, /ready, /info et /metrics.",
+            config_path="config/adapters/inbound/probe.yaml",
+            config_template="""\
+host: {host}
+port: {port}
+enabled: {enabled}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="host",
+                    kind="string",
+                    prompt="Host du serveur de probes",
+                    default="0.0.0.0",
+                ),
+                ParameterSpec(
+                    name="port",
+                    kind="string",
+                    prompt="Port du serveur de probes",
+                    default="9000",
+                ),
+                ParameterSpec(
+                    name="enabled",
+                    kind="boolean",
+                    prompt="Activer le serveur de probes",
+                    default=True,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 AUTH_CAPABILITY = CapabilitySpec(
     name="auth",
     layer="inbound",
@@ -1148,6 +1190,7 @@ CAPABILITY_CATALOG = (
     SECRETS_CAPABILITY,
     API_CAPABILITY,
     MCP_CAPABILITY,
+    PROBE_CAPABILITY,
     AUTH_CAPABILITY,
     TENANT_CAPABILITY,
     LICENSE_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -141,8 +141,8 @@ def add_adapter(
         typer.Option(
             "--capability",
             help=(
-                "Capacité cible: repository, cache, logger, secrets, api, mcp, auth, tenant, "
-                "license, llm, agent ou observability"
+                "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, "
+                "auth, tenant, license, llm, agent ou observability"
             ),
         ),
     ] = "repository",

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -427,6 +427,40 @@ def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -
     ]
 
 
+def test_add_probe_server_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="probe",
+        adapter="server",
+        adapter_params={
+            "host": "127.0.0.1",
+            "port": "9100",
+            "enabled": "false",
+        },
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+    config = (project_dir / "config" / "adapters" / "inbound" / "probe.yaml").read_text(
+        encoding="utf-8"
+    )
+    package_root = project_dir / "src" / "demo_service"
+
+    assert config == "host: 127.0.0.1\nport: 9100\nenabled: false\n"
+    assert arclith.config.probe.host == "127.0.0.1"
+    assert arclith.config.probe.port == 9100
+    assert arclith.config.probe.enabled is False
+    assert "probe:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert not (package_root / "adapters" / "inbound" / "server").exists()
+    assert not (package_root / "adapters" / "outbound" / "server").exists()
+
+
 def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -159,6 +159,20 @@ def test_mcp_capability_catalog_declares_fastmcp() -> None:
     assert [parameter.name for parameter in fastmcp.parameters] == ["host", "port"]
 
 
+def test_probe_capability_catalog_declares_server() -> None:
+    capability = get_capability("probe")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("server",)
+    server = capability.get_adapter("server")
+    assert server is not None
+    assert server.config_path == "config/adapters/inbound/probe.yaml"
+    assert server.entity_scoped is False
+    assert [parameter.name for parameter in server.parameters] == ["host", "port", "enabled"]
+
+
 def test_auth_capability_catalog_declares_keycloak() -> None:
     capability = get_capability("auth")
 
@@ -343,6 +357,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "fastapi" in encoded
     assert "mcp" in encoded
     assert "fastmcp" in encoded
+    assert "probe" in encoded
+    assert "server" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
@@ -433,6 +449,15 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert chain_parameters["resolvers"]["csv_choices"] is True
     assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
     assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
+    probe = payload_by_name["probe"]
+    assert [adapter["name"] for adapter in probe["adapters"]] == ["server"]
+    probe_server = probe["adapters"][0]
+    assert probe_server["config_path"] == "config/adapters/inbound/probe.yaml"
+    assert [parameter["name"] for parameter in probe_server["parameters"]] == [
+        "host",
+        "port",
+        "enabled",
+    ]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]
     keycloak_parameters = {parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -516,6 +516,57 @@ compatible API/MCP/probes. L'instrumentation MCP reste transverse: enregistrer l
 `mcp`, puis appeler `Arclith.instrument_mcp(mcp)` si les probes sont activées. Cette instrumentation
 ne fait pas partie de la capability `mcp/fastmcp`.
 
+### `probe`
+
+Capacité inbound transverse pour configurer le serveur de probes Arclith. Elle ne dépend d'aucun
+adapter métier: l'application enregistre ses readiness checks et Arclith expose les transports
+actifs via `run_with_probes(..., transports=[...])`.
+
+Adapter disponible:
+
+- `server`: serveur HTTP léger exposant `/health`, `/ready`, `/info` et `/metrics`.
+
+```bash
+arclith-cli add-adapter \
+  --capability probe \
+  --adapter server \
+  --param host=127.0.0.1 \
+  --param port=9000 \
+  --param enabled=true \
+  --yes
+```
+
+Résultat:
+
+```yaml
+# config/adapters/inbound/probe.yaml
+host: 127.0.0.1
+port: 9000
+enabled: true
+```
+
+Contrat HTTP réel:
+
+- `GET /health`: `200`, `{"status": "ok"}`.
+- `GET /ready`: `200`, `{"status": "ready"}` sans check ou si tous les checks retournent `True`;
+  `503`, `{"status": "not_ready"}` si un check retourne `False` ou lève une exception.
+- `GET /info`: service, version, Python, plateforme, uptime et `active_transports`.
+- `GET /metrics`: `collected_at` et métriques par transport collecté, par exemple `api` et `mcp`.
+
+Exemple de readiness DB côté application:
+
+```python
+async def db_ready() -> bool:
+    await database.ping()
+    return True
+
+arclith.add_readiness_check(db_ready)
+arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])
+```
+
+`enabled: false` conserve la configuration mais ne démarre pas de serveur en arrière-plan. Les
+métriques MCP restent explicites: enregistrer les tools, puis appeler `arclith.instrument_mcp(mcp)`.
+
 ### `tenant`
 
 Capacité inbound transverse pour résoudre un `TenantContext` depuis un claim JWT et Vault KV v2.

--- a/tests/units/adapters/inbound/probes/test_metrics.py
+++ b/tests/units/adapters/inbound/probes/test_metrics.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import threading
-import time
 from typing import Any
 
 import pytest
@@ -270,4 +268,3 @@ class TestEventBusCollectorProtocol:
             transport = "event_bus"
 
         assert not isinstance(BadCollector(), EventBusCollectorProtocol)
-

--- a/tests/units/adapters/inbound/probes/test_server.py
+++ b/tests/units/adapters/inbound/probes/test_server.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import time
 from typing import Any
 
-import pytest
-
 from arclith.adapters.inbound.probes.server import ProbeServer
 
 
@@ -172,4 +170,3 @@ class TestProbeServerRoutes:
         client = self._client(server)
         data = client.get("/info").json()
         assert data["uptime_s"] >= 5.0
-

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -160,6 +160,20 @@ def test_load_config_dir_mcp_via_fastmcp_alias():
     assert config.mcp.port == 8888
 
 
+def test_load_config_dir_probe_scoped():
+    path = _make_config_dir({
+        "adapters/inbound/probe.yaml": {
+            "host": "127.0.0.1",
+            "port": 9100,
+            "enabled": False,
+        }
+    })
+    config = load_config_dir(path)
+    assert config.probe.host == "127.0.0.1"
+    assert config.probe.port == 9100
+    assert config.probe.enabled is False
+
+
 def test_load_config_dir_cache_scoped():
     path = _make_config_dir({
         "adapters/inbound/cache.yaml": {

--- a/tests/units/test_arclith_probes.py
+++ b/tests/units/test_arclith_probes.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from typing import Any
+
+from arclith import Arclith
+
+
+class FakeProbeServer:
+    def __init__(self) -> None:
+        self.started = 0
+        self.active_transports: list[str] = []
+        self.readiness_checks: list[Any] = []
+
+    def set_active_transports(self, transports: list[str]) -> None:
+        self.active_transports = list(transports)
+
+    def start_in_background(self) -> None:
+        self.started += 1
+
+    def add_readiness_check(self, fn: Any) -> None:
+        self.readiness_checks.append(fn)
+
+
+def _write_config(tmp_path: Path, *, enabled: bool) -> Path:
+    config_dir = tmp_path / "config"
+    inbound_dir = config_dir / "adapters" / "inbound"
+    adapters_dir = config_dir / "adapters"
+    inbound_dir.mkdir(parents=True)
+    (adapters_dir / "adapters.yaml").write_text(
+        "logger: console\n"
+        "repository: memory\n"
+        "observability:\n"
+        "  enabled: []\n",
+        encoding="utf-8",
+    )
+    (inbound_dir / "probe.yaml").write_text(
+        "host: 127.0.0.1\n"
+        "port: 9100\n"
+        f"enabled: {str(enabled).lower()}\n",
+        encoding="utf-8",
+    )
+    return config_dir
+
+
+def test_run_with_probes_does_not_start_probe_server_when_disabled(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path, enabled=False))
+    probe_server = FakeProbeServer()
+    arclith.__dict__["_probe_server"] = probe_server
+    calls: list[str] = []
+
+    arclith.run_with_probes(lambda: calls.append("api"), transports=["api"])
+
+    assert calls == ["api"]
+    assert probe_server.started == 0
+    assert probe_server.active_transports == ["api"]
+
+
+def test_run_with_probes_starts_probe_server_and_records_transports(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path, enabled=True))
+    probe_server = FakeProbeServer()
+    arclith.__dict__["_probe_server"] = probe_server
+    calls: list[str] = []
+
+    arclith.run_with_probes(lambda: calls.append("api"), transports=["api", "mcp_http"])
+
+    assert calls == ["api"]
+    assert probe_server.started == 1
+    assert probe_server.active_transports == ["api", "mcp_http"]
+
+
+def test_add_readiness_check_registers_on_probe_server(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path, enabled=True))
+    probe_server = FakeProbeServer()
+    arclith.__dict__["_probe_server"] = probe_server
+
+    async def db_ready() -> bool:
+        return True
+
+    arclith.add_readiness_check(db_ready)
+
+    assert probe_server.readiness_checks == [db_ready]


### PR DESCRIPTION
## Summary
- add `probe/server` to the CLI capability catalog and JSON export
- generate loadable `config/adapters/inbound/probe.yaml` with host, port, and enabled
- document `/health`, `/ready`, `/info`, `/metrics`, readiness checks, disabled probes, and active transports
- cover disabled startup, background startup, active transports, and readiness registration

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 61 passed, 1 skipped
- `uv run pytest tests/units/adapters/inbound/probes/test_server.py tests/units/adapters/inbound/probes/test_metrics.py tests/units/infrastructure/test_config.py tests/units/test_arclith_probes.py -q` -> 122 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check arclith tests/units/adapters/inbound/probes tests/units/infrastructure/test_config.py tests/units/test_arclith_probes.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- probe smoke on free local port -> `/health` and `/info` passed
- `make quality` -> ruff, bandit, mypy and 323 tests passed; Coverage fails globally at 77.03% < 90

Closes #79