### PR TITLE
docs: split production baseline guide

### DIFF
--- a/docs/production/auth.md
+++ b/docs/production/auth.md
@@ -1,0 +1,60 @@
+# Auth Production
+
+Cette page fixe le minimum pour exposer une API ou un MCP Arclith en production.
+
+## Objectif
+
+Un service de production doit refuser toute requête non authentifiée avant
+d'entrer dans les use cases.
+
+## Stack Cible
+
+| Besoin | Choix |
+|---|---|
+| Identity provider | Keycloak |
+| Jeton | JWT RS256 |
+| Validation | JWKS |
+| Autorisation | rôles applicatifs |
+| Transports | FastAPI et FastMCP |
+
+## Ajouter L'adapter
+
+```bash
+arclith-cli add-adapter \
+  --capability auth \
+  --adapter keycloak \
+  --param url=https://keycloak.example.com \
+  --param realm=production \
+  --param audience=my-service-api \
+  --param client_id=my-service-swagger \
+  --yes
+```
+
+## Configuration Minimale
+
+```yaml
+# config/adapters/inbound/keycloak.yaml
+url: "https://keycloak.example.com"
+realm: "production"
+audience: my-service-api
+client_id: my-service-swagger
+```
+
+## Règles
+
+- Toujours vérifier `issuer`, `audience`, signature et expiration.
+- Garder les rôles métier dans les use cases ou policies applicatives.
+- Ne pas copier la logique JWT dans chaque endpoint.
+- Activer HTTPS devant Keycloak et devant le service.
+- Mettre le cache JWKS dans Redis si le service a plusieurs replicas.
+
+## Vérifier
+
+```bash
+uv run pytest
+uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+```
+
+## Suite
+
+Lire [cache Redis](cache.md), puis la capability [auth/keycloak](../capabilities/auth.md).

--- a/docs/production/baseline.md
+++ b/docs/production/baseline.md
@@ -2,7 +2,7 @@
 
 Cette page donne la configuration de base à viser pour un service Arclith de production.
 
-## Socle
+## Socle Minimal
 
 | Besoin | Capability |
 |---|---|
@@ -15,6 +15,14 @@ Cette page donne la configuration de base à viser pour un service Arclith de pr
 | Probes | [probe/server](../capabilities/probe.md) |
 | Observabilité | [observability/opentelemetry](../capabilities/observability.md) |
 | Runtime | [runtime/docker-image](../capabilities/runtime.md) |
+
+## Parcours
+
+1. [Auth production](auth.md)
+2. [Cache production](cache.md)
+3. [Secrets et Vault](secrets.md)
+4. [Observabilité production](observability.md)
+5. [Runtime et probes](runtime.md)
 
 ## Commandes De Départ
 
@@ -50,5 +58,5 @@ docker build -t my-service:local .
 
 ## Suite
 
-Lire les fiches capabilities, puis [Docker Compose](../runtime-docker/docker-compose.md) et
-[Kubernetes](../runtime-docker/kubernetes.md).
+Lire les pages du parcours ci-dessus, puis [Docker Compose](../runtime-docker/docker-compose.md)
+et [Kubernetes](../runtime-docker/kubernetes.md).

--- a/docs/production/cache.md
+++ b/docs/production/cache.md
@@ -1,0 +1,59 @@
+# Cache Production
+
+Cette page explique quand passer du cache mémoire à Redis.
+
+## Objectif
+
+Le cache doit être partagé dès que le service tourne avec plusieurs processus,
+workers ou replicas.
+
+## Stack Cible
+
+| Besoin | Choix |
+|---|---|
+| Local/test | `memory` |
+| Production | Redis |
+| Données typiques | JWKS, idempotence, résolution tenant |
+| Expiration | TTL explicite par usage |
+
+## Ajouter L'adapter
+
+```bash
+arclith-cli add-adapter --capability cache --adapter redis --yes
+```
+
+## Configuration Minimale
+
+```yaml
+# config/adapters/inbound/cache.yaml
+backend: redis
+redis_url: "${REDIS_URL}"
+jwks_ttl: 3600
+tenant_uri_ttl: 300
+```
+
+## Variables
+
+```bash
+export REDIS_URL=redis://redis:6379/0
+```
+
+## Règles
+
+- Ne pas utiliser `memory` en Kubernetes ou avec plusieurs workers.
+- Définir un TTL pour chaque famille de clé.
+- Préfixer les clés par service et environnement.
+- Ne jamais cacher un secret en clair.
+- Surveiller latence, erreurs Redis et taux de hit.
+
+## Vérifier Localement
+
+```bash
+docker run --rm -d --name arclith-redis -p 6379:6379 redis:7-alpine
+REDIS_URL=redis://127.0.0.1:6379/0 uv run pytest
+docker stop arclith-redis
+```
+
+## Suite
+
+Lire [secrets et Vault](secrets.md), puis la capability [cache/redis](../capabilities/cache.md).

--- a/docs/production/observability.md
+++ b/docs/production/observability.md
@@ -1,0 +1,54 @@
+# Observabilité Production
+
+Cette page donne le minimum pour diagnostiquer un service Arclith en production.
+
+## Objectif
+
+Chaque requête API, appel MCP, message bus ou run agent doit pouvoir être relié
+à un trace id, un service et un environnement.
+
+## Stack Cible
+
+| Besoin | Choix |
+|---|---|
+| Traces runtime/API | OpenTelemetry |
+| Traces agent | LangSmith |
+| Logs | logger structuré |
+| Santé | probes HTTP |
+| Corrélation | `traceparent` |
+
+## Ajouter Les Adapters
+
+```bash
+arclith-cli add-adapter --capability observability --adapter opentelemetry --yes
+arclith-cli add-adapter --capability observability --adapter langsmith --yes
+arclith-cli add-adapter --capability logger --adapter loguru --yes
+arclith-cli add-adapter --capability probe --adapter server --yes
+```
+
+## Variables Minimales
+
+```bash
+export OTEL_SERVICE_NAME=my-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production
+```
+
+## Règles
+
+- Nommer explicitement le service et l'environnement.
+- Propager `traceparent` entre API, MCP, bus et agent.
+- Ne pas logger les secrets, tokens ou payloads sensibles.
+- Exposer `/health` et `/ready` sur un port de probe dédié.
+- Garder LangSmith optionnel si aucun agent n'est lancé.
+
+## Vérifier
+
+```bash
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local uv run pytest
+curl -fsS http://127.0.0.1:9000/health
+```
+
+## Suite
+
+Lire [runtime et probes](runtime.md), puis les capabilities [observability](../capabilities/observability.md) et [logger](../capabilities/logger.md).

--- a/docs/production/runtime.md
+++ b/docs/production/runtime.md
@@ -1,0 +1,53 @@
+# Runtime Et Probes
+
+Cette page définit le minimum pour lancer un service Arclith en conteneur.
+
+## Objectif
+
+Une même image doit pouvoir lancer API, MCP, bus ou agent sans rebuild.
+
+## Stack Cible
+
+| Besoin | Choix |
+|---|---|
+| Image | `runtime/docker-image` |
+| Processus | `arclith-run` |
+| Santé | `probe/server` |
+| Sécurité | utilisateur non-root |
+| Orchestration | Compose puis Kubernetes |
+
+## Ajouter Les Adapters
+
+```bash
+arclith-cli add-adapter --capability probe --adapter server --yes
+arclith-cli add-adapter --capability runtime --adapter docker-image --yes
+```
+
+## Modes De Lancement
+
+```bash
+docker run --rm -p 8000:8000 -p 9000:9000 my-service:local api
+docker run --rm -p 8001:8001 -p 9000:9000 my-service:local mcp_http
+docker run --rm -p 2024:2024 -p 9000:9000 my-service:local agent
+```
+
+## Règles
+
+- Construire l'image une fois, configurer au runtime.
+- Garder les secrets hors des layers Docker.
+- Lancer le conteneur avec un utilisateur non-root.
+- Définir CPU, mémoire, readiness et liveness en orchestration.
+- Ne considérer un déploiement prêt qu'après une réponse positive de `/ready`.
+
+## Vérifier
+
+```bash
+docker build -t my-service:local .
+docker run --rm -d --name my-service -p 9000:9000 my-service:local api
+curl -fsS http://127.0.0.1:9000/ready
+docker stop my-service
+```
+
+## Suite
+
+Lire le tutoriel [Docker](../runtime-docker.md), puis [Docker Compose](../runtime-docker/docker-compose.md).

--- a/docs/production/secrets.md
+++ b/docs/production/secrets.md
@@ -1,0 +1,61 @@
+# Secrets Et Vault
+
+Cette page définit le flux minimal pour sortir les secrets du dépôt Git.
+
+## Objectif
+
+Le code et la configuration versionnée doivent contenir des références, jamais
+des valeurs secrètes réelles.
+
+## Stack Cible
+
+| Besoin | Choix |
+|---|---|
+| Injection conteneur | variables d'environnement |
+| Source centrale | Vault KV v2 |
+| Fallback local | fichier YAML gitignoré |
+| Résolution | `secrets/chain` |
+
+## Ajouter L'adapter
+
+```bash
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter chain \
+  --param field_path=adapters.mongodb.uri \
+  --param secret_key=apps/my-service/mongodb \
+  --yes
+```
+
+## Configuration Minimale
+
+```yaml
+# config/secrets.yaml
+resolver: chain
+chain:
+  - env
+  - vault
+  - yaml
+mappings:
+  adapters.mongodb.uri: apps/my-service/mongodb
+  cache.redis_url: apps/my-service/redis
+```
+
+## Règles
+
+- Aucun `.env` réel dans Git.
+- Les secrets de build sont interdits dans l'image Docker finale.
+- Vault doit être la source de vérité en production.
+- Le fallback YAML sert au développement local, avec un fichier ignoré.
+- Chaque secret doit avoir un propriétaire, une rotation et un usage identifié.
+
+## Vérifier
+
+```bash
+uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+git diff --check
+```
+
+## Suite
+
+Lire [observabilité](observability.md), puis la capability [secrets/vault](../capabilities/secrets.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,11 @@ nav:
       - Annexes locales: tutorials/todo-list/07-local-services.md
   - Production:
       - Baseline: production/baseline.md
+      - Auth: production/auth.md
+      - Cache: production/cache.md
+      - Secrets et Vault: production/secrets.md
+      - Observabilité: production/observability.md
+      - Runtime et probes: production/runtime.md
       - Docker:
           - Vue d'ensemble: runtime-docker.md
           - 1. Build: runtime-docker/build.md


### PR DESCRIPTION
## Summary
- Splits the production baseline into short training pages for auth, cache, secrets/Vault, observability, and runtime/probes.
- Keeps baseline.md as the production entrypoint and adds the new pages to the MkDocs navigation.
- Links each production topic back to the matching capability documentation.

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md
- pre-push hook: ruff, mypy, bandit, pytest coverage: 358 passed, 1 skipped, 90.84%
