### PR TITLE
[CLI] Add HTTP cache-control capability

### DIFF
--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -252,6 +252,13 @@ class CacheControlSettings(BaseModel):
     get_single_max_age: int = 300  # 5 minutes
     get_list_max_age: int = 60  # 1 minute
 
+    @field_validator("get_single_max_age", "get_list_max_age")
+    @classmethod
+    def must_be_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("cache_control max-age doit etre >= 0")
+        return v
+
 
 class HttpSettings(BaseModel):
     idempotency: IdempotencySettings = IdempotencySettings()

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -274,7 +274,34 @@ def _resolve_adapter_params(
         value = _resolve_parameter(parameter, provided_values.get(parameter.name), project_dir, prompt_missing)
         resolved[parameter.name] = _render_parameter_value(parameter, value)
 
-    return resolved
+    return _normalize_adapter_params(adapter, resolved)
+
+
+def _normalize_adapter_params(adapter: AdapterSpec, params: dict[str, Any]) -> dict[str, Any]:
+    if adapter.capability == "http" and adapter.name == "cache-control":
+        return _normalize_cache_control_params(params)
+    return params
+
+
+def _normalize_cache_control_params(params: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(params)
+    for name in ("get_single_max_age", "get_list_max_age"):
+        raw_value = str(normalized[name]).strip()
+        try:
+            value = int(raw_value)
+        except ValueError:
+            console.print(
+                f"[red]✗[/red] Valeur entière invalide pour [bold]{name}[/bold]: {raw_value}."
+            )
+            raise typer.Exit(1) from None
+        if value < 0:
+            console.print(
+                f"[red]✗[/red] Valeur invalide pour [bold]{name}[/bold]: {value}. "
+                "Utilisez une valeur >= 0."
+            )
+            raise typer.Exit(1)
+        normalized[name] = value
+    return normalized
 
 
 def _assert_supported_params(adapter: AdapterSpec, extra_params: dict[str, str]) -> None:

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -754,6 +754,37 @@ etag:
             ),
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="cache-control",
+            capability="http",
+            layer="inbound",
+            description="Directives Cache-Control FastAPI pour lectures GET et mutations.",
+            merge_config_templates=(
+                FileTemplateSpec(
+                    path="config/http.yaml",
+                    template="""\
+cache_control:
+  get_single_max_age: {get_single_max_age}
+  get_list_max_age: {get_list_max_age}
+""",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="get_single_max_age",
+                    kind="string",
+                    prompt="TTL Cache-Control des GET ressource unique",
+                    default="300",
+                ),
+                ParameterSpec(
+                    name="get_list_max_age",
+                    kind="string",
+                    prompt="TTL Cache-Control des GET collection",
+                    default="60",
+                ),
+            ),
+            entity_scoped=False,
+        ),
     ),
 )
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -546,6 +546,71 @@ def test_add_http_etag_adapter_merges_http_config(tmp_path: Path) -> None:
     assert not (package_root / "adapters" / "inbound" / "etag").exists()
 
 
+def test_add_http_cache_control_adapter_merges_http_config(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    http_path = project_dir / "config" / "http.yaml"
+    http_path.write_text(
+        "idempotency:\n"
+        "  enabled: true\n"
+        "  ttl_seconds: 86400\n"
+        "  required: true\n"
+        "etag:\n"
+        "  enabled: false\n"
+        "cache_control:\n"
+        "  get_single_max_age: 300\n"
+        "  get_list_max_age: 60\n",
+        encoding="utf-8",
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="http",
+        adapter="cache-control",
+        adapter_params={
+            "get_single_max_age": "900",
+            "get_list_max_age": "0",
+        },
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    config = yaml.safe_load(http_path.read_text(encoding="utf-8"))
+    arclith = Arclith(project_dir / "config")
+    package_root = project_dir / "src" / "demo_service"
+
+    assert config == {
+        "idempotency": {"enabled": True, "ttl_seconds": 86400, "required": True},
+        "etag": {"enabled": False},
+        "cache_control": {"get_single_max_age": 900, "get_list_max_age": 0},
+    }
+    assert arclith.config.http.cache_control.get_single_max_age == 900
+    assert arclith.config.http.cache_control.get_list_max_age == 0
+    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert not (package_root / "adapters" / "inbound" / "cache-control").exists()
+
+
+def test_add_http_cache_control_adapter_rejects_negative_max_age(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    http_path = project_dir / "config" / "http.yaml"
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="http",
+            adapter="cache-control",
+            adapter_params={
+                "get_single_max_age": "-1",
+                "get_list_max_age": "60",
+            },
+            yes=True,
+        )
+
+    assert not http_path.exists()
+
+
 def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -179,9 +179,10 @@ def test_http_capability_catalog_declares_idempotency() -> None:
     assert capability is not None
     assert capability.layer == "inbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("idempotency", "etag")
+    assert capability.adapter_names() == ("idempotency", "etag", "cache-control")
     idempotency = capability.get_adapter("idempotency")
     etag = capability.get_adapter("etag")
+    cache_control = capability.get_adapter("cache-control")
     assert idempotency is not None
     assert idempotency.config_path is None
     assert [template.path for template in idempotency.merge_config_templates] == ["config/http.yaml"]
@@ -196,6 +197,14 @@ def test_http_capability_catalog_declares_idempotency() -> None:
     assert [template.path for template in etag.merge_config_templates] == ["config/http.yaml"]
     assert etag.entity_scoped is False
     assert [parameter.name for parameter in etag.parameters] == ["enabled"]
+    assert cache_control is not None
+    assert cache_control.config_path is None
+    assert [template.path for template in cache_control.merge_config_templates] == ["config/http.yaml"]
+    assert cache_control.entity_scoped is False
+    assert [parameter.name for parameter in cache_control.parameters] == [
+        "get_single_max_age",
+        "get_list_max_age",
+    ]
 
 
 def test_auth_capability_catalog_declares_keycloak() -> None:
@@ -387,6 +396,7 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "http" in encoded
     assert "idempotency" in encoded
     assert "etag" in encoded
+    assert "cache-control" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
@@ -487,9 +497,10 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "enabled",
     ]
     http = payload_by_name["http"]
-    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency", "etag"]
+    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency", "etag", "cache-control"]
     idempotency = http["adapters"][0]
     etag = http["adapters"][1]
+    cache_control = http["adapters"][2]
     assert idempotency["config_path"] is None
     assert [template["path"] for template in idempotency["merge_config_templates"]] == ["config/http.yaml"]
     assert [parameter["name"] for parameter in idempotency["parameters"]] == [
@@ -500,6 +511,12 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert etag["config_path"] is None
     assert [template["path"] for template in etag["merge_config_templates"]] == ["config/http.yaml"]
     assert [parameter["name"] for parameter in etag["parameters"]] == ["enabled"]
+    assert cache_control["config_path"] is None
+    assert [template["path"] for template in cache_control["merge_config_templates"]] == ["config/http.yaml"]
+    assert [parameter["name"] for parameter in cache_control["parameters"]] == [
+        "get_single_max_age",
+        "get_list_max_age",
+    ]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]
     keycloak_parameters = {parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]}

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -33,16 +33,35 @@ cache_control:
   get_list_max_age: 60     # 1 minute - GET /
 ```
 
+Configuration via CLI:
+
+```bash
+arclith-cli add-adapter \
+  --capability http \
+  --adapter cache-control \
+  --param get_single_max_age=300 \
+  --param get_list_max_age=60 \
+  --yes
+```
+
+Les valeurs doivent être positives ou nulles. `get_list_max_age: 0` transforme les réponses
+collection en `no-store`, utile pour les listes temps-réel. Un TTL plus long réduit la latence et
+la bande passante, mais augmente la durée pendant laquelle l'utilisateur peut voir une donnée
+ancienne sans revalidation.
+
 ### Stratégie par verbe
 
 | Verbe            | Ressource          | Directive               | Raison                                                                           |
 |------------------|--------------------|-------------------------|----------------------------------------------------------------------------------|
 | **GET**          | Single (`/{uuid}`) | `private, max-age=300`  | Cacheable 5min par le client, pas le CDN (données potentiellement user-specific) |
 | **GET**          | Collection (`/`)   | `private, max-age=60`   | Shorter TTL (1min) car changements fréquents                                     |
-| **POST**         | Create             | `no-cache, no-store`    | Jamais cacher les mutations                                                      |
-| **PUT/PATCH**    | Update             | `no-cache, no-store`    | Jamais cacher les mutations                                                      |
-| **DELETE**       | Delete             | `no-cache, no-store`    | Jamais cacher les mutations                                                      |
+| **POST**         | Create             | `no-cache, no-store, must-revalidate` | Jamais cacher les mutations                                                      |
+| **PUT/PATCH**    | Update             | `no-cache, no-store, must-revalidate` | Jamais cacher les mutations                                                      |
+| **DELETE**       | Delete             | `no-cache, no-store, must-revalidate` | Jamais cacher les mutations                                                      |
 | **HEAD/OPTIONS** | Metadata           | `public, max-age=86400` | Cacheable 24h par tout le monde                                                  |
+
+Si une route définit déjà `Cache-Control`, le middleware ne l'écrase pas. Cela permet de garder une
+politique spécifique sur un endpoint sans contourner le câblage transverse.
 
 ### Heuristique ressource unique vs collection
 
@@ -103,7 +122,7 @@ Durée pendant laquelle la réponse est considérée "fraîche" sans revalidatio
 - Header: `Cache-Control: no-cache, no-store, must-revalidate`
 - Utilisé quand: mutations (POST/PUT/PATCH/DELETE)
 
-**Dans _sample:** Mutations utilisent `no-cache, no-store` pour éviter tout cache.
+**Dans _sample:** Mutations utilisent `no-cache, no-store, must-revalidate` pour éviter tout cache.
 
 ## Intégration avec ETag
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -490,6 +490,7 @@ Adapter disponible:
 
 - `idempotency`: middleware `Idempotency-Key` pour éviter les doubles mutations `POST`.
 - `etag`: middleware `ETag` / `If-None-Match` pour les lectures `GET` cacheables.
+- `cache-control`: directives `Cache-Control` pour lectures `GET` et mutations.
 
 ```bash
 arclith-cli add-adapter \
@@ -540,6 +541,31 @@ réponses `GET` JSON `2xx` qui contiennent `version` ou `data.version`: il ajout
 et retourne `304 Not Modified` sans body si `If-None-Match` correspond. Les mutations ne reçoivent
 pas de header de cache en sortie; `If-Match` sur `PUT`/`PATCH` est seulement exposé via
 `request.state.expected_version` pour que la route ou le service valide l'optimistic locking.
+
+```bash
+arclith-cli add-adapter \
+  --capability http \
+  --adapter cache-control \
+  --param get_single_max_age=300 \
+  --param get_list_max_age=60 \
+  --yes
+```
+
+Résultat fusionné dans `config/http.yaml`:
+
+```yaml
+cache_control:
+  get_single_max_age: 300
+  get_list_max_age: 60
+```
+
+`CacheControlMiddleware` est ajouté par `Arclith.fastapi()` et ne nécessite pas de modification des
+routers. Les `GET` vers une ressource unique détectée par un segment UUID-like reçoivent
+`private, max-age=<get_single_max_age>`. Les collections reçoivent
+`private, max-age=<get_list_max_age>`; si `get_list_max_age: 0`, elles reçoivent `no-store`.
+Les mutations `POST`, `PUT`, `PATCH` et `DELETE` restent non cacheables avec
+`no-cache, no-store, must-revalidate`. Si une route définit déjà `Cache-Control`, le middleware
+préserve ce header. Les TTL négatifs sont refusés au chargement de config.
 
 ### `mcp`
 

--- a/tests/units/adapters/inbound/fastapi/test_cache_control.py
+++ b/tests/units/adapters/inbound/fastapi/test_cache_control.py
@@ -1,0 +1,104 @@
+from typing import Any
+
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+
+from arclith.adapters.inbound.fastapi.cache_control import CacheControlMiddleware
+from arclith.domain.ports.outbound.logger import Logger, LogLevel
+
+
+class FakeLogger(Logger):
+    def __init__(self) -> None:
+        self.records: list[dict[str, Any]] = []
+
+    def log(self, level: LogLevel, message: str, **metadata: Any) -> None:
+        self.records.append({"level": level, "message": message, "metadata": metadata})
+
+
+def _client(app: FastAPI) -> TestClient:
+    app.add_middleware(
+        CacheControlMiddleware,
+        logger=FakeLogger(),
+        get_single_max_age=900,
+        get_list_max_age=0,
+    )
+    return TestClient(app)
+
+
+async def test_cache_control_passes_non_http_scope_unchanged() -> None:
+    seen_scopes: list[str] = []
+
+    async def app(scope: dict[str, str], receive: Any, send: Any) -> None:
+        seen_scopes.append(scope["type"])
+
+    middleware = CacheControlMiddleware(app, logger=FakeLogger())
+
+    await middleware({"type": "lifespan"}, None, None)
+
+    assert seen_scopes == ["lifespan"]
+
+
+def test_cache_control_get_single_resource_uses_single_ttl() -> None:
+    app = FastAPI()
+
+    @app.get("/items/0123456789abcdef0123456789abcdef")
+    async def read_item() -> dict[str, str]:
+        return {"uuid": "0123456789abcdef0123456789abcdef"}
+
+    response = _client(app).get("/items/0123456789abcdef0123456789abcdef")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "private, max-age=900"
+
+
+def test_cache_control_get_collection_uses_list_ttl_zero_as_no_store() -> None:
+    app = FastAPI()
+
+    @app.get("/items")
+    async def list_items() -> list[str]:
+        return []
+
+    response = _client(app).get("/items")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_cache_control_mutation_is_no_store() -> None:
+    app = FastAPI()
+
+    @app.post("/items")
+    async def create_item() -> dict[str, bool]:
+        return {"created": True}
+
+    response = _client(app).post("/items")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache, no-store, must-revalidate"
+
+
+def test_cache_control_preserves_existing_header() -> None:
+    app = FastAPI()
+
+    @app.get("/items")
+    async def list_items(response: Response) -> list[str]:
+        response.headers["Cache-Control"] = "public, max-age=42"
+        return []
+
+    response = _client(app).get("/items")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=42"
+
+
+def test_cache_control_supports_optional_directive_branches() -> None:
+    middleware = CacheControlMiddleware(
+        app=lambda scope, receive, send: None,
+        logger=FakeLogger(),
+        mutations_no_store=False,
+    )
+
+    assert middleware._get_cache_control("POST", "/items") == "no-cache"
+    assert middleware._get_cache_control("HEAD", "/items") == "public, max-age=86400"
+    assert middleware._get_cache_control("OPTIONS", "/items") == "public, max-age=86400"
+    assert middleware._get_cache_control("TRACE", "/items") is None

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from arclith.infrastructure.config import (
     AppConfig,
+    CacheControlSettings,
     DuckDBSettings,
     LangGraphSettings,
     LangSmithSettings,
@@ -436,6 +437,18 @@ def test_soft_delete_negative_raises():
 def test_soft_delete_zero_is_valid():
     s = SoftDeleteSettings(retention_days=0)
     assert s.retention_days == 0
+
+
+def test_cache_control_rejects_negative_max_age():
+    with pytest.raises(ValidationError, match="cache_control max-age doit etre >= 0"):
+        CacheControlSettings(get_single_max_age=-1)
+
+
+def test_cache_control_zero_max_age_is_valid():
+    settings = CacheControlSettings(get_single_max_age=0, get_list_max_age=0)
+
+    assert settings.get_single_max_age == 0
+    assert settings.get_list_max_age == 0
 
 
 def test_mongodb_uri_optional_at_parse_time():


### PR DESCRIPTION
## Summary
- add the `http/cache-control` CLI adapter and JSON catalog entry
- merge `cache_control.get_single_max_age` and `get_list_max_age` into `config/http.yaml` without overwriting idempotency/etag
- reject invalid negative cache-control TTLs in the CLI and config loader
- test Cache-Control behavior for GET single/list, mutations, existing headers, and optional directive branches
- document TTL tradeoffs, `0` list TTL behavior, and preserved route-level headers

## Validation
- `uv run pytest tests/test_capabilities.py tests/test_add_adapter.py -q` from `cli/` -> 66 passed, 1 skipped
- `uv run pytest tests/units/adapters/inbound/fastapi/test_cache_control.py tests/units/infrastructure/test_config.py -q` -> 90 passed
- `uv run ruff check arclith_cli tests` from `cli/` -> passed
- `uv run ruff check arclith tests/units/adapters/inbound/fastapi/test_cache_control.py tests/units/infrastructure/test_config.py` -> passed
- `make docs` -> passed with existing Material for MkDocs 2.0 warning
- `git diff --check` -> passed
- `make quality` -> ruff, bandit, mypy and 338 tests passed; coverage reached 90.22%

Closes #82