### PR TITLE
feat(cli): add Docker runtime capability

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,8 @@ uv tool install "git+https://github.com/karned-rekipe/arclith.git#subdirectory=c
 ### `init` — Initialiser un projet minimal
 
 Crée un projet Arclith vide de métier, avec le layout canonique `src/<package>/...`, une
-configuration minimale et un `main.py` prêt à recevoir les adapters.
+configuration minimale, un `main.py` prêt à recevoir les adapters et le runtime Docker standard
+(`Dockerfile`, `.dockerignore`, `arclith-run`).
 
 ```bash
 # Mode interactif
@@ -49,7 +50,9 @@ arclith-cli new MealPlan meal-plan-service --dir ~/projects --port 8500
 | `--dir` / `-d` | `.` | Répertoire parent |
 | `--ref` | `main` | Branche/tag du template |
 
-Le projet généré utilise un layout `src/<package>/...` pour le code applicatif et un dossier `config/` structuré par adapter (voir section [Configuration](#configuration)).
+Le projet généré utilise un layout `src/<package>/...` pour le code applicatif et un dossier
+`config/` structuré par adapter (voir section [Configuration](#configuration)). Le Dockerfile du
+template est régénéré côté CLI pour appliquer le contrat `runtime/docker-image` courant.
 
 ---
 
@@ -141,6 +144,7 @@ arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name=q
 arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=recipe_agent --yes
 arclith-cli add-adapter --capability observability --adapter langsmith
 arclith-cli add-adapter --capability observability --adapter opentelemetry --param service_name=my_recipe_service --yes
+arclith-cli add-adapter --capability runtime --adapter docker-image --yes
 arclith-cli add-adapter --capability cache --adapter memory --yes
 arclith-cli add-adapter --capability cache --adapter redis --param redis_url=redis://redis:6379 --yes
 arclith-cli add-adapter --capability repository --adapter memory --entity Recipe --yes
@@ -148,8 +152,8 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
 
 **Étapes du wizard :**
 
-1. **Type d'adapter** — selon la capacité : `memory` · `mongodb` · `duckdb` · `mariadb` · `fastapi` · `fastmcp` · `lmstudio` · `openai` · `anthropic` · `langgraph` · `langsmith` · `opentelemetry`
-2. **Entité(s) cible(s)** — détectées automatiquement pour les adapters entity-scoped ; ignorées pour les transports globaux, `cache/*`, `llm/*`, `agent/langgraph` et les adapters d'observability
+1. **Type d'adapter** — selon la capacité : `memory` · `mongodb` · `duckdb` · `mariadb` · `fastapi` · `fastmcp` · `rabbitmq` · `docker-image` · `lmstudio` · `openai` · `anthropic` · `langgraph` · `langsmith` · `opentelemetry`
+2. **Entité(s) cible(s)** — détectées automatiquement pour les adapters entity-scoped ; ignorées pour les transports globaux, `cache/*`, `llm/*`, `agent/langgraph`, `runtime/docker-image` et les adapters d'observability
 3. **Paramètres** — questions spécifiques à l'adapter :
    - `mongodb` → `db_name`, `collection_name`, `multitenant`
    - `duckdb` → `path`
@@ -166,14 +170,15 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `langsmith` → `tracing`, `project`, `endpoint`, `LANGSMITH_API_KEY`
    - `opentelemetry` → `service_name`, `endpoint`, `traces_endpoint`, `metrics_endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
    - `command-bus/rabbitmq` → `url`, `exchange`, `exchange_type`, `queue`, `routing_key`, `prefetch`, `consumer_name`, `concurrency`, `publisher_confirms`, `durable`, `retry_enabled`, `retry_requeue`, `dead_letter_exchange`, `dead_letter_routing_key`
+   - `runtime/docker-image` → `uv_version`, `api_port`, `mcp_port`, `probe_port`, `agent_port`
    - `repository/memory` → aucun paramètre
-4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `cache/*`, `llm/*`, `agent/langgraph` et `command-bus/rabbitmq` sont exposés par leurs fichiers de configuration scopés
+4. **Activation** — met à jour `config/adapters/adapters.yaml` pour les capacités activables (`repository: <adapter>` ou `observability.enabled: [<adapter>, ...]`) ; `api/fastapi`, `mcp/fastmcp`, `cache/*`, `llm/*`, `agent/langgraph`, `command-bus/rabbitmq` et `runtime/docker-image` sont exposés par leurs fichiers dédiés
 5. **Récapitulatif** — liste des fichiers créés ou remplacés avant confirmation
 
 | Option | Défaut | Description |
 |--------|--------|-------------|
-| `--capability` | `repository` | Capacité cible du catalogue standardisé (`repository`, `cache`, `api`, `mcp`, `http`, `command-bus`, `llm`, `agent`, `observability`) |
-| `--adapter` / `-a` | interactif | Adapter du catalogue : `memory`, `mongodb`, `duckdb`, `mariadb`, `fastapi`, `fastmcp`, `idempotency`, `etag`, `cache-control`, `rabbitmq`, `lmstudio`, `openai`, `anthropic`, `langgraph`, `langsmith`, `opentelemetry` |
+| `--capability` | `repository` | Capacité cible du catalogue standardisé (`repository`, `cache`, `api`, `mcp`, `http`, `command-bus`, `runtime`, `llm`, `agent`, `observability`) |
+| `--adapter` / `-a` | interactif | Adapter du catalogue : `memory`, `mongodb`, `duckdb`, `mariadb`, `fastapi`, `fastmcp`, `idempotency`, `etag`, `cache-control`, `rabbitmq`, `docker-image`, `lmstudio`, `openai`, `anthropic`, `langgraph`, `langsmith`, `opentelemetry` |
 | `--entity` / `-e` | auto si une seule entité | Entité cible, liste séparée par virgule acceptée |
 | `--all-entities` | `false` | Génère l'adapter pour toutes les entités détectées |
 | `--activate/--no-activate` | `--activate` | Met à jour `config/adapters/adapters.yaml` quand la capacité expose une clé d'activation |
@@ -194,6 +199,20 @@ src/<package>/infrastructure/containers/<entity>_container.py  # RepositoryRegis
 ```
 
 > ⚠️ `src/<package>/infrastructure/containers/<entity>_container.py` est **régénéré intégralement** si le fichier existe déjà — un avertissement est affiché dans le récapitulatif.
+
+**Runtime Docker :**
+
+```bash
+arclith-cli add-adapter --capability runtime --adapter docker-image --yes
+uv lock
+docker build -t my-recipe-service:local .
+docker run --rm -p 8000:8000 -p 9000:9000 my-recipe-service:local api
+```
+
+L'adapter `runtime/docker-image` génère `Dockerfile`, `.dockerignore` et `arclith-run`. Une seule
+image peut démarrer `api`, `mcp_http`, `mcp_sse`, `bus`, `agent` ou `all` par argument ou via
+`ARCLITH_RUNTIME_MODE`. Les secrets restent hors build; `.env`, `secrets.yaml` et les clés privées
+sont exclus du contexte Docker.
 
 **LangGraph / LangSmith :**
 

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -282,6 +282,8 @@ def _normalize_adapter_params(adapter: AdapterSpec, params: dict[str, Any]) -> d
         return _normalize_cache_control_params(params)
     if adapter.capability == "command-bus" and adapter.name == "rabbitmq":
         return _normalize_rabbitmq_command_bus_params(params)
+    if adapter.capability == "runtime" and adapter.name == "docker-image":
+        return _normalize_docker_image_params(params)
     return params
 
 
@@ -321,6 +323,33 @@ def _normalize_rabbitmq_command_bus_params(params: dict[str, Any]) -> dict[str, 
             console.print(
                 f"[red]✗[/red] Valeur invalide pour [bold]{name}[/bold]: {value}. "
                 "Utilisez une valeur > 0."
+            )
+            raise typer.Exit(1)
+        normalized[name] = value
+    return normalized
+
+
+def _normalize_docker_image_params(params: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(params)
+    uv_version = str(normalized["uv_version"]).strip()
+    if not uv_version:
+        console.print("[red]✗[/red] Version uv invalide: valeur vide.")
+        raise typer.Exit(1)
+    normalized["uv_version"] = uv_version
+
+    for name in ("api_port", "mcp_port", "probe_port", "agent_port"):
+        raw_value = str(normalized[name]).strip()
+        try:
+            value = int(raw_value)
+        except ValueError:
+            console.print(
+                f"[red]✗[/red] Port entier invalide pour [bold]{name}[/bold]: {raw_value}."
+            )
+            raise typer.Exit(1) from None
+        if value <= 0 or value > 65535:
+            console.print(
+                f"[red]✗[/red] Port invalide pour [bold]{name}[/bold]: {value}. "
+                "Utilisez une valeur entre 1 et 65535."
             )
             raise typer.Exit(1)
         normalized[name] = value
@@ -583,6 +612,8 @@ def _generate(
         generated_path = project_dir / render(file_template.path, params)
         generated_path.parent.mkdir(parents=True, exist_ok=True)
         generated_path.write_text(render(file_template.template, params), encoding="utf-8")
+        if generated_path.name == "arclith-run":
+            generated_path.chmod(0o755)
         console.print(f"[green]✓[/green] {generated_path.relative_to(project_dir)}")
 
     import_vars = _import_vars(paths)

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -29,6 +29,7 @@ from .entity_scanner import EntityInfo, scan_entities, scan_installed_adapters
 from .project_paths import ProjectPaths, detect_project_paths
 
 console = Console()
+_UV_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
@@ -332,8 +333,10 @@ def _normalize_rabbitmq_command_bus_params(params: dict[str, Any]) -> dict[str, 
 def _normalize_docker_image_params(params: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(params)
     uv_version = str(normalized["uv_version"]).strip()
-    if not uv_version:
-        console.print("[red]✗[/red] Version uv invalide: valeur vide.")
+    if not _UV_VERSION_RE.fullmatch(uv_version):
+        console.print(
+            "[red]✗[/red] Version uv invalide: utilisez un token sans espace, accolade ou saut de ligne."
+        )
         raise typer.Exit(1)
     normalized["uv_version"] = uv_version
 

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -929,7 +929,7 @@ rabbitmq:
 RUNTIME_CAPABILITY = CapabilitySpec(
     name="runtime",
     layer="runtime",
-    description="Runtime de deploiement standardise pour images et processus Arclith.",
+    description="Runtime de déploiement standardisé pour images et processus Arclith.",
     activation_config_key=None,
     adapters=(
         AdapterSpec(

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -3,8 +3,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from .runtime_templates import (
+    ARCLITH_RUN_TEMPLATE,
+    DEFAULT_AGENT_PORT,
+    DEFAULT_API_PORT,
+    DEFAULT_MCP_PORT,
+    DEFAULT_PROBE_PORT,
+    DEFAULT_UV_VERSION,
+    DOCKERFILE_TEMPLATE,
+    DOCKERIGNORE_TEMPLATE,
+)
+
 ParameterKind = Literal["string", "boolean"]
-LayerKind = Literal["inbound", "outbound", "bidirectional"]
+LayerKind = Literal["inbound", "outbound", "bidirectional", "runtime"]
 
 
 @dataclass(frozen=True)
@@ -915,6 +926,59 @@ rabbitmq:
     ),
 )
 
+RUNTIME_CAPABILITY = CapabilitySpec(
+    name="runtime",
+    layer="runtime",
+    description="Runtime de deploiement standardise pour images et processus Arclith.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="docker-image",
+            capability="runtime",
+            layer="runtime",
+            description="Dockerfile multi-stage non-root et entrypoint arclith-run multi-transport.",
+            file_templates=(
+                FileTemplateSpec(path="Dockerfile", template=DOCKERFILE_TEMPLATE),
+                FileTemplateSpec(path=".dockerignore", template=DOCKERIGNORE_TEMPLATE),
+                FileTemplateSpec(path="arclith-run", template=ARCLITH_RUN_TEMPLATE),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="uv_version",
+                    kind="string",
+                    prompt="Version uv pinnee dans le builder Docker",
+                    default=DEFAULT_UV_VERSION,
+                ),
+                ParameterSpec(
+                    name="api_port",
+                    kind="string",
+                    prompt="Port expose FastAPI",
+                    default=DEFAULT_API_PORT,
+                ),
+                ParameterSpec(
+                    name="mcp_port",
+                    kind="string",
+                    prompt="Port expose FastMCP",
+                    default=DEFAULT_MCP_PORT,
+                ),
+                ParameterSpec(
+                    name="probe_port",
+                    kind="string",
+                    prompt="Port expose probes /health",
+                    default=DEFAULT_PROBE_PORT,
+                ),
+                ParameterSpec(
+                    name="agent_port",
+                    kind="string",
+                    prompt="Port expose LangGraph agent",
+                    default=DEFAULT_AGENT_PORT,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 AUTH_CAPABILITY = CapabilitySpec(
     name="auth",
     layer="inbound",
@@ -1422,6 +1486,7 @@ CAPABILITY_CATALOG = (
     PROBE_CAPABILITY,
     HTTP_CAPABILITY,
     COMMAND_BUS_CAPABILITY,
+    RUNTIME_CAPABILITY,
     AUTH_CAPABILITY,
     TENANT_CAPABILITY,
     LICENSE_CAPABILITY,

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -9,6 +9,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.tree import Tree
 
+from .runtime_templates import DOCKERIGNORE_TEMPLATE, render_arclith_run, render_dockerfile
+
 console = Console()
 
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -161,25 +163,61 @@ dist/
         f'''"""Application entrypoint for {project_name}."""
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 
 from arclith import Arclith
 
 _CONFIG = Path(__file__).parent / "config"
+_MODE = os.getenv("MODE", "api")
+_VALID_MODES = {{"api", "mcp_http", "mcp_sse", "all"}}
+
+if _MODE not in _VALID_MODES:
+    print(
+        f"Unsupported MODE={{_MODE!r}}. Expected one of: {{', '.join(sorted(_VALID_MODES))}}.",
+        file=sys.stderr,
+    )
+    sys.exit(64)
 
 arclith = Arclith(_CONFIG)
 app = arclith.fastapi()
+
+
+def build_mcp():
+    return arclith.fastmcp("{project_name} MCP")
 
 
 def _run_api() -> None:
     arclith.run_api("main:app")
 
 
+def _run_mcp_http() -> None:
+    arclith.run_mcp_http(build_mcp())
+
+
+def _run_mcp_sse() -> None:
+    arclith.run_mcp_sse(build_mcp())
+
+
 if __name__ == "__main__":
-    arclith.run_with_probes(_run_api, transports=["api"])
+    match _MODE:
+        case "api":
+            arclith.run_with_probes(_run_api, transports=["api"])
+        case "mcp_http":
+            arclith.run_with_probes(_run_mcp_http, transports=["mcp_http"])
+        case "mcp_sse":
+            arclith.run_with_probes(_run_mcp_sse, transports=["mcp_sse"])
+        case "all":
+            arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])
 ''',
         encoding="utf-8",
     )
+    (target_dir / "Dockerfile").write_text(render_dockerfile(), encoding="utf-8")
+    (target_dir / ".dockerignore").write_text(DOCKERIGNORE_TEMPLATE, encoding="utf-8")
+    entrypoint = target_dir / "arclith-run"
+    entrypoint.write_text(render_arclith_run(), encoding="utf-8")
+    entrypoint.chmod(0o755)
 
 
 def _write_config(target_dir: Path, project_name: str) -> None:

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -19,6 +19,7 @@ from .core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_useca
 from .export_config import export_config_cmd
 from .init_project import init_project_cmd
 from .rename import EntityNames, apply_rename
+from .runtime_templates import DOCKERIGNORE_TEMPLATE, render_arclith_run, render_dockerfile
 from .scaffold import download_and_extract
 from .updater import run_update
 
@@ -112,6 +113,7 @@ def new(
 
     with console.status("[bold]Renommage de l'entité…[/bold]"):
         apply_rename(target_dir, names, project_name=project_name, port=port)
+        _write_runtime_files(target_dir, api_port=port, mcp_port=port + 1)
 
     console.print("[green]✓[/green] Renommage terminé")
     _print_summary(target_dir, project_name, port)
@@ -142,7 +144,7 @@ def add_adapter(
             "--capability",
             help=(
                 "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, http, "
-                "command-bus, auth, tenant, license, llm, agent ou observability"
+                "command-bus, runtime, auth, tenant, license, llm, agent ou observability"
             ),
         ),
     ] = "repository",
@@ -367,6 +369,17 @@ def _parse_param_options(values: list[str] | None) -> dict[str, str]:
             raise typer.Exit(1)
         result[key] = value.strip()
     return result
+
+
+def _write_runtime_files(target_dir: Path, *, api_port: int, mcp_port: int) -> None:
+    (target_dir / "Dockerfile").write_text(
+        render_dockerfile(api_port=str(api_port), mcp_port=str(mcp_port)),
+        encoding="utf-8",
+    )
+    (target_dir / ".dockerignore").write_text(DOCKERIGNORE_TEMPLATE, encoding="utf-8")
+    entrypoint = target_dir / "arclith-run"
+    entrypoint.write_text(render_arclith_run(), encoding="utf-8")
+    entrypoint.chmod(0o755)
 
 
 def _print_summary(target_dir: Path, project_name: str, port: int) -> None:

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -82,6 +82,7 @@ def new(
     """Créer un nouveau projet [bold]arclith[/bold] scaffoldé depuis le template officiel [dim]_sample[/dim]."""
     entity = entity or _prompt_entity()
     project_name = project_name or _prompt_project()
+    _validate_runtime_ports(api_port=port, mcp_port=port + 1)
 
     names = EntityNames.from_input(entity)
     target_dir = directory.resolve() / project_name
@@ -372,6 +373,7 @@ def _parse_param_options(values: list[str] | None) -> dict[str, str]:
 
 
 def _write_runtime_files(target_dir: Path, *, api_port: int, mcp_port: int) -> None:
+    _validate_runtime_ports(api_port=api_port, mcp_port=mcp_port)
     (target_dir / "Dockerfile").write_text(
         render_dockerfile(api_port=str(api_port), mcp_port=str(mcp_port)),
         encoding="utf-8",
@@ -380,6 +382,16 @@ def _write_runtime_files(target_dir: Path, *, api_port: int, mcp_port: int) -> N
     entrypoint = target_dir / "arclith-run"
     entrypoint.write_text(render_arclith_run(), encoding="utf-8")
     entrypoint.chmod(0o755)
+
+
+def _validate_runtime_ports(*, api_port: int, mcp_port: int) -> None:
+    for label, value in (("REST", api_port), ("MCP", mcp_port)):
+        if value <= 0 or value > 65535:
+            console.print(
+                f"[red]✗[/red] Port {label} invalide: [bold]{value}[/bold]. "
+                "Utilisez une valeur entre 1 et 65535."
+            )
+            raise typer.Exit(1)
 
 
 def _print_summary(target_dir: Path, project_name: str, port: int) -> None:

--- a/cli/arclith_cli/runtime_templates.py
+++ b/cli/arclith_cli/runtime_templates.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+DEFAULT_UV_VERSION = "0.8.14"
+DEFAULT_API_PORT = "8000"
+DEFAULT_MCP_PORT = "8001"
+DEFAULT_PROBE_PORT = "9000"
+DEFAULT_AGENT_PORT = "2024"
+
+
+DOCKERFILE_TEMPLATE = """# syntax=docker/dockerfile:1.7
+# Multi-stage Arclith runtime image. Dependencies come from uv.lock only.
+FROM python:3.13-slim-bookworm AS builder
+
+ARG UV_VERSION={uv_version}
+
+ENV UV_LINK_MODE=copy \\
+    UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /app
+
+RUN python -m pip install --no-cache-dir --root-user-action=ignore "uv==$UV_VERSION"
+
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \\
+    uv sync --frozen --no-dev --no-install-project
+
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/uv \\
+    uv sync --frozen --no-dev
+
+
+FROM python:3.13-slim-bookworm AS runtime
+
+RUN groupadd --gid 1001 arclith \\
+ && useradd --uid 1001 --gid arclith --home-dir /app --shell /usr/sbin/nologin --no-create-home arclith
+
+WORKDIR /app
+
+COPY --from=builder --chown=1001:1001 /app/.venv /app/.venv
+COPY --chown=1001:1001 . .
+
+RUN chmod 0555 /app/arclith-run
+
+ENV PATH="/app/.venv/bin:$PATH" \\
+    PYTHONPATH="/app/src:/app" \\
+    PYTHONUNBUFFERED=1 \\
+    PYTHONDONTWRITEBYTECODE=1 \\
+    ARCLITH_PROBE_PORT={probe_port}
+
+USER 1001:1001
+
+# FastAPI, FastMCP, probes and LangGraph local server.
+EXPOSE {api_port} {mcp_port} {probe_port} {agent_port}
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \\
+    CMD python -c "import os, urllib.request; urllib.request.urlopen('http://127.0.0.1:' + os.getenv('ARCLITH_PROBE_PORT', '9000') + '/health', timeout=2)" || exit 1
+
+ENTRYPOINT ["./arclith-run"]
+CMD ["api"]
+"""
+
+
+DOCKERIGNORE_TEMPLATE = """.git
+.venv
+__pycache__/
+*.py[cod]
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+dist/
+*.egg-info/
+tests/
+docs/
+site/
+.env
+.env.*
+!.env.example
+secrets.yaml
+*.pem
+*.key
+*.crt
+id_rsa
+id_ed25519
+"""
+
+
+ARCLITH_RUN_TEMPLATE = """#!/usr/bin/env sh
+set -eu
+
+if [ -n "${{ARCLITH_RUNTIME_MODE:-}}" ]; then
+    mode="$ARCLITH_RUNTIME_MODE"
+    if [ "${{1:-}}" = "api" ]; then
+        shift
+    fi
+elif [ -n "${{MODE:-}}" ]; then
+    mode="$MODE"
+    if [ "${{1:-}}" = "api" ]; then
+        shift
+    fi
+elif [ "$#" -gt 0 ]; then
+    mode="$1"
+    shift
+else
+    mode="api"
+fi
+
+case "$mode" in
+    api)
+        export MODE=api
+        exec python main.py "$@"
+        ;;
+    mcp|mcp_http)
+        export MODE=mcp_http
+        exec python main.py "$@"
+        ;;
+    mcp_sse)
+        export MODE=mcp_sse
+        exec python main.py "$@"
+        ;;
+    bus|command_bus|command-bus)
+        export MODE=bus
+        exec python main.py "$@"
+        ;;
+    agent)
+        if [ -n "${{ARCLITH_AGENT_COMMAND:-}}" ]; then
+            exec sh -c "$ARCLITH_AGENT_COMMAND" -- "$@"
+        fi
+        if [ ! -f langgraph.json ]; then
+            echo "langgraph.json missing; configure agent/langgraph or set ARCLITH_AGENT_COMMAND." >&2
+            exit 64
+        fi
+        exec langgraph dev \\
+            --host "${{LANGGRAPH_HOST:-0.0.0.0}}" \\
+            --port "${{LANGGRAPH_PORT:-2024}}" \\
+            --no-browser \\
+            --allow-blocking \\
+            "$@"
+        ;;
+    all)
+        export MODE=all
+        exec python main.py "$@"
+        ;;
+    *)
+        echo "Unsupported Arclith runtime mode: $mode" >&2
+        echo "Expected: api, mcp, mcp_http, mcp_sse, bus, agent or all." >&2
+        exit 64
+        ;;
+esac
+"""
+
+
+def render_dockerfile(
+    *,
+    uv_version: str = DEFAULT_UV_VERSION,
+    api_port: str = DEFAULT_API_PORT,
+    mcp_port: str = DEFAULT_MCP_PORT,
+    probe_port: str = DEFAULT_PROBE_PORT,
+    agent_port: str = DEFAULT_AGENT_PORT,
+) -> str:
+    return DOCKERFILE_TEMPLATE.format(
+        uv_version=uv_version,
+        api_port=api_port,
+        mcp_port=mcp_port,
+        probe_port=probe_port,
+        agent_port=agent_port,
+    )
+
+
+def render_arclith_run() -> str:
+    return ARCLITH_RUN_TEMPLATE.format()

--- a/cli/arclith_cli/runtime_templates.py
+++ b/cli/arclith_cli/runtime_templates.py
@@ -45,7 +45,8 @@ ENV PATH="/app/.venv/bin:$PATH" \\
     PYTHONPATH="/app/src:/app" \\
     PYTHONUNBUFFERED=1 \\
     PYTHONDONTWRITEBYTECODE=1 \\
-    ARCLITH_PROBE_PORT={probe_port}
+    ARCLITH_PROBE_PORT={probe_port} \\
+    LANGGRAPH_PORT={agent_port}
 
 USER 1001:1001
 
@@ -91,14 +92,14 @@ set -eu
 
 if [ -n "${{ARCLITH_RUNTIME_MODE:-}}" ]; then
     mode="$ARCLITH_RUNTIME_MODE"
-    if [ "${{1:-}}" = "api" ]; then
-        shift
-    fi
+    case "${{1:-}}" in
+        api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;
+    esac
 elif [ -n "${{MODE:-}}" ]; then
     mode="$MODE"
-    if [ "${{1:-}}" = "api" ]; then
-        shift
-    fi
+    case "${{1:-}}" in
+        api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;
+    esac
 elif [ "$#" -gt 0 ]; then
     mode="$1"
     shift

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import re
 import stat
 import subprocess
@@ -1781,7 +1782,7 @@ def test_add_runtime_docker_image_generates_hardened_templates(tmp_path: Path) -
             "api_port": "8100",
             "mcp_port": "8101",
             "probe_port": "9100",
-            "agent_port": "2024",
+            "agent_port": "2025",
         },
         yes=True,
     )
@@ -1795,7 +1796,8 @@ def test_add_runtime_docker_image_generates_hardened_templates(tmp_path: Path) -
     assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
     assert "uv sync --frozen --no-dev" in dockerfile
     assert "USER 1001:1001" in dockerfile
-    assert "EXPOSE 8100 8101 9100 2024" in dockerfile
+    assert "EXPOSE 8100 8101 9100 2025" in dockerfile
+    assert "LANGGRAPH_PORT=2025" in dockerfile
     assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
     assert 'CMD ["api"]' in dockerfile
     assert "MODE=api" not in dockerfile
@@ -1805,6 +1807,7 @@ def test_add_runtime_docker_image_generates_hardened_templates(tmp_path: Path) -
     assert "secrets.yaml" in dockerignore
     assert "*.pem" in dockerignore
     assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
+    assert "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;" in entrypoint
     assert "api)" in entrypoint
     assert "mcp|mcp_http)" in entrypoint
     assert "bus|command_bus|command-bus)" in entrypoint
@@ -1826,6 +1829,66 @@ def test_add_runtime_docker_image_rejects_invalid_port(tmp_path: Path) -> None:
         )
 
     assert not (project_dir / "Dockerfile").exists()
+
+
+@pytest.mark.parametrize(
+    "uv_version",
+    [
+        "0.8.14 beta",
+        "0.8.14\nRUN echo injected",
+        "0.8.14{api_port}",
+    ],
+)
+def test_add_runtime_docker_image_rejects_unsafe_uv_version(tmp_path: Path, uv_version: str) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="runtime",
+            adapter="docker-image",
+            adapter_params={"uv_version": uv_version},
+            yes=True,
+        )
+
+    assert not (project_dir / "Dockerfile").exists()
+
+
+def test_runtime_entrypoint_drops_explicit_mode_when_env_mode_is_set(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="runtime",
+        adapter="docker-image",
+        yes=True,
+    )
+    (project_dir / "main.py").write_text(
+        "import json\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "Path('runtime.json').write_text(\n"
+        "    json.dumps({'mode': os.environ.get('MODE'), 'argv': sys.argv[1:]}),\n"
+        "    encoding='utf-8',\n"
+        ")\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["./arclith-run", "bus"],
+        cwd=project_dir,
+        env={**os.environ, "ARCLITH_RUNTIME_MODE": "mcp_http"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, f"entrypoint failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert json.loads((project_dir / "runtime.json").read_text(encoding="utf-8")) == {
+        "mode": "mcp_http",
+        "argv": [],
+    }
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import re
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -1766,6 +1768,64 @@ def test_add_chain_secrets_adapter_rejects_unknown_resolver(tmp_path: Path) -> N
         )
 
     assert not (project_dir / "config" / "secrets.yaml").exists()
+
+
+def test_add_runtime_docker_image_generates_hardened_templates(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="runtime",
+        adapter="docker-image",
+        adapter_params={
+            "api_port": "8100",
+            "mcp_port": "8101",
+            "probe_port": "9100",
+            "agent_port": "2024",
+        },
+        yes=True,
+    )
+
+    dockerfile = (project_dir / "Dockerfile").read_text(encoding="utf-8")
+    dockerignore = (project_dir / ".dockerignore").read_text(encoding="utf-8")
+    entrypoint_path = project_dir / "arclith-run"
+    entrypoint = entrypoint_path.read_text(encoding="utf-8")
+    assert "FROM python:3.13-slim-bookworm AS builder" in dockerfile
+    assert "FROM python:3.13-slim-bookworm AS runtime" in dockerfile
+    assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
+    assert "uv sync --frozen --no-dev" in dockerfile
+    assert "USER 1001:1001" in dockerfile
+    assert "EXPOSE 8100 8101 9100 2024" in dockerfile
+    assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
+    assert 'CMD ["api"]' in dockerfile
+    assert "MODE=api" not in dockerfile
+    assert re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
+    assert re.search(r"(?m)^ENV .*SECRET|^ENV .*TOKEN|^ENV .*PASSWORD", dockerfile) is None
+    assert ".env" in dockerignore
+    assert "secrets.yaml" in dockerignore
+    assert "*.pem" in dockerignore
+    assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
+    assert "api)" in entrypoint
+    assert "mcp|mcp_http)" in entrypoint
+    assert "bus|command_bus|command-bus)" in entrypoint
+    assert "agent)" in entrypoint
+    assert "all)" in entrypoint
+    assert entrypoint_path.stat().st_mode & stat.S_IXUSR
+
+
+def test_add_runtime_docker_image_rejects_invalid_port(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="runtime",
+            adapter="docker-image",
+            adapter_params={"api_port": "0"},
+            yes=True,
+        )
+
+    assert not (project_dir / "Dockerfile").exists()
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -238,6 +238,32 @@ def test_command_bus_capability_catalog_declares_rabbitmq() -> None:
     ]
 
 
+def test_runtime_capability_catalog_declares_docker_image() -> None:
+    capability = get_capability("runtime")
+
+    assert capability is not None
+    assert capability.layer == "runtime"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("docker-image",)
+    docker_image = capability.get_adapter("docker-image")
+    assert docker_image is not None
+    assert docker_image.layer == "runtime"
+    assert docker_image.config_path is None
+    assert [template.path for template in docker_image.file_templates] == [
+        "Dockerfile",
+        ".dockerignore",
+        "arclith-run",
+    ]
+    assert docker_image.entity_scoped is False
+    assert [parameter.name for parameter in docker_image.parameters] == [
+        "uv_version",
+        "api_port",
+        "mcp_port",
+        "probe_port",
+        "agent_port",
+    ]
+
+
 def test_auth_capability_catalog_declares_keycloak() -> None:
     capability = get_capability("auth")
 
@@ -430,6 +456,8 @@ def test_capability_catalog_is_json_serializable() -> None:
     assert "cache-control" in encoded
     assert "command-bus" in encoded
     assert "rabbitmq" in encoded
+    assert "runtime" in encoded
+    assert "docker-image" in encoded
     assert "auth" in encoded
     assert "keycloak" in encoded
     assert "tenant" in encoded
@@ -571,6 +599,22 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "retry_requeue",
         "dead_letter_exchange",
         "dead_letter_routing_key",
+    ]
+    runtime = payload_by_name["runtime"]
+    assert runtime["layer"] == "runtime"
+    assert [adapter["name"] for adapter in runtime["adapters"]] == ["docker-image"]
+    docker_image = runtime["adapters"][0]
+    assert [template["path"] for template in docker_image["file_templates"]] == [
+        "Dockerfile",
+        ".dockerignore",
+        "arclith-run",
+    ]
+    assert [parameter["name"] for parameter in docker_image["parameters"]] == [
+        "uv_version",
+        "api_port",
+        "mcp_port",
+        "probe_port",
+        "agent_port",
     ]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -243,6 +243,7 @@ def test_runtime_capability_catalog_declares_docker_image() -> None:
 
     assert capability is not None
     assert capability.layer == "runtime"
+    assert capability.description == "Runtime de déploiement standardisé pour images et processus Arclith."
     assert capability.activation_config_key is None
     assert capability.adapter_names() == ("docker-image",)
     docker_image = capability.get_adapter("docker-image")

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -1,3 +1,5 @@
+import re
+import stat
 from pathlib import Path
 
 import pytest
@@ -41,6 +43,9 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert generated == tmp_path / "todo-list-service"
     assert (generated / "pyproject.toml").exists()
     assert (generated / "main.py").exists()
+    assert (generated / "Dockerfile").exists()
+    assert (generated / ".dockerignore").exists()
+    assert (generated / "arclith-run").exists()
     assert (generated / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8") == (
         "logger: console\n"
         "repository: memory\n"
@@ -55,6 +60,30 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert (package_root / "adapters" / "inbound" / "__init__.py").exists()
     assert (package_root / "infrastructure" / "containers" / "__init__.py").exists()
     assert sorted(path.name for path in (package_root / "domain" / "models").glob("*.py")) == ["__init__.py"]
+
+    dockerfile = (generated / "Dockerfile").read_text(encoding="utf-8")
+    dockerignore = (generated / ".dockerignore").read_text(encoding="utf-8")
+    main = (generated / "main.py").read_text(encoding="utf-8")
+    arclith_run = generated / "arclith-run"
+    entrypoint = arclith_run.read_text(encoding="utf-8")
+    assert "FROM python:3.13-slim-bookworm AS builder" in dockerfile
+    assert "FROM python:3.13-slim-bookworm AS runtime" in dockerfile
+    assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
+    assert "uv sync --frozen --no-dev" in dockerfile
+    assert "USER 1001:1001" in dockerfile
+    assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
+    assert 'CMD ["api"]' in dockerfile
+    assert "MODE=api" not in dockerfile
+    assert re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
+    assert ".env" in dockerignore
+    assert "secrets.yaml" in dockerignore
+    assert "id_rsa" in dockerignore
+    assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
+    assert "bus|command_bus|command-bus)" in entrypoint
+    assert "langgraph dev" in entrypoint
+    assert '_VALID_MODES = {"api", "mcp_http", "mcp_sse", "all"}' in main
+    assert 'arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])' in main
+    assert arclith_run.stat().st_mode & stat.S_IXUSR
 
 
 def test_init_project_refuses_existing_directory(tmp_path: Path) -> None:

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -74,11 +74,13 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
     assert 'CMD ["api"]' in dockerfile
     assert "MODE=api" not in dockerfile
+    assert "LANGGRAPH_PORT=2024" in dockerfile
     assert re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
     assert ".env" in dockerignore
     assert "secrets.yaml" in dockerignore
     assert "id_rsa" in dockerignore
     assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
+    assert "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;" in entrypoint
     assert "bus|command_bus|command-bus)" in entrypoint
     assert "langgraph dev" in entrypoint
     assert '_VALID_MODES = {"api", "mcp_http", "mcp_sse", "all"}' in main

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
@@ -113,7 +114,7 @@ def test_scaffold_and_run(temp_workspace: Path):
             "--dir",
             str(temp_workspace),
             "--port",
-            "9000",
+            "8100",
             *_template_args(),
         ],
         capture_output=True,
@@ -182,9 +183,15 @@ def test_scaffold_and_run(temp_workspace: Path):
     for dirname in expected_dirs:
         assert (project_dir / dirname).is_dir(), f"Missing expected directory: {dirname}"
     
-    expected_files = ["Dockerfile", "Makefile"]
+    expected_files = ["Dockerfile", "Makefile", ".dockerignore", "arclith-run"]
     for fname in expected_files:
         assert (project_dir / fname).exists(), f"Missing expected file: {fname}"
+    dockerfile = (project_dir / "Dockerfile").read_text(encoding="utf-8")
+    assert "uv sync --frozen --no-dev --no-install-project" in dockerfile
+    assert "USER 1001:1001" in dockerfile
+    assert "EXPOSE 8100 8101 9000 2024" in dockerfile
+    assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
+    assert (project_dir / "arclith-run").stat().st_mode & stat.S_IXUSR
 
     # Step 6 — validate core scaffolding through the CLI entry point
     result = subprocess.run(

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -100,6 +100,30 @@ def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Pat
     ).exists()
 
 
+def test_new_rejects_port_without_room_for_mcp(temp_workspace: Path):
+    project_dir = temp_workspace / "bad-port-service"
+
+    result = subprocess.run(
+        [
+            "arclith-cli",
+            "new",
+            "Plan",
+            "bad-port-service",
+            "--dir",
+            str(temp_workspace),
+            "--port",
+            "65535",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+    assert not project_dir.exists()
+    assert "Port MCP invalide" in result.stdout + result.stderr
+
+
 def test_scaffold_and_run(temp_workspace: Path):
     """Test that scaffolded project installs and runs successfully."""
     project_dir = temp_workspace / "test-plan-service"

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -636,6 +636,41 @@ uv add "arclith[rabbitmq]"
 
 Voir aussi la référence dédiée [Command Bus](command-bus.md).
 
+### `runtime`
+
+Capacité de déploiement pour générer une image Docker Arclith multi-stage, non-root et
+multi-transport.
+
+Adapter disponible:
+
+- `docker-image`: génère `Dockerfile`, `.dockerignore` et `arclith-run`.
+
+```bash
+arclith-cli add-adapter \
+  --capability runtime \
+  --adapter docker-image \
+  --param api_port=8000 \
+  --param mcp_port=8001 \
+  --param probe_port=9000 \
+  --param agent_port=2024 \
+  --yes
+```
+
+Contrat runtime:
+
+- `api`: démarre `MODE=api python main.py`;
+- `mcp` ou `mcp_http`: démarre `MODE=mcp_http python main.py`;
+- `mcp_sse`: démarre `MODE=mcp_sse python main.py`;
+- `bus`: démarre `MODE=bus python main.py`;
+- `agent`: démarre `langgraph dev` via `langgraph.json`, ou `ARCLITH_AGENT_COMMAND` si défini;
+- `all`: démarre `MODE=all python main.py`.
+
+Le Dockerfile utilise `uv sync --frozen` et nécessite donc un `uv.lock` à jour. Aucun secret n'est
+accepté au build: `.env`, `secrets.yaml` et les clés privées sont exclus par `.dockerignore`. Les
+secrets doivent venir de l'environnement runtime, Docker secrets, Vault ou fichiers montés.
+
+Voir aussi la référence dédiée [Runtime Docker](runtime-docker.md).
+
 ### `mcp`
 
 Capacité inbound pour exposer les cas d'usage via MCP.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -278,6 +278,37 @@ contourner les use cases.
 
 ---
 
+## ADR-013 — Image Docker runtime unique et non-root
+
+**Date :** 2026-08-09
+
+**Contexte :** Les projets Arclith peuvent exposer les mêmes cas d'usage via API FastAPI, MCP,
+worker RabbitMQ ou agent LangGraph. Générer une image par transport pousserait à rebuilder pour un
+simple choix de runtime et augmenterait le risque d'images divergentes.
+
+**Décision :** déclarer une capability `runtime` avec l'adapter `docker-image`. Le Dockerfile généré
+est multi-stage, Python 3.13, installe les dépendances avec `uv sync --frozen`, puis exécute l'image
+finale sous l'utilisateur non-root `1001:1001`. Le choix du transport passe par l'entrypoint
+`arclith-run`, via un argument, `ARCLITH_RUNTIME_MODE` ou `MODE`.
+
+**Pourquoi pas l'alternative évidente (un Dockerfile par transport) :**
+API, MCP, bus et agent partagent le même code applicatif et la même config Arclith. Des images
+séparées multiplieraient les locks, les scans et les chemins de déploiement sans isoler davantage la
+logique métier. Un entrypoint runtime garde le rebuild réservé aux changements de code ou de
+dépendances.
+
+**Conséquence sur le code :**
+
+- `arclith-cli init` génère `Dockerfile`, `.dockerignore` et `arclith-run`.
+- `arclith-cli add-adapter --capability runtime --adapter docker-image` régénère ces fichiers dans
+  un projet existant.
+- Les secrets ne sont jamais fournis par `ARG`/`ENV` de build; ils restent dans l'environnement
+  runtime, Docker secrets, Vault ou fichiers montés.
+- Le mode `agent` reste configurable avec `ARCLITH_AGENT_COMMAND` pour ne pas figer un serveur
+  LangGraph unique.
+
+---
+
 **Contexte :** Exposer les services via le Model Context Protocol.
 
 **Décision :** `fastmcp>=3.1.0` avec trois transports : stdio, SSE, streamable-HTTP.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -310,7 +310,32 @@ LangGraph, LangSmith et LLM local LM Studio, suivre:
 
 - [Quickstart agent Arclith from scratch](agent-quickstart.md)
 
-## 6. Valider avant commit
+## 6. Construire l'image runtime
+
+Les projets créés avec `arclith-cli init` incluent un Dockerfile runtime. Pour un projet existant:
+
+```bash
+arclith-cli add-adapter --capability runtime --adapter docker-image --yes
+uv lock
+docker build -t pantry-agent:local .
+```
+
+La même image démarre les transports par argument:
+
+```bash
+docker run --rm -p 8100:8100 -p 9000:9000 pantry-agent:local api
+docker run --rm -p 8101:8101 -p 9000:9000 pantry-agent:local mcp_http
+docker run --rm --env ARCLITH_RUNTIME_MODE=all -p 8100:8100 -p 8101:8101 -p 9000:9000 pantry-agent:local
+```
+
+Pour `bus`, ajouter d'abord `command-bus/rabbitmq` et implémenter le runner `MODE=bus` dans
+`main.py`. Pour `agent`, ajouter `agent/langgraph`; `arclith-run agent` utilise `langgraph.json` ou
+`ARCLITH_AGENT_COMMAND`.
+
+Les secrets restent hors image: utiliser l'environnement runtime, Docker secrets, Vault ou fichiers
+montés. Le `.dockerignore` généré exclut `.env`, `secrets.yaml` et les clés privées.
+
+## 7. Valider avant commit
 
 ```bash
 make quality
@@ -343,5 +368,6 @@ make demo-smoke
 - Sample fonctionnel: `../_sample`
 - CLI: `cli/README.md`
 - Capacités standardisées: `docs/capabilities.md`
+- Runtime Docker: `docs/runtime-docker.md`
 - Architecture: `arclith/docs/architecture.md`
 - Decisions: `docs/decisions.md`

--- a/docs/runtime-docker.md
+++ b/docs/runtime-docker.md
@@ -1,0 +1,167 @@
+# Runtime Docker Arclith
+
+## Objectif
+
+`runtime/docker-image` standardise une image Docker Arclith unique pour plusieurs transports. Le
+choix du processus se fait au runtime par argument d'entrypoint, `ARCLITH_RUNTIME_MODE` ou `MODE`;
+il ne nécessite pas de rebuild.
+
+```text
+docker image
+  -> arclith-run
+  -> MODE=api | mcp_http | mcp_sse | bus | agent | all
+  -> main.py ou LangGraph
+```
+
+Le framework ne génère pas de logique métier. Le projet reste responsable des runners déclarés dans
+`main.py`, des handlers RabbitMQ et du graphe LangGraph.
+
+## Génération
+
+Les projets créés par `arclith-cli init` incluent déjà `Dockerfile`, `.dockerignore` et
+`arclith-run`. Pour ajouter ou régénérer ces fichiers dans un projet existant:
+
+```bash
+arclith-cli add-adapter \
+  --capability runtime \
+  --adapter docker-image \
+  --param api_port=8000 \
+  --param mcp_port=8001 \
+  --param probe_port=9000 \
+  --param agent_port=2024 \
+  --yes
+```
+
+Fichiers générés:
+
+```text
+Dockerfile
+.dockerignore
+arclith-run
+```
+
+## Build Déterministe
+
+Le Dockerfile est multi-stage:
+
+- `builder`: installe `uv`, lit `pyproject.toml` et `uv.lock`, puis exécute `uv sync --frozen`.
+- `runtime`: repart d'une image Python 3.13 slim, copie uniquement l'environnement virtuel et le
+  contexte filtré par `.dockerignore`, puis lance sous l'utilisateur non-root `1001:1001`.
+
+Avant de construire l'image, verrouiller les dépendances:
+
+```bash
+uv lock
+docker build -t my-service:local .
+```
+
+Les dépendances optionnelles sont gouvernées par le `pyproject.toml` du projet. Pour une image qui
+doit lancer un worker RabbitMQ ou un agent LangGraph, ajouter les extras correspondants avant le
+lock:
+
+```bash
+uv add "arclith[rabbitmq]"
+uv add "arclith[langgraph]"
+uv lock
+```
+
+## Modes Runtime
+
+L'entrypoint accepte un argument explicite:
+
+```bash
+docker run --rm -p 8000:8000 -p 9000:9000 my-service:local api
+docker run --rm -p 8001:8001 -p 9000:9000 my-service:local mcp_http
+docker run --rm --env MODE=all -p 8000:8000 -p 8001:8001 -p 9000:9000 my-service:local
+docker run --rm --env ARCLITH_RUNTIME_MODE=bus my-service:local
+docker run --rm -p 2024:2024 my-service:local agent
+```
+
+Contrat des modes:
+
+| Mode | Action |
+|---|---|
+| `api` | `MODE=api python main.py` |
+| `mcp` / `mcp_http` | `MODE=mcp_http python main.py` |
+| `mcp_sse` | `MODE=mcp_sse python main.py` |
+| `bus` / `command_bus` / `command-bus` | `MODE=bus python main.py` |
+| `agent` | `langgraph dev` ou `ARCLITH_AGENT_COMMAND` |
+| `all` | `MODE=all python main.py` |
+
+`api` est le `CMD` par défaut. Les modes `bus`, `mcp_*` et `all` supposent que `main.py` les
+implémente. Le mode `agent` utilise `langgraph.json`; si le projet a besoin d'un serveur agent
+différent, définir `ARCLITH_AGENT_COMMAND`.
+
+## Probes Et Healthcheck
+
+Le Dockerfile expose par défaut:
+
+- `8000`: FastAPI.
+- `8001`: FastMCP.
+- `9000`: probes Arclith.
+- `2024`: LangGraph local server.
+
+Le `HEALTHCHECK` interroge `/health` sur `ARCLITH_PROBE_PORT`, `9000` par défaut:
+
+```bash
+docker run --rm -p 8000:8000 -p 9000:9000 my-service:local api
+curl -fsS http://127.0.0.1:9000/health
+```
+
+## Secrets
+
+Aucun secret ne doit être fourni au build. Ne pas utiliser `ARG` ou `ENV` pour des tokens,
+mots de passe ou clés privées dans le Dockerfile. Fournir les secrets au runtime:
+
+- variables d'environnement injectées par l'orchestrateur;
+- Docker secrets montés en fichiers;
+- Vault ou adapter `secrets/chain`;
+- fichiers montés hors image, jamais copiés dans les layers.
+
+Le `.dockerignore` généré exclut notamment `.env`, `secrets.yaml`, les clés privées, `.venv`,
+les caches et les artefacts de couverture.
+
+## Compose Et Kubernetes
+
+En Compose, préférer l'argument d'entrypoint et `depends_on.condition: service_healthy` pour les
+dépendances locales:
+
+```yaml
+services:
+  api:
+    image: my-service:local
+    command: ["api"]
+    ports:
+      - "8000:8000"
+      - "9000:9000"
+
+  worker:
+    image: my-service:local
+    command: ["bus"]
+    environment:
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+```
+
+En Kubernetes, garder la même image et changer seulement `args`:
+
+```yaml
+containers:
+  - name: api
+    image: my-service:local
+    args: ["api"]
+```
+
+## Validation Locale
+
+Le smoke Docker ne pousse aucune image:
+
+```bash
+uv lock
+docker build -t my-service:local .
+docker run --rm -d --name my-service-smoke -p 8000:8000 -p 9000:9000 my-service:local api
+curl -fsS http://127.0.0.1:9000/health
+docker rm -f my-service-smoke
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Auth: auth.md
       - HTTP: http-conventions.md
       - Command Bus: command-bus.md
+      - Runtime Docker: runtime-docker.md
       - Idempotence: idempotency.md
       - Multitenant: multitenant.md
       - Cache: caching.md


### PR DESCRIPTION
## Summary
- add a first-class runtime/docker-image capability that generates a multi-stage Python 3.13 Dockerfile, .dockerignore and arclith-run entrypoint
- include the runtime files in arclith-cli init/new scaffolds with non-root UID/GID 1001 and runtime mode selection for API, MCP, bus, agent and all
- document the Docker runtime contract, secrets policy and local validation flow

Closes #84

## References
- Docker multi-stage builds: https://docs.docker.com/build/building/multi-stage/
- Docker build secrets guidance: https://docs.docker.com/build/building/secrets/
- Docker Compose startup order: https://docs.docker.com/compose/how-tos/startup-order/

## Validation
- uv run pytest tests/test_core_scaffold.py tests/test_capabilities.py tests/test_add_adapter.py tests/test_e2e_scaffold.py::test_scaffold_and_run -q
- uv run pytest tests -q (from cli/)
- uv run ruff check arclith_cli tests (from cli/)
- make docs
- make quality
- uv run arclith-cli init issue84-runtime-smoke --dir /tmp/arclith-issue84-smoke.HjpB6Y
- uv lock (generated smoke project)
- docker build -t arclith-issue84-runtime-smoke:local .
- docker run smoke: /health returned {"status":"ok"}; container UID/GID verified as 1001:1001