### PR TITLE
docs: refresh project entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,87 @@
 # Arclith
 
-Python 3.13 framework for building microservices with Hexagonal Architecture and Clean Architecture.
+Arclith est un framework Python 3.13 pour construire des microservices en architecture
+hexagonale. Il fournit un socle applicatif orienté domaine: entités, ports, use cases,
+configuration, adapters, probes, FastAPI, FastMCP, LangGraph, observabilité et runtime Docker.
 
-Arclith provides reusable domain models, use cases, repositories, adapters, FastAPI/FastMCP/LangGraph bootstrap, configuration, probes, and service wiring.
+Le dépôt contient aussi `arclith-cli`, la CLI qui génère les fichiers projet sans court-circuiter le
+cœur métier. L'objectif est de garder une trajectoire unique: domaine et use cases d'abord, puis
+API, MCP, agent, bus, persistance et runtime.
 
-## Canonical Service Layout
+## Liens Essentiels
 
-Arclith applications should use a namespaced `src/<package>/...` layout. This keeps imports explicit, avoids top-level package collisions, and matches how the project is built and tested.
+- Documentation publiée: [GitHub Pages](https://karned-rekipe.github.io/arclith/)
+- Tutoriel de formation: [Todo List walkthrough](https://karned-rekipe.github.io/arclith/tutorials/todo-list/)
+- Quickstart framework: [docs/quickstart.md](docs/quickstart.md)
+- Quickstart agent: [docs/agent-quickstart.md](docs/agent-quickstart.md)
+- Référence des capacités CLI: [docs/capabilities.md](docs/capabilities.md)
+- Runtime Docker: [docs/runtime-docker.md](docs/runtime-docker.md)
+- Repository: [karned-rekipe/arclith](https://github.com/karned-rekipe/arclith)
+- Sample fonctionnel: [karned-rekipe/_sample](https://github.com/karned-rekipe/_sample)
+- Backlog: [GitHub Project](https://github.com/orgs/karned-rekipe/projects/5)
+- Issues: [GitHub Issues](https://github.com/karned-rekipe/arclith/issues)
+- Releases: [GitHub Releases](https://github.com/karned-rekipe/arclith/releases)
+- Packages: [arclith](https://pypi.org/project/arclith/) et
+  [arclith-cli](https://pypi.org/project/arclith-cli/) sur PyPI
+
+## Quickstart Minimal API Et MCP
+
+Créer un projet minimal avec la CLI publiée:
+
+```bash
+uvx --from arclith-cli arclith-cli init pantry-service --dir .
+cd pantry-service
+uv sync
+uv run pytest
+```
+
+Lancer l'API FastAPI et les probes dans un premier terminal:
+
+```bash
+MODE=api uv run python main.py
+```
+
+Vérifier les probes depuis un second terminal:
+
+```bash
+curl -fsS http://127.0.0.1:9000/health
+```
+
+Arrêter l'API avec `Ctrl+C`, puis lancer le serveur MCP HTTP:
+
+```bash
+MODE=mcp_http uv run python main.py
+```
+
+Poser ensuite le cœur métier minimal:
+
+```bash
+uvx --from arclith-cli arclith-cli add-entity ShoppingItem
+uvx --from arclith-cli arclith-cli add-usecase PlanShoppingList
+uvx --from arclith-cli arclith-cli add-intent-interpreter ShoppingIntent
+```
+
+Ce quickstart vérifie le socle. Pour construire une vraie fonctionnalité API + MCP + agent pas à
+pas, suivre le [parcours Todo](https://karned-rekipe.github.io/arclith/tutorials/todo-list/).
+
+## Parcours De Formation
+
+Le parcours recommandé pour un nouveau venu est:
+
+1. Lire la [vue d'ensemble Pages](https://karned-rekipe.github.io/arclith/).
+2. Exécuter le [Quickstart Arclith](https://karned-rekipe.github.io/arclith/quickstart/).
+3. Suivre le [Tutoriel Todo](https://karned-rekipe.github.io/arclith/tutorials/todo-list/) dans
+   l'ordre: entité, ports/use cases, API, MCP, agent, services locaux.
+4. Lire la [référence des capacités](https://karned-rekipe.github.io/arclith/capabilities/) pour
+   ajouter les adapters nécessaires via `arclith-cli`.
+5. Lire les références spécialisées quand le besoin apparaît: [auth](docs/auth.md),
+   [HTTP](docs/http-conventions.md), [command bus](docs/command-bus.md),
+   [runtime Docker](docs/runtime-docker.md), [cache](docs/caching.md) et
+   [décisions d'architecture](docs/decisions.md).
+
+## Layout Canonique
+
+Les applications Arclith utilisent un layout `src/<package>/...`:
 
 ```text
 src/my_service/
@@ -19,7 +94,7 @@ tests/
 main.py
 ```
 
-The current convention is exposed by the framework:
+La convention est exposée par le framework:
 
 ```python
 from arclith import canonical_project_layout
@@ -28,79 +103,40 @@ layout = canonical_project_layout("my_service")
 print(layout.domain)  # src/my_service/domain
 ```
 
-## Project Links
-
-- Repository: [karned-rekipe/arclith](https://github.com/karned-rekipe/arclith)
-- Functional sample: [karned-rekipe/_sample](https://github.com/karned-rekipe/_sample)
-- GitHub Project: [Arclith backlog](https://github.com/orgs/karned-rekipe/projects/5)
-- Issues: [Arclith issues](https://github.com/karned-rekipe/arclith/issues)
-- PyPI: [arclith](https://pypi.org/project/arclith/)
-- PyPI CLI: [arclith-cli](https://pypi.org/project/arclith-cli/)
-
-## Installation
+## Dépendances Optionnelles
 
 ```bash
-pip install arclith
-```
-
-## Quickstart
-
-Pour créer un projet concret avec la CLI, lancer API/MCP/probes, puis faire évoluer les adapters :
-
-- [Quickstart Arclith](docs/quickstart.md)
-- [Quickstart agent Arclith from scratch](docs/agent-quickstart.md)
-- [Capacités standardisées](docs/capabilities.md)
-- [CLI](cli/README.md)
-- [Release PyPI](docs/release.md)
-- [Sample fonctionnel](https://github.com/karned-rekipe/_sample)
-
-Pour poser uniquement le cœur métier minimal après création d'un projet :
-
-```bash
-arclith-cli init todo-list-service
-cd todo-list-service
-arclith-cli add-entity ShoppingItem
-arclith-cli add-usecase PlanShoppingList
-```
-
-Ces commandes ne génèrent pas de CRUD ni de wiring adapter par défaut.
-
-### Optional dependencies
-
-```bash
-pip install "arclith[mongodb]"
-pip install "arclith[duckdb]"
-pip install "arclith[mariadb]"
-pip install "arclith[fastapi]"
-pip install "arclith[mcp]"
-pip install "arclith[langgraph]"
-pip install "arclith[opentelemetry]"
-pip install "arclith[all]"
-```
-
-Pour ajouter LangGraph, LangSmith et OpenTelemetry à un projet généré:
-
-```bash
+uv add "arclith[mongodb]"
+uv add "arclith[duckdb]"
+uv add "arclith[mariadb]"
+uv add "arclith[rabbitmq]"
 uv add "arclith[langgraph]"
 uv add "arclith[opentelemetry]"
-arclith-cli add-adapter --capability agent --adapter langgraph
-arclith-cli add-adapter --capability observability --adapter langsmith
-arclith-cli add-adapter --capability observability --adapter opentelemetry
-uv run langgraph dev --no-browser --allow-blocking --port 2024
+uv add "arclith[all]"
 ```
 
-Arclith génère `langgraph.json`, le point d'entrée LangGraph et le câblage `Arclith.langgraph(...)`.
-Le code spécifique du projet reste dans `src/<package>/adapters/inbound/langgraph/agent.py`.
-LangSmith et OpenTelemetry sont ajoutés dans `observability.enabled` et peuvent être actifs en
-parallèle.
+Chaque adapter doit être ajouté via `arclith-cli add-adapter`; voir la
+[référence des capacités](docs/capabilities.md).
 
-## Development
+## Documentation, Pages Et Wiki
+
+La documentation canonique est versionnée dans `docs/` et publiée sur
+[GitHub Pages](https://karned-rekipe.github.io/arclith/). C'est la bonne source pour une référence
+durable et pour le parcours de formation.
+
+Le Wiki GitHub peut rester utile pour des notes temporaires ou des brouillons non versionnés, mais
+il ne doit pas devenir la référence principale: il n'est pas relu par les mêmes PR, checks MkDocs et
+validations que `docs/`.
+
+## Développement
 
 ```bash
 uv sync
-uv run pytest
+make precommit
+make coverage
+make docs
 ```
 
-## License
+## Licence
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Apache 2.0 — voir [LICENSE](LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,22 @@
 # Arclith
 
 Arclith est un framework Python 3.13 pour construire des microservices en architecture hexagonale.
+Il sert de socle commun pour structurer les projets autour du domaine, des ports, des use cases et
+des adapters.
 
-Le chemin recommandé pour découvrir le projet est le tutoriel Todo:
+## Liens Rapides
+
+- [Repository GitHub](https://github.com/karned-rekipe/arclith)
+- [Sample fonctionnel](https://github.com/karned-rekipe/_sample)
+- [Backlog GitHub Project](https://github.com/orgs/karned-rekipe/projects/5)
+- [Issues](https://github.com/karned-rekipe/arclith/issues)
+- [PyPI arclith](https://pypi.org/project/arclith/)
+- [PyPI arclith-cli](https://pypi.org/project/arclith-cli/)
+
+## Parcours Initiatique
+
+Le chemin recommandé pour découvrir le projet est le tutoriel Todo. Il joue le rôle de formation
+guidée pour les nouveaux venus:
 
 - [Vue d'ensemble](tutorials/todo-list/index.md)
 - [Initialiser le projet](tutorials/todo-list/01-init-project.md)
@@ -11,9 +25,17 @@ Le chemin recommandé pour découvrir le projet est le tutoriel Todo:
 - [Exposer une API](tutorials/todo-list/04-api.md)
 - [Exposer un MCP](tutorials/todo-list/05-mcp.md)
 - [Ajouter un agent](tutorials/todo-list/06-agent.md)
+- [Brancher les services locaux](tutorials/todo-list/07-local-services.md)
 
-Les quickstarts existants restent disponibles:
+## Démarrer Vite
 
 - [Quickstart Arclith](quickstart.md)
 - [Quickstart Agent](agent-quickstart.md)
 - [Capacités standardisées](capabilities.md)
+- [Runtime Docker](runtime-docker.md)
+
+## Référence
+
+La référence maintenue est cette documentation Pages, versionnée dans le dépôt et validée par
+MkDocs. Le Wiki GitHub peut servir de brouillon, mais les décisions et guides durables doivent être
+rapatriés dans `docs/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,6 @@ nav:
       - Cache: caching.md
       - Décisions: decisions.md
       - Release: release.md
-      - OAuth2 Troubleshooting: oauth2-troubleshooting.md
 
 validation:
   nav:


### PR DESCRIPTION
## Summary
- remove the empty OAuth2 troubleshooting page from the MkDocs navigation and repository
- refresh the README as a concise project entrypoint with essential links, a minimal API/MCP quickstart, Docker reference, and onboarding path
- expand the GitHub Pages landing page with quick links, the Todo training path, and documentation/Wiki positioning

## Validation
- git diff --check
- make docs
