### PR TITLE
docs: expand security capability guides

### DIFF
--- a/docs/capabilities/auth.md
+++ b/docs/capabilities/auth.md
@@ -2,11 +2,16 @@
 
 Authentification JWT Keycloak mutualisée FastAPI et FastMCP.
 
+## Objectif
+
+Centraliser la validation JWT pour éviter une logique différente entre API,
+MCP et tenants.
+
 ## Adapter
 
 | Adapter | Usage |
 |---|---|
-| `keycloak` | JWT RS256 via JWKS Keycloak |
+| `keycloak` | JWT RS256 via JWKS Keycloak et Swagger UI OAuth2 PKCE |
 
 ## Commande
 
@@ -21,7 +26,7 @@ arclith-cli add-adapter \
   --yes
 ```
 
-## Configuration
+## Configuration Générée
 
 ```yaml
 # config/adapters/inbound/keycloak.yaml
@@ -31,16 +36,38 @@ audience: rekipe-api
 client_id: swagger-public
 ```
 
-## Règle
+## Utiliser Dans L'API
 
-La vérification JWT est commune aux transports API et MCP.
+```python
+from fastapi import APIRouter, Depends
+
+require_auth = arclith.auth_dependency()
+router = APIRouter(dependencies=[Depends(require_auth)])
+```
+
+## Utiliser Dans MCP
+
+```python
+require_auth = arclith.auth_dependency(transport="mcp")
+```
+
+L'auth MCP nécessite un transport HTTP/SSE qui expose les headers.
+
+## Règles
+
+- Vérifier signature, expiration, issuer et audience.
+- Utiliser Redis pour le cache JWKS en multi-worker.
+- Garder les décisions métier dans les policies ou use cases.
+- Ne pas coder de secret client dans Swagger UI: le client PKCE est public.
+- Coupler avec [license](license.md) quand un rôle applicatif est obligatoire.
 
 ## Validation
 
 ```bash
 uv run pytest
+curl -fsS http://keycloak:8080/realms/rekipe/.well-known/openid-configuration
 ```
 
 ## Suite
 
-Lire [Authentification & Autorisation](../auth.md).
+Lire [Auth production](../production/auth.md), puis [Authentification & Autorisation](../auth.md).

--- a/docs/capabilities/cache.md
+++ b/docs/capabilities/cache.md
@@ -2,6 +2,11 @@
 
 Cache technique pour JWKS, idempotency et résolution tenant.
 
+## Objectif
+
+Partager les données techniques courtes entre API, MCP, agent et workers quand
+ils tournent dans plusieurs processus.
+
 ## Adapters
 
 | Adapter | Usage |
@@ -15,7 +20,7 @@ Cache technique pour JWKS, idempotency et résolution tenant.
 arclith-cli add-adapter --capability cache --adapter redis --yes
 ```
 
-## Configuration
+## Configuration Générée
 
 ```yaml
 # config/adapters/inbound/cache.yaml
@@ -25,18 +30,32 @@ jwks_ttl: 3600
 tenant_uri_ttl: 300
 ```
 
-## Règle
+`redis_url` doit être résolu par [secrets](secrets.md) ou par `REDIS_URL`.
 
-Utiliser Redis dès que API, MCP, agent ou workers tournent dans des processus séparés.
+## Usages
+
+| Usage | Clé De Décision |
+|---|---|
+| JWKS Keycloak | réduire les appels à Keycloak |
+| Idempotency-Key | rejouer une réponse POST déjà traitée |
+| Tenant URI | éviter un appel Vault à chaque requête |
+
+## Règles
+
+- Utiliser Redis dès que plusieurs processus partagent le trafic.
+- Définir un TTL court et explicite par usage.
+- Préfixer les clés par service et environnement.
+- Ne pas stocker de secret brut dans le cache.
+- Surveiller erreurs, latence et saturation Redis.
 
 ## Validation
 
 ```bash
 docker run --rm -d --name arclith-redis -p 6379:6379 redis:7-alpine
 REDIS_URL=redis://127.0.0.1:6379 uv run pytest
-docker rm -f arclith-redis
+docker stop arclith-redis
 ```
 
 ## Suite
 
-Lire [HTTP](http.md) pour l'idempotence et les headers cache.
+Lire [Cache production](../production/cache.md), puis [HTTP](http.md).

--- a/docs/capabilities/observability.md
+++ b/docs/capabilities/observability.md
@@ -2,6 +2,11 @@
 
 Observabilité du runtime, de l'API et des agents.
 
+## Objectif
+
+Produire les signaux nécessaires pour relier une requête, un tool MCP, une
+commande RabbitMQ et un run agent.
+
 ## Adapters
 
 | Adapter | Usage |
@@ -16,7 +21,7 @@ arclith-cli add-adapter --capability observability --adapter opentelemetry --yes
 arclith-cli add-adapter --capability observability --adapter langsmith --yes
 ```
 
-## Configuration
+## Activation
 
 ```yaml
 # config/adapters/adapters.yaml
@@ -26,9 +31,35 @@ observability:
     - langsmith
 ```
 
-## Règle
+## OpenTelemetry
 
-LangSmith sert au banc de test agent. OpenTelemetry sert à l'observabilité transverse runtime/API.
+```yaml
+# config/adapters/outbound/opentelemetry.yaml
+service_name: "my-service"
+endpoint: "http://localhost:4318"
+protocol: "http/protobuf"
+traces: true
+metrics: false
+instrument_fastapi: true
+```
+
+## LangSmith
+
+```yaml
+# config/adapters/outbound/langsmith.yaml
+tracing: true
+project: "my-service-dev"
+endpoint: "https://api.smith.langchain.com"
+api_key_env: LANGSMITH_API_KEY
+```
+
+## Règles
+
+- OpenTelemetry sert au runtime, API, métriques et corrélation.
+- LangSmith sert aux runs agents et aux évaluations.
+- Définir `service.name`, `service.version` et l'environnement.
+- Propager `traceparent` entre HTTP, MCP, bus et agent.
+- Ne jamais envoyer de secret dans logs, traces ou attributs.
 
 ## Validation
 
@@ -38,4 +69,4 @@ OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local uv run pytest
 
 ## Suite
 
-Lire [logger](logger.md) et [agent](agent.md).
+Lire [Observabilité production](../production/observability.md), [logger](logger.md) et [agent](agent.md).

--- a/docs/capabilities/secrets.md
+++ b/docs/capabilities/secrets.md
@@ -2,6 +2,11 @@
 
 Résolution de secrets avant validation de la configuration Arclith.
 
+## Objectif
+
+Remplacer les valeurs sensibles dans la configuration par des références
+résolues au runtime.
+
 ## Adapters
 
 | Adapter | Usage |
@@ -22,7 +27,7 @@ arclith-cli add-adapter \
   --yes
 ```
 
-## Configuration
+## Configuration Générée
 
 ```yaml
 # config/secrets.yaml
@@ -35,16 +40,42 @@ mappings:
   adapters.mongodb.uri: apps/my-service/mongodb
 ```
 
-## Règle
+## Resolvers
 
-Aucune valeur secrète réelle ne doit être commitée.
+| Resolver | À Utiliser Quand |
+|---|---|
+| `env` | Docker, CI/CD, Kubernetes |
+| `yaml` | POC local avec fichier gitignoré |
+| `vault` | production |
+| `chain` | fallback ordonné `env`, `vault`, `yaml` |
+
+## Mappings
+
+```yaml
+mappings:
+  adapters.mongodb.uri: apps/my-service/mongodb
+  adapters.mariadb.password: apps/my-service/mariadb/password
+  cache.redis_url: apps/my-service/redis
+```
+
+La clé de gauche est le champ Arclith. La valeur de droite est la référence dans
+le resolver choisi.
+
+## Règles
+
+- Aucune valeur secrète réelle ne doit être commitée.
+- Ne pas injecter de secret au build Docker.
+- Préférer Vault comme source de vérité en production.
+- Garder les fichiers YAML locaux gitignorés.
+- Documenter propriétaire, rotation et usage de chaque secret.
 
 ## Validation
 
 ```bash
 uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+git diff --check
 ```
 
 ## Suite
 
-Lire [Baseline production](../production/baseline.md).
+Lire [Secrets et Vault](../production/secrets.md), puis [tenant](tenant.md).


### PR DESCRIPTION
## Summary
- Expands auth, cache, secrets, and observability capability pages.
- Adds concise production-oriented guidance for JWT, Redis, Vault/secret mappings, OpenTelemetry, and LangSmith.
- Links these capability guides back to the production pages.

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md
- pre-push hook: ruff, mypy, bandit, pytest coverage: 358 passed, 1 skipped, 90.84%
