### PR TITLE
[CLI] Add HTTP ETag capability

### DIFF
--- a/arclith/adapters/inbound/fastapi/etag.py
+++ b/arclith/adapters/inbound/fastapi/etag.py
@@ -31,8 +31,8 @@ class ETaggerMiddleware:
         1. Client sends `If-Match: "v1"` header
         2. Middleware extracts expected version
         3. Handler receives expected version in request state
-        4. Service validates version → 409 Conflict if mismatch
-        5. On success, response includes new `ETag: "v2"`
+        4. Service validates version and rejects stale mutations
+        5. Mutations keep their original response headers
 
     Workflow (conditional GET - cache validation):
         1. Client sends `If-None-Match: "v1"` header
@@ -43,7 +43,7 @@ class ETaggerMiddleware:
     Benefits:
         - No version field in PUT/PATCH payloads (cleaner API)
         - Standard HTTP semantics (CDN/proxy compatible)
-        - 412 Precondition Failed for version conflicts
+        - Application-level validation can reject version conflicts
         - 304 Not Modified for cache validation
     """
 
@@ -82,41 +82,84 @@ class ETaggerMiddleware:
         if if_none_match:
             scope["state"]["if_none_match"] = if_none_match
 
-        # Capture response to inject ETag
         response_data: dict[str, Any] = {"status": 200, "headers": [], "body": b""}
 
         async def _send_wrapper(message: Any) -> None:
             if message["type"] == "http.response.start":
                 response_data["status"] = message["status"]
                 response_data["headers"] = list(message.get("headers", []))
-
-                # Don't modify message yet - we'll do it after collecting body
-                await send(message)
-
             elif message["type"] == "http.response.body":
                 response_data["body"] += message.get("body", b"")
 
-                # If response is complete, inject ETag
-                if not message.get("more_body", False):
-                    # Try to extract version from response body
-                    etag = self._extract_etag_from_body(response_data["body"], response_data["status"])
-
-                    if etag and method == "GET":
-                        # Check If-None-Match for cache validation
-                        if if_none_match and if_none_match.strip('"') == etag.strip('"'):
-                            # Version matches → 304 Not Modified
-                            self._logger.info(
-                                "💾 Cache hit (304 Not Modified)",
-                                if_none_match = if_none_match,
-                                etag = etag,
-                            )
-                            # Note: We already sent the start message, so we can't change status
-                            # This is a limitation - would need to buffer the entire response
-                            # For now, just log and continue
-
-                await send(message)
-
         await self._app(scope, receive, _send_wrapper)
+        await self._send_response(send, method, if_none_match, response_data)
+
+    async def _send_response(
+            self,
+            send: Any,
+            method: str,
+            if_none_match: str | None,
+            response_data: dict[str, Any],
+    ) -> None:
+        etag = self._extract_etag_from_body(response_data["body"], response_data["status"])
+        if method != "GET" or etag is None:
+            await self._send_original_response(send, response_data)
+            return
+
+        if if_none_match and self._etag_matches(if_none_match, etag):
+            self._logger.info(
+                "💾 Cache hit (304 Not Modified)",
+                if_none_match=if_none_match,
+                etag=etag,
+            )
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 304,
+                    "headers": self._headers_with_etag(response_data["headers"], etag, drop_body_headers=True),
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": response_data["status"],
+                "headers": self._headers_with_etag(response_data["headers"], etag),
+            }
+        )
+        await send({"type": "http.response.body", "body": response_data["body"]})
+
+    @staticmethod
+    async def _send_original_response(send: Any, response_data: dict[str, Any]) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": response_data["status"],
+                "headers": response_data["headers"],
+            }
+        )
+        await send({"type": "http.response.body", "body": response_data["body"]})
+
+    @staticmethod
+    def _headers_with_etag(
+            headers: list[tuple[bytes, bytes]],
+            etag: str,
+            *,
+            drop_body_headers: bool = False,
+    ) -> list[tuple[bytes, bytes]]:
+        dropped = {b"etag"}
+        if drop_body_headers:
+            dropped.update({b"content-length"})
+        filtered = [(key, value) for key, value in headers if key.lower() not in dropped]
+        return [*filtered, (b"etag", etag.encode("utf-8"))]
+
+    @staticmethod
+    def _etag_matches(if_none_match: str, etag: str) -> bool:
+        candidates = [candidate.strip() for candidate in if_none_match.split(",")]
+        normalized_etag = etag.strip('"')
+        return any(candidate.strip('"') == normalized_etag for candidate in candidates)
 
     def _parse_etag(self, etag: str) -> int | None:
         """Parse ETag header to extract version number.
@@ -144,7 +187,7 @@ class ETaggerMiddleware:
 
     def _extract_etag_from_body(self, body: bytes, status: int) -> str | None:
         """Extract version from JSON response body to generate ETag.
-        
+
         Only for successful responses (2xx) with JSON body containing 'version' field.
         """
         if not (200 <= status < 300):

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -730,6 +730,30 @@ idempotency:
             ),
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="etag",
+            capability="http",
+            layer="inbound",
+            description="Middleware ETag et If-None-Match pour les lectures GET cacheables.",
+            merge_config_templates=(
+                FileTemplateSpec(
+                    path="config/http.yaml",
+                    template="""\
+etag:
+  enabled: {enabled}
+""",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="enabled",
+                    kind="boolean",
+                    prompt="Activer le middleware ETag",
+                    default=True,
+                ),
+            ),
+            entity_scoped=False,
+        ),
     ),
 )
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -506,6 +506,46 @@ def test_add_http_idempotency_adapter_merges_http_config(tmp_path: Path) -> None
     assert not (package_root / "adapters" / "inbound" / "idempotency").exists()
 
 
+def test_add_http_etag_adapter_merges_http_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    http_path = project_dir / "config" / "http.yaml"
+    http_path.write_text(
+        "idempotency:\n"
+        "  enabled: true\n"
+        "  ttl_seconds: 86400\n"
+        "  required: true\n"
+        "cache_control:\n"
+        "  get_single_max_age: 120\n"
+        "  get_list_max_age: 30\n",
+        encoding="utf-8",
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="http",
+        adapter="etag",
+        adapter_params={"enabled": "false"},
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    config = yaml.safe_load(http_path.read_text(encoding="utf-8"))
+    arclith = Arclith(project_dir / "config")
+    package_root = project_dir / "src" / "demo_service"
+
+    assert config == {
+        "idempotency": {"enabled": True, "ttl_seconds": 86400, "required": True},
+        "cache_control": {"get_single_max_age": 120, "get_list_max_age": 30},
+        "etag": {"enabled": False},
+    }
+    assert arclith.config.http.etag.enabled is False
+    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert not (package_root / "adapters" / "inbound" / "etag").exists()
+
+
 def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -179,8 +179,9 @@ def test_http_capability_catalog_declares_idempotency() -> None:
     assert capability is not None
     assert capability.layer == "inbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("idempotency",)
+    assert capability.adapter_names() == ("idempotency", "etag")
     idempotency = capability.get_adapter("idempotency")
+    etag = capability.get_adapter("etag")
     assert idempotency is not None
     assert idempotency.config_path is None
     assert [template.path for template in idempotency.merge_config_templates] == ["config/http.yaml"]
@@ -190,6 +191,11 @@ def test_http_capability_catalog_declares_idempotency() -> None:
         "ttl_seconds",
         "required",
     ]
+    assert etag is not None
+    assert etag.config_path is None
+    assert [template.path for template in etag.merge_config_templates] == ["config/http.yaml"]
+    assert etag.entity_scoped is False
+    assert [parameter.name for parameter in etag.parameters] == ["enabled"]
 
 
 def test_auth_capability_catalog_declares_keycloak() -> None:
@@ -380,6 +386,7 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "server" in encoded
     assert "http" in encoded
     assert "idempotency" in encoded
+    assert "etag" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
@@ -480,8 +487,9 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "enabled",
     ]
     http = payload_by_name["http"]
-    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency"]
+    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency", "etag"]
     idempotency = http["adapters"][0]
+    etag = http["adapters"][1]
     assert idempotency["config_path"] is None
     assert [template["path"] for template in idempotency["merge_config_templates"]] == ["config/http.yaml"]
     assert [parameter["name"] for parameter in idempotency["parameters"]] == [
@@ -489,6 +497,9 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "ttl_seconds",
         "required",
     ]
+    assert etag["config_path"] is None
+    assert [template["path"] for template in etag["merge_config_templates"]] == ["config/http.yaml"]
+    assert [parameter["name"] for parameter in etag["parameters"]] == ["enabled"]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]
     keycloak_parameters = {parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -109,6 +109,11 @@ Durée pendant laquelle la réponse est considérée "fraîche" sans revalidatio
 
 Le cache HTTP est plus efficace couplé avec ETag (RFC 7232).
 
+Dans Arclith, `ETaggerMiddleware` s'applique aux réponses `GET` JSON `2xx` qui exposent un champ
+`version` ou `data.version`. Les `POST`, `PUT`, `PATCH` et `DELETE` ne reçoivent pas de header de
+cache en sortie; `If-Match` sur `PUT`/`PATCH` reste disponible côté requête pour l'optimistic
+locking applicatif.
+
 **Workflow:**
 
 1. **Première requête:**
@@ -297,4 +302,3 @@ cache_control:
 - **RFC 7234:** [Caching](https://www.rfc-editor.org/rfc/rfc7234.html)
 - **MDN:** [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 - **Google Web Fundamentals:** [HTTP Caching](https://web.dev/http-cache/)
-

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -489,6 +489,7 @@ modifier les routes métier.
 Adapter disponible:
 
 - `idempotency`: middleware `Idempotency-Key` pour éviter les doubles mutations `POST`.
+- `etag`: middleware `ETag` / `If-None-Match` pour les lectures `GET` cacheables.
 
 ```bash
 arclith-cli add-adapter \
@@ -518,6 +519,27 @@ cache. Avec `required: true`, un `POST` sans header est rejeté en `400`.
 Le cache sous-jacent est `cache/memory` par défaut: il suffit en développement ou mono-processus.
 En multi-worker, Kubernetes ou API/MCP séparés, configurer `cache/redis` pour partager les clés
 idempotentes entre processus.
+
+```bash
+arclith-cli add-adapter \
+  --capability http \
+  --adapter etag \
+  --param enabled=true \
+  --yes
+```
+
+Résultat fusionné dans `config/http.yaml`:
+
+```yaml
+etag:
+  enabled: true
+```
+
+Quand `enabled: true`, `Arclith.fastapi()` ajoute `ETaggerMiddleware`. Le middleware concerne les
+réponses `GET` JSON `2xx` qui contiennent `version` ou `data.version`: il ajoute `ETag: "v<version>"`
+et retourne `304 Not Modified` sans body si `If-None-Match` correspond. Les mutations ne reçoivent
+pas de header de cache en sortie; `If-Match` sur `PUT`/`PATCH` est seulement exposé via
+`request.state.expected_version` pour que la route ou le service valide l'optimistic locking.
 
 ### `mcp`
 

--- a/tests/units/adapters/inbound/fastapi/test_etag.py
+++ b/tests/units/adapters/inbound/fastapi/test_etag.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from arclith import Arclith
+from arclith.adapters.inbound.fastapi.etag import ETaggerMiddleware, get_expected_version_from_request
+from arclith.domain.ports.outbound.logger import Logger, LogLevel
+
+
+class FakeLogger(Logger):
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
+        self.records.append({"level": level, "message": message, "metadata": metadata})
+
+
+def test_etag_get_adds_header_from_wrapped_response_version() -> None:
+    app = FastAPI()
+
+    @app.get("/items/1")
+    async def read_item() -> dict[str, dict[str, int]]:
+        return {"data": {"version": 3}}
+
+    app.add_middleware(ETaggerMiddleware, logger=FakeLogger())
+    response = TestClient(app).get("/items/1")
+
+    assert response.status_code == 200
+    assert response.headers["etag"] == '"v3"'
+    assert response.json() == {"data": {"version": 3}}
+
+
+def test_etag_get_if_none_match_returns_304_without_body() -> None:
+    app = FastAPI()
+
+    @app.get("/items/1")
+    async def read_item() -> dict[str, int]:
+        return {"version": 3}
+
+    app.add_middleware(ETaggerMiddleware, logger=FakeLogger())
+    response = TestClient(app).get("/items/1", headers={"If-None-Match": '"v3"'})
+
+    assert response.status_code == 304
+    assert response.headers["etag"] == '"v3"'
+    assert response.content == b""
+
+
+def test_etag_put_if_match_is_available_without_response_cache_header() -> None:
+    app = FastAPI()
+
+    @app.put("/items/1")
+    async def update_item(request: Request) -> dict[str, int | None]:
+        return {"expected_version": get_expected_version_from_request(request), "version": 4}
+
+    app.add_middleware(ETaggerMiddleware, logger=FakeLogger())
+    response = TestClient(app).put("/items/1", headers={"If-Match": 'W/"v3"'})
+
+    assert response.status_code == 200
+    assert response.json() == {"expected_version": 3, "version": 4}
+    assert "etag" not in response.headers
+
+
+def test_arclith_fastapi_does_not_add_etag_when_disabled(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    adapters_dir = config_dir / "adapters"
+    adapters_dir.mkdir(parents=True)
+    (adapters_dir / "adapters.yaml").write_text(
+        "logger: console\n"
+        "repository: memory\n"
+        "observability:\n"
+        "  enabled: []\n",
+        encoding="utf-8",
+    )
+    (config_dir / "http.yaml").write_text(
+        "idempotency:\n"
+        "  enabled: false\n"
+        "etag:\n"
+        "  enabled: false\n"
+        "cache_control:\n"
+        "  get_single_max_age: 300\n"
+        "  get_list_max_age: 60\n",
+        encoding="utf-8",
+    )
+
+    app = Arclith(config_dir).fastapi()
+
+    @app.get("/items/1")
+    async def read_item() -> dict[str, int]:
+        return {"version": 3}
+
+    response = TestClient(app).get("/items/1")
+
+    assert response.status_code == 200
+    assert "etag" not in response.headers


### PR DESCRIPTION
## Summary
- add `http/etag` to the CLI capability catalog and JSON export
- merge `http.etag.enabled` into `config/http.yaml` without overwriting idempotency/cache_control
- buffer ETag middleware responses so GET ETags and 304 If-None-Match work as documented
- document GET-only cache validation and mutation behavior

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 64 passed, 1 skipped
- `uv run pytest tests/units/adapters/inbound/fastapi/test_etag.py -q` -> 4 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check arclith tests/units/adapters/inbound/fastapi/test_etag.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- `make quality` -> ruff, bandit, mypy and 330 tests passed; Coverage fails globally at 88.87% < 90

Closes #81