### PR TITLE
docs: expand Docker runtime tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ API, MCP, agent, bus, persistance et runtime.
 - Quickstart framework: [docs/quickstart.md](docs/quickstart.md)
 - Quickstart agent: [docs/agent-quickstart.md](docs/agent-quickstart.md)
 - Référence des capacités CLI: [docs/capabilities.md](docs/capabilities.md)
-- Runtime Docker: [docs/runtime-docker.md](docs/runtime-docker.md)
+- Tutoriel Docker: [docs/runtime-docker.md](docs/runtime-docker.md)
 - Repository: [karned-rekipe/arclith](https://github.com/karned-rekipe/arclith)
 - Sample fonctionnel: [karned-rekipe/_sample](https://github.com/karned-rekipe/_sample)
 - Backlog: [GitHub Project](https://github.com/orgs/karned-rekipe/projects/5)
@@ -76,7 +76,7 @@ Le parcours recommandé pour un nouveau venu est:
    ajouter les adapters nécessaires via `arclith-cli`.
 5. Lire les références spécialisées quand le besoin apparaît: [auth](docs/auth.md),
    [HTTP](docs/http-conventions.md), [command bus](docs/command-bus.md),
-   [runtime Docker](docs/runtime-docker.md), [cache](docs/caching.md) et
+   [tutoriel Docker](docs/runtime-docker.md), [cache](docs/caching.md) et
    [décisions d'architecture](docs/decisions.md).
 
 ## Layout Canonique

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -669,7 +669,7 @@ Le Dockerfile utilise `uv sync --frozen` et nécessite donc un `uv.lock` à jour
 accepté au build: `.env`, `secrets.yaml` et les clés privées sont exclus par `.dockerignore`. Les
 secrets doivent venir de l'environnement runtime, Docker secrets, Vault ou fichiers montés.
 
-Voir aussi la référence dédiée [Runtime Docker](runtime-docker.md).
+Voir aussi le tutoriel dédié [Docker](runtime-docker.md).
 
 ### `mcp`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ guidée pour les nouveaux venus:
 - [Quickstart Arclith](quickstart.md)
 - [Quickstart Agent](agent-quickstart.md)
 - [Capacités standardisées](capabilities.md)
-- [Runtime Docker](runtime-docker.md)
+- [Tutoriel Docker complet](runtime-docker.md)
 
 ## Référence
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -368,6 +368,6 @@ make demo-smoke
 - Sample fonctionnel: `../_sample`
 - CLI: `cli/README.md`
 - Capacités standardisées: `docs/capabilities.md`
-- Runtime Docker: `docs/runtime-docker.md`
+- Tutoriel Docker: `docs/runtime-docker.md`
 - Architecture: `arclith/docs/architecture.md`
 - Decisions: `docs/decisions.md`

--- a/docs/runtime-docker.md
+++ b/docs/runtime-docker.md
@@ -5,8 +5,8 @@ comment lancer cette même image en local, avec Docker Compose et avec Kubernete
 
 L'idée directrice est simple: une seule image immutable, plusieurs processus au runtime. L'image
 contient le code, les dépendances verrouillées et l'entrypoint `arclith-run`. Le choix du transport
-se fait par argument (`api`, `mcp_http`, `agent`, `bus`, `all`) ou par variable
-`ARCLITH_RUNTIME_MODE`.
+se fait par argument (`api`, `mcp_http`, `mcp_sse`, `agent`, `bus`, `all`) ou par variable
+`ARCLITH_RUNTIME_MODE` / `MODE`.
 
 ```text
 image Docker Arclith

--- a/docs/runtime-docker.md
+++ b/docs/runtime-docker.md
@@ -1,107 +1,38 @@
-# Runtime Docker Arclith
+# Tutoriel Docker Arclith
 
-## Objectif
+Ce parcours explique comment passer d'un projet Arclith local à une image Docker exploitable, puis
+comment lancer cette même image en local, avec Docker Compose et avec Kubernetes.
 
-`runtime/docker-image` standardise une image Docker Arclith unique pour plusieurs transports. Le
-choix du processus se fait au runtime par argument d'entrypoint, `ARCLITH_RUNTIME_MODE` ou `MODE`;
-il ne nécessite pas de rebuild.
+L'idée directrice est simple: une seule image immutable, plusieurs processus au runtime. L'image
+contient le code, les dépendances verrouillées et l'entrypoint `arclith-run`. Le choix du transport
+se fait par argument (`api`, `mcp_http`, `agent`, `bus`, `all`) ou par variable
+`ARCLITH_RUNTIME_MODE`.
 
 ```text
-docker image
+image Docker Arclith
   -> arclith-run
-  -> MODE=api | mcp_http | mcp_sse | bus | agent | all
+  -> api | mcp_http | mcp_sse | agent | bus | all
   -> main.py ou LangGraph
 ```
 
-Le framework ne génère pas de logique métier. Le projet reste responsable des runners déclarés dans
-`main.py`, des handlers RabbitMQ et du graphe LangGraph.
+## Parcours
 
-## Génération
+1. [Build](runtime-docker/build.md): générer les fichiers runtime, préparer la configuration
+   conteneur, construire et inspecter l'image.
+2. [Lancement local API](runtime-docker/local-api.md): lancer FastAPI en conteneur, exposer
+   `/openapi.json` et valider les probes.
+3. [Lancement local MCP](runtime-docker/local-mcp.md): lancer FastMCP en `streamable-http` et
+   vérifier l'accès client.
+4. [Lancement local agent](runtime-docker/local-agent.md): lancer le runtime LangGraph/agent et
+   gérer les variables LLM hors image.
+5. [Lancement local autres possibilités](runtime-docker/local-other-modes.md): modes `all`,
+   `mcp_sse`, `bus` et overrides runtime.
+6. [Docker Compose](runtime-docker/docker-compose.md): orchestrer API, MCP, agent, worker et
+   dépendances locales.
+7. [Kubernetes](runtime-docker/kubernetes.md): déployer l'image en workloads séparés, avec probes,
+   secrets, ressources et sécurité.
 
-Les projets créés par `arclith-cli init` incluent déjà `Dockerfile`, `.dockerignore` et
-`arclith-run`. Pour ajouter ou régénérer ces fichiers dans un projet existant:
-
-```bash
-arclith-cli add-adapter \
-  --capability runtime \
-  --adapter docker-image \
-  --param api_port=8000 \
-  --param mcp_port=8001 \
-  --param probe_port=9000 \
-  --param agent_port=2024 \
-  --yes
-```
-
-Fichiers générés:
-
-```text
-Dockerfile
-.dockerignore
-arclith-run
-```
-
-## Build Déterministe
-
-Le Dockerfile est multi-stage:
-
-- `builder`: installe `uv`, lit `pyproject.toml` et `uv.lock`, puis exécute `uv sync --frozen`.
-- `runtime`: repart d'une image Python 3.13 slim, copie uniquement l'environnement virtuel et le
-  contexte filtré par `.dockerignore`, puis lance sous l'utilisateur non-root `1001:1001`.
-
-Avant de construire l'image, verrouiller les dépendances:
-
-```bash
-uv lock
-docker build -t my-service:local .
-```
-
-Les dépendances optionnelles sont gouvernées par le `pyproject.toml` du projet. Pour une image qui
-doit lancer un worker RabbitMQ ou un agent LangGraph, ajouter les extras correspondants avant le
-lock:
-
-```bash
-uv add "arclith[rabbitmq]"
-uv add "arclith[langgraph]"
-uv lock
-```
-
-## Modes Runtime
-
-L'entrypoint accepte un argument explicite:
-
-```bash
-docker run --rm -p 8000:8000 -p 9000:9000 my-service:local api
-docker run --rm -p 8001:8001 -p 9000:9000 my-service:local mcp_http
-docker run --rm --env MODE=all -p 8000:8000 -p 8001:8001 -p 9000:9000 my-service:local
-docker run --rm --env ARCLITH_RUNTIME_MODE=bus my-service:local
-docker run --rm -p 2024:2024 my-service:local agent
-```
-
-Les ports à droite de `-p` sont les ports écoutés dans le conteneur. Ils doivent correspondre aux
-fichiers de configuration du projet, par exemple `config/adapters/inbound/fastapi.yaml` pour
-FastAPI et `config/adapters/inbound/probe.yaml` pour les probes. Les ports à gauche sont les ports
-exposés sur le poste.
-
-Par exemple, si FastAPI est configuré sur `8120`, publier l'API sur le même port:
-
-```bash
-docker run --rm -p 8120:8120 -p 9000:9000 my-service:local api
-curl -fsS http://127.0.0.1:8120/openapi.json
-curl -fsS http://127.0.0.1:9000/health
-```
-
-Ou garder `8000` côté poste en le routant vers `8120` dans le conteneur:
-
-```bash
-docker run --rm -p 8000:8120 -p 9000:9000 my-service:local api
-curl -fsS http://127.0.0.1:8000/openapi.json
-curl -fsS http://127.0.0.1:9000/health
-```
-
-Sans `-d`, `docker run` garde le terminal attaché au serveur. Lancer les `curl` depuis un second
-terminal, ou utiliser le smoke détaché plus bas.
-
-Contrat des modes:
+## Contrat Runtime
 
 | Mode | Action |
 |---|---|
@@ -112,155 +43,29 @@ Contrat des modes:
 | `agent` | `langgraph dev` ou `ARCLITH_AGENT_COMMAND` |
 | `all` | `MODE=all python main.py` |
 
-`api` est le `CMD` par défaut. Les modes `bus`, `mcp_*` et `all` supposent que `main.py` les
-implémente. Le mode `agent` utilise `langgraph.json`; si le projet a besoin d'un serveur agent
-différent, définir `ARCLITH_AGENT_COMMAND`.
+Les modes `bus`, `agent` et `all` supposent que le projet a bien les adapters, runners et
+dépendances nécessaires. Arclith fournit le socle runtime; le projet garde la responsabilité de son
+métier, de ses handlers et de son graphe.
 
-## Probes Et Healthcheck
+## Principes SOTA
 
-Le Dockerfile expose par défaut:
+- Construire depuis un `uv.lock` à jour avec `uv sync --frozen`.
+- Ne jamais injecter de secrets au build; utiliser l'environnement runtime, Docker secrets,
+  Kubernetes Secret ou Vault.
+- Garder un processus principal par conteneur en production. Réutiliser la même image avec des
+  arguments différents plutôt que créer plusieurs images.
+- Exposer les services conteneur sur `0.0.0.0`; réserver `127.0.0.1` aux lancements hors Docker.
+- Valider `/health`, `/ready` et le endpoint métier exposé par le transport, pas seulement le fait
+  que le conteneur soit `running`.
+- Taguer les images avec une version immutable et, en déploiement, préférer un digest ou un tag de
+  release à `latest`.
+- Faire sortir logs et métriques sur les canaux standards: stdout/stderr, probes Arclith,
+  OpenTelemetry si activé.
 
-- `8000`: FastAPI.
-- `8001`: FastMCP.
-- `9000`: probes Arclith.
-- `2024`: LangGraph local server.
+## Références Officielles
 
-Le `HEALTHCHECK` interroge `/health` sur `ARCLITH_PROBE_PORT`, `9000` par défaut:
-
-```bash
-(
-  set -eu
-
-  API_CONTAINER_PORT="${API_CONTAINER_PORT:-8000}"
-  API_HOST_PORT="${API_HOST_PORT:-$API_CONTAINER_PORT}"
-  PROBE_CONTAINER_PORT="${PROBE_CONTAINER_PORT:-9000}"
-  PROBE_HOST_PORT="${PROBE_HOST_PORT:-$PROBE_CONTAINER_PORT}"
-
-  container_id="$(
-    docker run --rm -d \
-      -p "$API_HOST_PORT:$API_CONTAINER_PORT" \
-      -p "$PROBE_HOST_PORT:$PROBE_CONTAINER_PORT" \
-      my-service:local api
-  )"
-  cleanup() {
-    docker stop "$container_id" >/dev/null 2>&1 || true
-  }
-  trap cleanup EXIT
-
-  # Le HEALTHCHECK Docker utilise /health; /openapi.json est un smoke API additionnel.
-  for endpoint in "$PROBE_HOST_PORT/health" "$API_HOST_PORT/openapi.json"; do
-    ready=0
-    for _ in $(seq 1 30); do
-      if curl -fsS "http://127.0.0.1:$endpoint" >/dev/null 2>&1; then
-        ready=1
-        break
-      fi
-      sleep 1
-    done
-
-    if [ "$ready" -ne 1 ]; then
-      docker logs "$container_id"
-      exit 1
-    fi
-  done
-
-  curl -fsS "http://127.0.0.1:$PROBE_HOST_PORT/health"
-  curl -fsS "http://127.0.0.1:$API_HOST_PORT/openapi.json" >/dev/null
-)
-```
-
-## Secrets
-
-Aucun secret ne doit être fourni au build. Ne pas utiliser `ARG` ou `ENV` pour des tokens,
-mots de passe ou clés privées dans le Dockerfile. Fournir les secrets au runtime:
-
-- variables d'environnement injectées par l'orchestrateur;
-- Docker secrets montés en fichiers;
-- Vault ou adapter `secrets/chain`;
-- fichiers montés hors image, jamais copiés dans les layers.
-
-Le `.dockerignore` généré exclut notamment `.env`, `secrets.yaml`, les clés privées, `.venv`,
-les caches et les artefacts de couverture.
-
-## Compose Et Kubernetes
-
-En Compose, préférer l'argument d'entrypoint et `depends_on.condition: service_healthy` pour les
-dépendances locales:
-
-```yaml
-services:
-  api:
-    image: my-service:local
-    command: ["api"]
-    ports:
-      - "8000:8000"
-      - "9000:9000"
-
-  worker:
-    image: my-service:local
-    command: ["bus"]
-    environment:
-      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
-    depends_on:
-      rabbitmq:
-        condition: service_healthy
-```
-
-En Kubernetes, garder la même image et changer seulement `args`:
-
-```yaml
-containers:
-  - name: api
-    image: my-service:local
-    args: ["api"]
-```
-
-## Validation Locale
-
-Le smoke Docker ne pousse aucune image. Il attend explicitement que les probes et l'API soient
-disponibles, car `docker run -d` rend la main avant que les serveurs Uvicorn aient terminé leur
-démarrage:
-
-```bash
-(
-  set -eu
-
-  API_CONTAINER_PORT="${API_CONTAINER_PORT:-8000}"
-  API_HOST_PORT="${API_HOST_PORT:-$API_CONTAINER_PORT}"
-  PROBE_CONTAINER_PORT="${PROBE_CONTAINER_PORT:-9000}"
-  PROBE_HOST_PORT="${PROBE_HOST_PORT:-$PROBE_CONTAINER_PORT}"
-
-  uv lock
-  docker build -t my-service:local .
-
-  container_id="$(
-    docker run --rm -d \
-      -p "$API_HOST_PORT:$API_CONTAINER_PORT" \
-      -p "$PROBE_HOST_PORT:$PROBE_CONTAINER_PORT" \
-      my-service:local api
-  )"
-  cleanup() {
-    docker stop "$container_id" >/dev/null 2>&1 || true
-  }
-  trap cleanup EXIT
-
-  for endpoint in "$PROBE_HOST_PORT/health" "$API_HOST_PORT/openapi.json"; do
-    ready=0
-    for _ in $(seq 1 30); do
-      if curl -fsS "http://127.0.0.1:$endpoint" >/dev/null 2>&1; then
-        ready=1
-        break
-      fi
-      sleep 1
-    done
-
-    if [ "$ready" -ne 1 ]; then
-      docker logs "$container_id"
-      exit 1
-    fi
-  done
-
-  curl -fsS "http://127.0.0.1:$PROBE_HOST_PORT/health"
-  curl -fsS "http://127.0.0.1:$API_HOST_PORT/openapi.json" >/dev/null
-)
-```
+- [Docker build best practices](https://docs.docker.com/build/building/best-practices/)
+- [Docker build secrets](https://docs.docker.com/build/building/secrets/)
+- [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
+- [Kubernetes security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)

--- a/docs/runtime-docker/build.md
+++ b/docs/runtime-docker/build.md
@@ -1,0 +1,140 @@
+# Docker Build
+
+Objectif: produire une image Docker Arclith déterministe, minimale et réutilisable pour tous les
+transports du service.
+
+## Prérequis
+
+- Docker Desktop ou un moteur Docker compatible BuildKit.
+- Python 3.13 et `uv` côté poste.
+- Un projet Arclith avec `pyproject.toml`, `uv.lock`, `main.py`, `config/` et `src/`.
+
+Pour créer un projet de test:
+
+```bash
+uvx --from arclith-cli arclith-cli init my-service --dir .
+cd my-service
+uv sync
+uv run pytest
+```
+
+## Générer Le Runtime Docker
+
+Les projets créés par `arclith-cli init` incluent déjà:
+
+```text
+Dockerfile
+.dockerignore
+arclith-run
+```
+
+Pour ajouter ou régénérer ces fichiers dans un projet existant:
+
+```bash
+arclith-cli add-adapter \
+  --capability runtime \
+  --adapter docker-image \
+  --param api_port=8000 \
+  --param mcp_port=8001 \
+  --param probe_port=9000 \
+  --param agent_port=2024 \
+  --yes
+```
+
+Le Dockerfile généré suit ce contrat:
+
+- build multi-stage à partir de `python:3.13-slim-bookworm`;
+- installation des dépendances par `uv sync --frozen`;
+- copie de `.venv` depuis le stage builder;
+- exécution non-root en `1001:1001`;
+- exclusion de `.env`, `secrets.yaml`, clés privées, tests, docs et caches via `.dockerignore`;
+- `HEALTHCHECK` sur `/health` du serveur de probes.
+
+## Préparer La Configuration Conteneur
+
+Dans un conteneur, un service publié doit écouter sur `0.0.0.0`. `127.0.0.1` signifie "loopback
+du conteneur" et n'est pas accessible via `docker run -p`.
+
+Créer ou vérifier les fichiers suivants avant le build:
+
+```bash
+arclith-cli add-adapter \
+  --capability api \
+  --adapter fastapi \
+  --param host=0.0.0.0 \
+  --param port=8000 \
+  --param reload=false \
+  --yes
+
+arclith-cli add-adapter \
+  --capability mcp \
+  --adapter fastmcp \
+  --param host=0.0.0.0 \
+  --param port=8001 \
+  --yes
+```
+
+Le reload FastAPI doit rester désactivé dans une image runtime. Le rechargement automatique est un
+outil de développement local, pas un comportement de conteneur.
+
+## Verrouiller Et Construire
+
+```bash
+uv lock
+docker build -t my-service:local .
+```
+
+Pour préparer une publication registry, utiliser un tag explicite:
+
+```bash
+VERSION=0.1.0
+IMAGE=ghcr.io/karned-rekipe/my-service:$VERSION
+
+docker build -t "$IMAGE" .
+docker image inspect "$IMAGE" --format '{{.Id}} {{.Config.User}}'
+```
+
+Le résultat attendu doit montrer un utilisateur non-root, par exemple `1001:1001`.
+
+## Inspection Locale
+
+Vérifier que l'image ne contient pas les fichiers à risque:
+
+```bash
+docker run --rm --entrypoint sh my-service:local -lc 'id && test ! -f .env && test ! -f secrets.yaml'
+docker history my-service:local
+```
+
+Inspecter les ports exposés:
+
+```bash
+docker image inspect my-service:local \
+  --format '{{json .Config.ExposedPorts}}'
+```
+
+## Publication
+
+Publier seulement après validation locale:
+
+```bash
+docker push "$IMAGE"
+```
+
+En production, préférer ensuite le digest:
+
+```bash
+docker image inspect "$IMAGE" --format '{{index .RepoDigests 0}}'
+```
+
+## Checklist SOTA
+
+- `uv.lock` commité et synchronisé avec `pyproject.toml`.
+- Aucune clé, aucun token et aucun fichier `.env` dans le contexte final.
+- Image lancée en non-root.
+- Ports conteneur alignés avec `config/adapters/inbound/*.yaml`.
+- Tag immutable ou digest pour les déploiements.
+- Build reproductible en CI avec les mêmes commandes que localement.
+- Couches ordonnées pour préserver le cache: dépendances avant code applicatif, contexte réduit par
+  `.dockerignore`.
+
+Page suivante: [lancer l'API localement](local-api.md).

--- a/docs/runtime-docker/docker-compose.md
+++ b/docs/runtime-docker/docker-compose.md
@@ -1,0 +1,169 @@
+# Lancement Via Docker Compose
+
+Objectif: orchestrer plusieurs transports Arclith et leurs dépendances locales avec une seule image.
+
+Compose est adapté au développement intégré, aux démonstrations et aux environnements single-node.
+Pour la production scalable, passer à Kubernetes ou à un orchestrateur équivalent.
+
+## Fichier Compose Minimal
+
+```yaml
+x-arclith-service: &arclith-service
+  image: my-service:local
+  build: .
+
+services:
+  api:
+    <<: *arclith-service
+    command: ["api"]
+    ports:
+      - "8000:8000"
+      - "9000:9000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/health', timeout=2)"
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 15s
+
+  mcp:
+    <<: *arclith-service
+    command: ["mcp_http"]
+    ports:
+      - "8001:8001"
+      - "9001:9000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/health', timeout=2)"
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 15s
+```
+
+Lancer:
+
+```bash
+docker compose up --build
+```
+
+Vérifier depuis le poste:
+
+```bash
+curl -fsS http://127.0.0.1:9000/health
+curl -fsS http://127.0.0.1:9001/health
+```
+
+## Ajouter MongoDB Et RabbitMQ
+
+```yaml
+x-arclith-service: &arclith-service
+  image: my-service:local
+  build: .
+
+services:
+  api:
+    <<: *arclith-service
+    command: ["api"]
+    environment:
+      MONGODB_URI: mongodb://mongo:27017/
+    depends_on:
+      mongo:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+      - "9000:9000"
+
+  worker:
+    <<: *arclith-service
+    command: ["bus"]
+    environment:
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
+      MONGODB_URI: mongodb://mongo:27017/
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+
+  mongo:
+    image: mongo:8
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  rabbitmq:
+    image: rabbitmq:4-management
+    ports:
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  mongo-data:
+```
+
+## Réseaux Et Exposition
+
+Par défaut, Compose crée un réseau privé par projet. Exposer sur le host uniquement les transports
+utiles à l'humain ou au client externe:
+
+- API: `8000`;
+- MCP: `8001`;
+- probes API/MCP: `9000`, `9001`;
+- RabbitMQ management local: `15672`, seulement si nécessaire.
+
+Les dépendances internes utilisent les noms de services: `mongo`, `rabbitmq`, `api`, `mcp`.
+
+## Secrets
+
+Pour un usage local, un fichier `.env.local` non commité est acceptable:
+
+```yaml
+services:
+  api:
+    env_file:
+      - .env.local
+```
+
+Pour un usage plus proche production, préférer des secrets Compose montés en fichiers et un adapter
+de secrets Arclith capable de les lire.
+
+```yaml
+services:
+  api:
+    secrets:
+      - mongodb-uri
+
+secrets:
+  mongodb-uri:
+    file: ./secrets/mongodb-uri.txt
+```
+
+Compose monte les secrets dans `/run/secrets/<nom>`. Le projet doit ensuite lire ce fichier via son
+resolver de secrets, plutôt que supposer une variable d'environnement en clair.
+
+## Checklist SOTA
+
+- `depends_on.condition: service_healthy` pour les dépendances critiques.
+- Données persistantes dans des volumes nommés.
+- Probes par service, pas seulement sur l'API.
+- Ports host limités au strict nécessaire.
+- Même image pour API, MCP, agent et worker; seul `command` change.
+- Secrets hors image et hors dépôt.
+
+Page suivante: [Kubernetes](kubernetes.md).

--- a/docs/runtime-docker/kubernetes.md
+++ b/docs/runtime-docker/kubernetes.md
@@ -1,0 +1,217 @@
+# Lancement Via Kubernetes
+
+Objectif: déployer l'image Arclith en workloads Kubernetes séparés, chacun avec un transport clair,
+des probes, des ressources et un contexte de sécurité.
+
+## Principe
+
+Ne pas lancer tous les transports dans un seul Pod de production. Utiliser la même image immutable,
+mais créer un workload par responsabilité:
+
+- `Deployment/api`: FastAPI;
+- `Deployment/mcp`: FastMCP HTTP;
+- `Deployment/agent`: LangGraph/Agent Server;
+- `Deployment/worker`: command-bus RabbitMQ;
+- `Job` ou `CronJob`: tâches ponctuelles si nécessaire.
+
+## Image
+
+Publier une image versionnée:
+
+```bash
+IMAGE=ghcr.io/karned-rekipe/my-service:0.1.0
+docker build -t "$IMAGE" .
+docker push "$IMAGE"
+```
+
+En production, pin un digest si la plateforme le permet:
+
+```text
+ghcr.io/karned-rekipe/my-service@sha256:<digest>
+```
+
+## Config Et Secrets
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-service-config
+data:
+  APP_ENV: production
+  ARCLITH_PROBE_PORT: "9000"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-secrets
+type: Opaque
+stringData:
+  MONGODB_URI: mongodb://mongo:27017/my-service
+  LANGSMITH_API_KEY: change-me
+```
+
+En vrai déploiement, générer les `Secret` depuis le gestionnaire de secrets de la plateforme, pas
+depuis un manifeste commité en clair.
+
+## Deployment API
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-service
+      transport: api
+  template:
+    metadata:
+      labels:
+        app: my-service
+        transport: api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: ghcr.io/karned-rekipe/my-service:0.1.0
+          args: ["api"]
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: probes
+              containerPort: 9000
+          envFrom:
+            - configMapRef:
+                name: my-service-config
+            - secretRef:
+                name: my-service-secrets
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: probes
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+            periodSeconds: 20
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+```
+
+Service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service-api
+spec:
+  selector:
+    app: my-service
+    transport: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+```
+
+## MCP, Agent Et Worker
+
+MCP réutilise l'image avec un autre argument:
+
+```yaml
+containers:
+  - name: mcp
+    image: ghcr.io/karned-rekipe/my-service:0.1.0
+    args: ["mcp_http"]
+    ports:
+      - name: mcp
+        containerPort: 8001
+      - name: probes
+        containerPort: 9000
+```
+
+Agent:
+
+```yaml
+containers:
+  - name: agent
+    image: ghcr.io/karned-rekipe/my-service:0.1.0
+    args: ["agent"]
+    env:
+      - name: LANGGRAPH_HOST
+        value: "0.0.0.0"
+      - name: LANGGRAPH_PORT
+        value: "2024"
+    ports:
+      - name: agent
+        containerPort: 2024
+    readinessProbe:
+      tcpSocket:
+        port: agent
+```
+
+Worker RabbitMQ:
+
+```yaml
+containers:
+  - name: worker
+    image: ghcr.io/karned-rekipe/my-service:0.1.0
+    args: ["bus"]
+    envFrom:
+      - secretRef:
+          name: my-service-secrets
+```
+
+## Déploiement
+
+```bash
+kubectl apply -f k8s/
+kubectl rollout status deployment/my-service-api
+kubectl get pods -l app=my-service
+kubectl logs deployment/my-service-api
+```
+
+## Checklist SOTA
+
+- Image immutable, idéalement pin par digest.
+- Un workload par transport.
+- `readinessProbe` et `livenessProbe` sur les probes Arclith quand disponibles.
+- `resources.requests` et `resources.limits` définis.
+- `runAsNonRoot`, `allowPrivilegeEscalation: false`, capabilities droppées.
+- `seccompProfile: RuntimeDefault` pour rester aligné avec le profil de sécurité restreint.
+- Secrets injectés par la plateforme, jamais committés.
+- Logs collectés depuis stdout/stderr et traces exportées via OpenTelemetry si activé.
+- Rollout vérifié avec `kubectl rollout status` et smoke applicatif après déploiement.
+
+Retour: [vue d'ensemble Docker](../runtime-docker.md).

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -1,0 +1,109 @@
+# Lancement Local Agent
+
+Objectif: lancer le runtime agent/LangGraph depuis la même image Docker, sans intégrer de clés LLM
+dans l'image.
+
+## Prérequis Projet
+
+Le mode `agent` nécessite:
+
+- l'extra LangGraph dans le projet;
+- un adapter `agent/langgraph`;
+- un `langgraph.json`;
+- les variables LLM et LangSmith injectées au runtime.
+
+Préparer le projet:
+
+```bash
+uv add "arclith[langgraph]"
+
+arclith-cli add-adapter \
+  --capability agent \
+  --adapter langgraph \
+  --param graph_name=my_agent \
+  --yes
+```
+
+Si le projet utilise LM Studio ou un endpoint OpenAI-compatible lancé sur le poste, ne pas utiliser
+`localhost` depuis le conteneur. Sur Docker Desktop, utiliser souvent:
+
+```text
+http://host.docker.internal:1234/v1
+```
+
+## Build
+
+```bash
+uv lock
+docker build -t my-service:local .
+```
+
+## Lancer L'Agent
+
+```bash
+docker run --rm \
+  --env-file .env.local \
+  -e LANGGRAPH_HOST=0.0.0.0 \
+  -e LANGGRAPH_PORT=2024 \
+  -p 2024:2024 \
+  my-service:local agent
+```
+
+`arclith-run agent` lance `langgraph dev` par défaut avec `--host 0.0.0.0`. Si le projet a besoin
+d'une commande agent différente, utiliser `ARCLITH_AGENT_COMMAND`:
+
+```bash
+docker run --rm \
+  --env-file .env.local \
+  -e ARCLITH_AGENT_COMMAND='langgraph dev --host 0.0.0.0 --port 2024 --no-browser --allow-blocking' \
+  -p 2024:2024 \
+  my-service:local agent
+```
+
+## Vérifier
+
+Ouvrir LangSmith Studio ou le client agent sur:
+
+```text
+http://127.0.0.1:2024
+```
+
+Pour une validation complète, déclencher un run avec un `thread_id` durable et vérifier que le graphe
+appelle bien les ports/use cases du projet. Le conteneur qui expose l'agent ne doit pas écrire en
+base directement depuis le LLM.
+
+## Secrets
+
+Ne jamais écrire ces valeurs dans le Dockerfile:
+
+```text
+OPENAI_API_KEY
+ANTHROPIC_API_KEY
+LANGSMITH_API_KEY
+MONGODB_URI
+VAULT_TOKEN
+```
+
+Utiliser un fichier local non commité:
+
+```bash
+cp .env.example .env.local
+chmod 0600 .env.local
+```
+
+Puis injecter:
+
+```bash
+docker run --rm --env-file .env.local my-service:local agent
+```
+
+## Checklist SOTA
+
+- LLM comme adapter outbound, jamais comme accès direct à la persistance.
+- Variables LLM injectées au runtime uniquement.
+- `host.docker.internal` utilisé quand le modèle tourne sur le poste hôte.
+- Traces LangSmith/OpenTelemetry activées par configuration, pas par code métier.
+- En production, remplacer `langgraph dev` par la commande serveur validée du projet via
+  `ARCLITH_AGENT_COMMAND` si nécessaire.
+
+Page suivante: [autres modes locaux](local-other-modes.md).

--- a/docs/runtime-docker/local-api.md
+++ b/docs/runtime-docker/local-api.md
@@ -1,0 +1,135 @@
+# Lancement Local API
+
+Objectif: lancer FastAPI depuis l'image Docker et valider le chemin complet `host -> conteneur ->
+Arclith -> probes`.
+
+## Configuration
+
+FastAPI et les probes doivent écouter sur `0.0.0.0` dans le conteneur:
+
+```yaml
+# config/adapters/inbound/fastapi.yaml
+host: 0.0.0.0
+port: 8000
+reload: false
+```
+
+```yaml
+# config/adapters/inbound/probe.yaml
+host: 0.0.0.0
+port: 9000
+enabled: true
+```
+
+Reconstruire l'image après toute modification de configuration embarquée:
+
+```bash
+uv lock
+docker build -t my-service:local .
+```
+
+## Lancer En Mode Attaché
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -p 9000:9000 \
+  my-service:local api
+```
+
+Dans un second terminal:
+
+```bash
+curl -fsS http://127.0.0.1:9000/health
+curl -fsS http://127.0.0.1:9000/ready
+curl -fsS http://127.0.0.1:9000/info
+curl -fsS http://127.0.0.1:8000/openapi.json >/dev/null
+```
+
+## Smoke Détaché
+
+Utiliser ce smoke pour éviter la course au démarrage: `docker run -d` rend la main avant que
+Uvicorn soit forcément prêt.
+
+```bash
+(
+  set -eu
+
+  API_CONTAINER_PORT="${API_CONTAINER_PORT:-8000}"
+  API_HOST_PORT="${API_HOST_PORT:-$API_CONTAINER_PORT}"
+  PROBE_CONTAINER_PORT="${PROBE_CONTAINER_PORT:-9000}"
+  PROBE_HOST_PORT="${PROBE_HOST_PORT:-$PROBE_CONTAINER_PORT}"
+
+  container_id="$(
+    docker run --rm -d \
+      -p "$API_HOST_PORT:$API_CONTAINER_PORT" \
+      -p "$PROBE_HOST_PORT:$PROBE_CONTAINER_PORT" \
+      my-service:local api
+  )"
+  cleanup() {
+    docker stop "$container_id" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  for endpoint in "$PROBE_HOST_PORT/health" "$API_HOST_PORT/openapi.json"; do
+    ready=0
+    for _ in $(seq 1 30); do
+      if curl -fsS "http://127.0.0.1:$endpoint" >/dev/null 2>&1; then
+        ready=1
+        break
+      fi
+      sleep 1
+    done
+
+    if [ "$ready" -ne 1 ]; then
+      docker logs "$container_id"
+      exit 1
+    fi
+  done
+
+  curl -fsS "http://127.0.0.1:$PROBE_HOST_PORT/health"
+)
+```
+
+## Mapping De Ports
+
+La partie droite de `-p host:container` doit correspondre au port configuré dans le conteneur.
+
+Si FastAPI écoute dans le conteneur sur `8120`:
+
+```bash
+docker run --rm -p 8120:8120 -p 9000:9000 my-service:local api
+curl -fsS http://127.0.0.1:8120/openapi.json >/dev/null
+```
+
+Pour publier ce même service sur le port host `8000`:
+
+```bash
+docker run --rm -p 8000:8120 -p 9000:9000 my-service:local api
+curl -fsS http://127.0.0.1:8000/openapi.json >/dev/null
+```
+
+## Durcissement Local
+
+Une fois le smoke fonctionnel, tester le mode durci:
+
+```bash
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  -p 8000:8000 \
+  -p 9000:9000 \
+  my-service:local api
+```
+
+## Checklist SOTA
+
+- API et probes exposées séparément.
+- `/health` valide le processus, `/ready` valide les dépendances.
+- `reload: false` dans l'image.
+- Logs sur stdout/stderr, pas de fichier de log local.
+- Ports host et conteneur explicitement documentés.
+
+Page suivante: [lancer le MCP localement](local-mcp.md).

--- a/docs/runtime-docker/local-mcp.md
+++ b/docs/runtime-docker/local-mcp.md
@@ -1,0 +1,102 @@
+# Lancement Local MCP
+
+Objectif: exposer les tools MCP du projet via FastMCP `streamable-http` depuis l'image Docker.
+
+## Configuration
+
+FastMCP doit écouter sur `0.0.0.0` dans le conteneur:
+
+```yaml
+# config/adapters/inbound/fastmcp.yaml
+host: 0.0.0.0
+port: 8001
+```
+
+Créer la configuration si elle n'existe pas:
+
+```bash
+arclith-cli add-adapter \
+  --capability mcp \
+  --adapter fastmcp \
+  --param host=0.0.0.0 \
+  --param port=8001 \
+  --yes
+```
+
+Reconstruire après modification:
+
+```bash
+uv lock
+docker build -t my-service:local .
+```
+
+## Lancer Le Serveur MCP
+
+```bash
+docker run --rm \
+  -p 8001:8001 \
+  -p 9000:9000 \
+  my-service:local mcp_http
+```
+
+Le endpoint FastMCP HTTP est exposé sur:
+
+```text
+http://127.0.0.1:8001/mcp
+```
+
+Les probes restent indépendantes:
+
+```bash
+curl -fsS http://127.0.0.1:9000/health
+curl -fsS http://127.0.0.1:9000/info
+```
+
+## Smoke Client MCP
+
+Depuis le projet local, utiliser le client FastMCP pour vérifier le protocole, pas seulement le port:
+
+```bash
+uv run python - <<'PY'
+import asyncio
+
+from fastmcp import Client
+
+
+async def main() -> None:
+    async with Client("http://127.0.0.1:8001/mcp") as client:
+        tools = await client.list_tools()
+        print([tool.name for tool in tools])
+
+
+asyncio.run(main())
+PY
+```
+
+Un projet minimal peut renvoyer une liste vide. Un projet métier doit exposer les tools attendus.
+
+## Probes Sur Port Séparé
+
+Si l'API tourne déjà sur le host avec les probes en `9000`, publier les probes MCP sur un autre port
+host:
+
+```bash
+docker run --rm \
+  -p 8001:8001 \
+  -p 9001:9000 \
+  my-service:local mcp_http
+
+curl -fsS http://127.0.0.1:9001/health
+```
+
+Le port conteneur des probes reste `9000`; seul le port host change.
+
+## Checklist SOTA
+
+- FastMCP écoute sur `0.0.0.0` dans Docker.
+- La validation utilise un client MCP réel.
+- Les tools MCP appellent des ports/use cases, jamais des repositories concrets.
+- Les headers d'auth et de tenant sont testés via le transport HTTP si l'auth est activée.
+- Les probes restent exposées séparément pour diagnostiquer le runtime MCP.
+
+Page suivante: [lancer l'agent localement](local-agent.md).

--- a/docs/runtime-docker/local-other-modes.md
+++ b/docs/runtime-docker/local-other-modes.md
@@ -1,0 +1,104 @@
+# Lancement Local Autres Possibilités
+
+Objectif: comprendre les autres modes runtime fournis par `arclith-run` et savoir quand les utiliser.
+
+## Sélection Du Mode
+
+Trois formes sont acceptées:
+
+```bash
+docker run --rm my-service:local api
+docker run --rm -e ARCLITH_RUNTIME_MODE=mcp_http my-service:local
+docker run --rm -e MODE=all my-service:local
+```
+
+Priorité:
+
+1. `ARCLITH_RUNTIME_MODE`;
+2. `MODE`;
+3. premier argument de `docker run`;
+4. `api` par défaut.
+
+## Mode `all`
+
+`all` lance l'API et le MCP HTTP dans le même conteneur si le `main.py` du projet le supporte.
+C'est pratique pour une démonstration locale, mais il vaut mieux séparer les processus en production.
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -p 8001:8001 \
+  -p 9000:9000 \
+  my-service:local all
+```
+
+Vérifier:
+
+```bash
+curl -fsS http://127.0.0.1:8000/openapi.json >/dev/null
+curl -fsS http://127.0.0.1:9000/info
+```
+
+## Mode `mcp_sse`
+
+Utiliser `mcp_sse` seulement si un client a besoin du transport SSE:
+
+```bash
+docker run --rm \
+  -p 8001:8001 \
+  -p 9000:9000 \
+  my-service:local mcp_sse
+```
+
+Le transport recommandé pour les nouveaux clients reste `mcp_http` / streamable HTTP.
+
+## Mode `bus`
+
+`bus` lance un worker command-bus, typiquement RabbitMQ. Il faut d'abord ajouter l'adapter et écrire
+le dispatcher/handler projet.
+
+```bash
+uv add "arclith[rabbitmq]"
+
+arclith-cli add-adapter \
+  --capability command-bus \
+  --adapter rabbitmq \
+  --param url=amqp://guest:guest@rabbitmq:5672/ \
+  --param queue=arclith.commands \
+  --param routing_key=commands \
+  --yes
+```
+
+Lancer avec une URL RabbitMQ disponible depuis le conteneur:
+
+```bash
+docker run --rm \
+  -e RABBITMQ_URL=amqp://guest:guest@host.docker.internal:5672/ \
+  my-service:local bus
+```
+
+Le worker doit ack après succès métier, nack sans requeue sur erreur non récupérable, borner
+`prefetch` et propager `correlation_id` / `traceparent`.
+
+## Runtime Durci
+
+Pour les modes non interactifs, tester aussi:
+
+```bash
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --cap-drop=ALL \
+  --security-opt no-new-privileges \
+  my-service:local bus
+```
+
+## Checklist SOTA
+
+- `all` réservé au local ou à une démo.
+- Production: un Deployment/processus par transport.
+- Worker bus idempotent, borné et observable.
+- URLs de dépendances configurées pour le réseau conteneur, pas pour le poste local.
+- Arrêt propre: un processus principal, signaux Docker/Kubernetes propagés au runtime.
+
+Page suivante: [Docker Compose](docker-compose.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,15 @@ nav:
       - Quickstart Arclith: quickstart.md
       - Quickstart Agent: agent-quickstart.md
       - Capacités: capabilities.md
+  - Tutoriel Docker:
+      - Vue d'ensemble: runtime-docker.md
+      - 1. Build: runtime-docker/build.md
+      - 2. Lancement local API: runtime-docker/local-api.md
+      - 3. Lancement local MCP: runtime-docker/local-mcp.md
+      - 4. Lancement local agent: runtime-docker/local-agent.md
+      - 5. Autres modes locaux: runtime-docker/local-other-modes.md
+      - 6. Docker Compose: runtime-docker/docker-compose.md
+      - 7. Kubernetes: runtime-docker/kubernetes.md
   - Tutoriel Todo:
       - Vue d'ensemble: tutorials/todo-list/index.md
       - Préparer LM Studio: tutorials/todo-list/00-lm-studio.md
@@ -59,7 +68,6 @@ nav:
       - Auth: auth.md
       - HTTP: http-conventions.md
       - Command Bus: command-bus.md
-      - Runtime Docker: runtime-docker.md
       - Idempotence: idempotency.md
       - Multitenant: multitenant.md
       - Cache: caching.md


### PR DESCRIPTION
## Summary
- split the Docker runtime documentation into a complete tutorial path from build to deployment
- add one page per step: build, local API, local MCP, local agent, other local modes, Docker Compose, Kubernetes
- promote the Docker tutorial in MkDocs navigation, README, quickstart, index and capabilities docs
- document SOTA practices: immutable image, non-root runtime, no build secrets, probe validation, one process per container in production, Compose health dependencies, Kubernetes probes, resources and security context

## Validation
- git diff --check
- make docs
- generated a temporary Arclith service, configured API and MCP for Docker, built arclith-runtime-tutorial:local
- Docker API smoke returned {"status":"ok"} on /health
- Docker MCP smoke connected with FastMCP Client and list_tools returned [] on the minimal project
