### PR TITLE
docs: add quickstarts learning path

### DIFF
--- a/docs/quickstarts/agent.md
+++ b/docs/quickstarts/agent.md
@@ -10,6 +10,14 @@ Ajouter un agent LangGraph minimal à un service.
 
 ## Étapes
 
+Si tu n'as pas encore de projet :
+
+```bash
+uvx --from arclith-cli arclith-cli init todo-agent --dir .
+cd todo-agent
+uv sync
+```
+
 ```bash
 uv add "arclith[langgraph]"
 uvx --from arclith-cli arclith-cli add-adapter \
@@ -49,4 +57,4 @@ transitions pour appeler ses use cases.
 
 ## Suite
 
-Lire [agent/langgraph](../capabilities/agent.md).
+Lire [agent/langgraph](../capabilities/agent.md), puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).

--- a/docs/quickstarts/api.md
+++ b/docs/quickstarts/api.md
@@ -40,4 +40,4 @@ Si `/health` ne répond pas, le serveur n'est pas encore prêt ou le port `9000`
 
 ## Suite
 
-Lire [api/fastapi](../capabilities/api.md).
+Lire [MCP](mcp.md), puis [api/fastapi](../capabilities/api.md).

--- a/docs/quickstarts/bus.md
+++ b/docs/quickstarts/bus.md
@@ -10,6 +10,14 @@ Ajouter la capability RabbitMQ et vérifier le bootstrap bus.
 
 ## Étapes
 
+Si tu n'as pas encore de projet :
+
+```bash
+uvx --from arclith-cli arclith-cli init todo-bus --dir .
+cd todo-bus
+uv sync
+```
+
 ```bash
 docker run --rm -d --name arclith-rabbitmq \
   -p 5672:5672 -p 15672:15672 \
@@ -61,4 +69,4 @@ docker rm -f arclith-rabbitmq
 
 ## Suite
 
-Lire [command-bus/rabbitmq](../capabilities/command-bus.md).
+Lire [Agent](agent.md), puis [command-bus/rabbitmq](../capabilities/command-bus.md).

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -1,0 +1,34 @@
+# Quickstarts
+
+Ces pages servent à vérifier les flux les plus fréquents en quelques minutes.
+
+## Choisir
+
+| Besoin | Page |
+|---|---|
+| Démarrer un service HTTP | [API](api.md) |
+| Exposer des tools MCP | [MCP](mcp.md) |
+| Ajouter un worker RabbitMQ | [Bus](bus.md) |
+| Préparer un agent LangGraph | [Agent](agent.md) |
+
+## Projet De Départ
+
+Si tu n'as pas encore de projet Arclith :
+
+```bash
+uvx --from arclith-cli arclith-cli init my-service --dir .
+cd my-service
+uv sync
+```
+
+Les quickstarts partent ensuite de ce dossier.
+
+## Règle
+
+Un quickstart valide seulement le bootstrap.
+
+Pour écrire du métier réel, suivre le [parcours Todo](../tutorials/todo-list/index.md).
+
+## Suite
+
+Commencer par [API](api.md).

--- a/docs/quickstarts/mcp.md
+++ b/docs/quickstarts/mcp.md
@@ -44,4 +44,4 @@ Le test protocolaire complet est traité dans le [Deep Dive MCP](../deep-dives/m
 
 ## Suite
 
-Lire [mcp/fastmcp](../capabilities/mcp.md).
+Lire [Bus](bus.md), puis [mcp/fastmcp](../capabilities/mcp.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ extra_css:
 nav:
   - Accueil: index.md
   - Quickstarts:
+      - Vue d'ensemble: quickstarts/index.md
       - API: quickstarts/api.md
       - MCP: quickstarts/mcp.md
       - Bus: quickstarts/bus.md


### PR DESCRIPTION
## Summary
- Adds a Quickstarts landing page for the common API, MCP, bus, and agent paths.
- Links each quickstart to the matching deeper capability page or tutorial step.
- Keeps the docs navigation short and classroom-oriented.

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md
