### PR TITLE
[CLI] Add HTTP idempotency capability

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -686,6 +686,53 @@ enabled: {enabled}
     ),
 )
 
+HTTP_CAPABILITY = CapabilitySpec(
+    name="http",
+    layer="inbound",
+    description="Middlewares HTTP transverses pour FastAPI.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="idempotency",
+            capability="http",
+            layer="inbound",
+            description="Middleware Idempotency-Key pour éviter les doubles mutations POST.",
+            merge_config_templates=(
+                FileTemplateSpec(
+                    path="config/http.yaml",
+                    template="""\
+idempotency:
+  enabled: {enabled}
+  ttl_seconds: {ttl_seconds}
+  required: {required}
+""",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="enabled",
+                    kind="boolean",
+                    prompt="Activer le middleware idempotency",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="ttl_seconds",
+                    kind="string",
+                    prompt="TTL idempotency en secondes",
+                    default="86400",
+                ),
+                ParameterSpec(
+                    name="required",
+                    kind="boolean",
+                    prompt="Exiger Idempotency-Key sur les POST",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 AUTH_CAPABILITY = CapabilitySpec(
     name="auth",
     layer="inbound",
@@ -1191,6 +1238,7 @@ CAPABILITY_CATALOG = (
     API_CAPABILITY,
     MCP_CAPABILITY,
     PROBE_CAPABILITY,
+    HTTP_CAPABILITY,
     AUTH_CAPABILITY,
     TENANT_CAPABILITY,
     LICENSE_CAPABILITY,

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -141,7 +141,7 @@ def add_adapter(
         typer.Option(
             "--capability",
             help=(
-                "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, "
+                "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, http, "
                 "auth, tenant, license, llm, agent ou observability"
             ),
         ),

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -461,6 +461,51 @@ def test_add_probe_server_adapter_generates_loadable_inbound_config(tmp_path: Pa
     assert not (package_root / "adapters" / "outbound" / "server").exists()
 
 
+def test_add_http_idempotency_adapter_merges_http_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    http_path = project_dir / "config" / "http.yaml"
+    http_path.write_text(
+        "etag:\n"
+        "  enabled: true\n"
+        "cache_control:\n"
+        "  get_single_max_age: 120\n"
+        "  get_list_max_age: 30\n",
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="http",
+            adapter="idempotency",
+            adapter_params={
+                "enabled": "false",
+                "ttl_seconds": "7200",
+                "required": "true",
+            },
+            yes=True,
+        )
+
+    from arclith import Arclith
+
+    config = yaml.safe_load(http_path.read_text(encoding="utf-8"))
+    arclith = Arclith(project_dir / "config")
+    package_root = project_dir / "src" / "demo_service"
+
+    assert config == {
+        "etag": {"enabled": True},
+        "cache_control": {"get_single_max_age": 120, "get_list_max_age": 30},
+        "idempotency": {"enabled": False, "ttl_seconds": 7200, "required": True},
+    }
+    assert arclith.config.http.idempotency.enabled is False
+    assert arclith.config.http.idempotency.ttl_seconds == 7200
+    assert arclith.config.http.idempotency.required is True
+    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert not (package_root / "adapters" / "inbound" / "idempotency").exists()
+
+
 def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -173,6 +173,25 @@ def test_probe_capability_catalog_declares_server() -> None:
     assert [parameter.name for parameter in server.parameters] == ["host", "port", "enabled"]
 
 
+def test_http_capability_catalog_declares_idempotency() -> None:
+    capability = get_capability("http")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("idempotency",)
+    idempotency = capability.get_adapter("idempotency")
+    assert idempotency is not None
+    assert idempotency.config_path is None
+    assert [template.path for template in idempotency.merge_config_templates] == ["config/http.yaml"]
+    assert idempotency.entity_scoped is False
+    assert [parameter.name for parameter in idempotency.parameters] == [
+        "enabled",
+        "ttl_seconds",
+        "required",
+    ]
+
+
 def test_auth_capability_catalog_declares_keycloak() -> None:
     capability = get_capability("auth")
 
@@ -359,6 +378,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "fastmcp" in encoded
     assert "probe" in encoded
     assert "server" in encoded
+    assert "http" in encoded
+    assert "idempotency" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
@@ -457,6 +478,16 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "host",
         "port",
         "enabled",
+    ]
+    http = payload_by_name["http"]
+    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency"]
+    idempotency = http["adapters"][0]
+    assert idempotency["config_path"] is None
+    assert [template["path"] for template in idempotency["merge_config_templates"]] == ["config/http.yaml"]
+    assert [parameter["name"] for parameter in idempotency["parameters"]] == [
+        "enabled",
+        "ttl_seconds",
+        "required",
     ]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -481,6 +481,44 @@ Le module `routes` appartient au projet consommateur: il construit ou injecte se
 appelle les ports applicatifs. `arclith-cli add-adapter --capability api --adapter fastapi` ne
 génère pas ces routes pour éviter de mélanger transport HTTP et logique métier.
 
+### `http`
+
+Capacité inbound pour configurer les middlewares HTTP transverses de `Arclith.fastapi()` sans
+modifier les routes métier.
+
+Adapter disponible:
+
+- `idempotency`: middleware `Idempotency-Key` pour éviter les doubles mutations `POST`.
+
+```bash
+arclith-cli add-adapter \
+  --capability http \
+  --adapter idempotency \
+  --param enabled=true \
+  --param ttl_seconds=86400 \
+  --param required=false \
+  --yes
+```
+
+Résultat fusionné dans `config/http.yaml` sans écraser `etag` ni `cache_control`:
+
+```yaml
+idempotency:
+  enabled: true
+  ttl_seconds: 86400
+  required: false
+```
+
+Quand `enabled: true`, `Arclith.fastapi()` ajoute `IdempotencyMiddleware`. Le client fournit
+`Idempotency-Key` sur les `POST`; au premier succès `2xx`, la réponse est stockée dans le cache
+technique pendant `ttl_seconds`. Une requête suivante avec la même clé et le même path rejoue la
+réponse stockée avec `X-Idempotency-Replay: true`. Les réponses `4xx` et `5xx` ne sont pas mises en
+cache. Avec `required: true`, un `POST` sans header est rejeté en `400`.
+
+Le cache sous-jacent est `cache/memory` par défaut: il suffit en développement ou mono-processus.
+En multi-worker, Kubernetes ou API/MCP séparés, configurer `cache/redis` pour partager les clés
+idempotentes entre processus.
+
 ### `mcp`
 
 Capacité inbound pour exposer les cas d'usage via MCP.

--- a/docs/http-conventions.md
+++ b/docs/http-conventions.md
@@ -26,7 +26,7 @@ Tous les endpoints FastAPI DOIVENT déclarer explicitement leur `status_code` et
 | Endpoint             | Status                        | Response Body                   | Headers                      | Cas                            |
 |----------------------|-------------------------------|---------------------------------|------------------------------|--------------------------------|
 | `POST /v1/resources` | **201 Created**               | `{ "data": { "uuid": "..." } }` | `Location`, `Link`           | Succès création                |
-|                      | **200 OK**                    | `{ "data": { "uuid": "..." } }` | `X-Idempotency-Replay: true` | Cache hit idempotency          |
+|                      | **2xx original rejoué**       | `{ "data": { "uuid": "..." } }` | `X-Idempotency-Replay: true` | Cache hit idempotency          |
 |                      | **400 Bad Request**           | `{ "detail": "..." }`           | —                            | Erreur syntaxe (JSON malformé) |
 |                      | **422 Unprocessable Entity**  | `{ "detail": [...] }`           | —                            | Validation métier échouée      |
 |                      | **500 Internal Server Error** | `{ "detail": "..." }`           | —                            | Erreur serveur                 |
@@ -37,7 +37,7 @@ Tous les endpoints FastAPI DOIVENT déclarer explicitement leur `status_code` et
 2. **Location header** : `Location: /v1/resources/{uuid}` (RFC 7231)
 3. **Link header** : `Link: </v1/resources/{uuid}>; rel="self", ...` (RFC 8288 - HATEOAS)
 4. **Prefer header** : Si client envoie `Prefer: return=representation` → retourner objet complet (RFC 7240)
-5. **Idempotency-Key** : Header optionnel (requis en prod e-commerce) → 200 si cache hit (voir `docs/idempotency.md`)
+5. **Idempotency-Key** : Header optionnel (requis en prod e-commerce) → rejoue la réponse `2xx` cachée (voir `docs/idempotency.md`)
 
 **Exemple cURL :**
 

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -16,7 +16,7 @@ par défaut.
 
 1. Client envoie `POST /orders` avec `Idempotency-Key: <uuid>`
 2. Middleware vérifie le cache
-    - **Hit** → retourne la réponse cachée (200 au lieu de 201)
+    - **Hit** → rejoue la réponse cachée avec `X-Idempotency-Replay: true`
     - **Miss** → exécute la requête, cache la réponse si 2xx
 3. Requêtes suivantes avec la même clé retournent la réponse cachée
 
@@ -28,6 +28,11 @@ idempotency:
   ttl_seconds: 86400  # 24 hours
   required: false  # true = reject POST sans Idempotency-Key
 ```
+
+Le cache utilisé par le middleware est le cache technique Arclith. `cache/memory`
+est adapté aux tests et au mono-processus; utiliser `cache/redis` dès que plusieurs
+workers, replicas Kubernetes ou processus API/MCP doivent partager les clés
+idempotentes.
 
 ### Usage Client
 
@@ -49,7 +54,7 @@ curl -X POST https://api.example.com/v1/orders \
   -H "Content-Type: application/json" \
   -d '{"product_id": "123", "quantity": 1}'
 
-# Returns: 200 OK (cached)
+# Returns: status original rejoué (cached)
 # Response: {"status": "success", "data": {"uuid": "..."}} (same UUID)
 # Header: X-Idempotency-Replay: true
 ```
@@ -245,4 +250,3 @@ paths:
 - **PayPal:** [Idempotency](https://developer.paypal.com/api/rest/reference/idempotency/)
 - **AWS:
   ** [Making idempotent API requests](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html)
-

--- a/tests/units/adapters/inbound/fastapi/test_idempotency.py
+++ b/tests/units/adapters/inbound/fastapi/test_idempotency.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from arclith.adapters.inbound.fastapi.idempotency import IdempotencyMiddleware
+from arclith.domain.ports.outbound.logger import Logger, LogLevel
+
+
+class FakeCache:
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.data.get(key)
+
+    async def set(self, key: str, value: str, ttl_s: int) -> None:
+        self.data[key] = value
+        self.ttls[key] = ttl_s
+
+    async def delete(self, key: str) -> None:
+        self.data.pop(key, None)
+
+
+class FakeLogger(Logger):
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
+        self.records.append({"level": level, "message": message, "metadata": metadata})
+
+
+def test_idempotency_cache_miss_caches_success_then_replays_response() -> None:
+    app = FastAPI()
+    cache = FakeCache()
+    logger = FakeLogger()
+    calls = 0
+
+    @app.post("/items")
+    async def create_item() -> JSONResponse:
+        nonlocal calls
+        calls += 1
+        return JSONResponse({"calls": calls}, status_code=201)
+
+    app.add_middleware(IdempotencyMiddleware, cache=cache, logger=logger, ttl=60)
+    client = TestClient(app)
+
+    first = client.post("/items", headers={"Idempotency-Key": "create-1"})
+    second = client.post("/items", headers={"Idempotency-Key": "create-1"})
+
+    assert first.status_code == 201
+    assert first.json() == {"calls": 1}
+    assert second.status_code == 201
+    assert second.json() == {"calls": 1}
+    assert second.headers["x-idempotency-replay"] == "true"
+    assert calls == 1
+    assert cache.ttls["idempotency:/items:create-1"] == 60
+
+
+def test_idempotency_required_rejects_post_without_key() -> None:
+    app = FastAPI()
+    calls = 0
+
+    @app.post("/items")
+    async def create_item() -> dict[str, int]:
+        nonlocal calls
+        calls += 1
+        return {"calls": calls}
+
+    app.add_middleware(
+        IdempotencyMiddleware,
+        cache=FakeCache(),
+        logger=FakeLogger(),
+        required=True,
+    )
+    response = TestClient(app).post("/items")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Idempotency-Key header is required for POST requests"}
+    assert calls == 0
+
+
+def test_idempotency_does_not_cache_error_responses() -> None:
+    app = FastAPI()
+    calls = 0
+
+    @app.post("/items")
+    async def create_item() -> JSONResponse:
+        nonlocal calls
+        calls += 1
+        return JSONResponse({"calls": calls}, status_code=422)
+
+    app.add_middleware(IdempotencyMiddleware, cache=FakeCache(), logger=FakeLogger())
+    client = TestClient(app)
+
+    first = client.post("/items", headers={"Idempotency-Key": "bad-1"})
+    second = client.post("/items", headers={"Idempotency-Key": "bad-1"})
+
+    assert first.status_code == 422
+    assert first.json() == {"calls": 1}
+    assert second.status_code == 422
+    assert second.json() == {"calls": 2}
+    assert "x-idempotency-replay" not in second.headers


### PR DESCRIPTION
## Summary
- add `http/idempotency` to the CLI capability catalog and JSON export
- merge `config/http.yaml` idempotency settings without overwriting `etag` or `cache_control`
- cover middleware cache miss/hit, required `Idempotency-Key`, and non-caching of 4xx responses
- document `Idempotency-Key`, Redis recommendation for multi-worker, and the current replay contract

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 63 passed, 1 skipped
- `uv run pytest tests/units/adapters/inbound/fastapi/test_idempotency.py -q` -> 3 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check arclith tests/units/adapters/inbound/fastapi/test_idempotency.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- `make quality` -> ruff, bandit, mypy and 326 tests passed; Coverage fails globally at 80.78% < 90

Note: the existing middleware replays the cached successful response with its original status plus `X-Idempotency-Replay: true`; the docs now describe that current contract instead of forcing a 200.

Closes #80