### PR TITLE
docs: expand runtime operations capability guides

### DIFF
--- a/docs/capabilities/http.md
+++ b/docs/capabilities/http.md
@@ -2,6 +2,11 @@
 
 Middlewares HTTP transverses pour FastAPI.
 
+## Objectif
+
+Standardiser les comportements HTTP qui évitent les doubles mutations,
+améliorent le cache et sécurisent les mises à jour concurrentes.
+
 ## Adapters
 
 | Adapter | Usage |
@@ -33,9 +38,21 @@ cache_control:
   get_list_max_age: 60
 ```
 
-## Règle
+## Comportements
 
-En production multi-worker, associer ces middlewares à [cache/redis](cache.md).
+| Adapter | Entrée | Sortie |
+|---|---|---|
+| `idempotency` | `Idempotency-Key` sur `POST` | replay d'une réponse déjà traitée |
+| `etag` | `If-Match`, `If-None-Match` | version attendue ou `304` |
+| `cache-control` | méthode et chemin HTTP | header `Cache-Control` adapté |
+
+## Règles
+
+- En production multi-worker, associer ces middlewares à [cache/redis](cache.md).
+- Exiger `Idempotency-Key` sur les mutations critiques.
+- Utiliser ETag pour les ressources versionnées.
+- Mettre `no-store` sur les mutations et payloads sensibles.
+- Tester les headers publics dans les tests API.
 
 ## Validation
 
@@ -48,4 +65,4 @@ curl -i -X POST http://127.0.0.1:8000/v1/items/ \
 
 ## Suite
 
-Lire [HTTP](../http-conventions.md).
+Lire [API](api.md), puis [HTTP](../http-conventions.md).

--- a/docs/capabilities/logger.md
+++ b/docs/capabilities/logger.md
@@ -2,11 +2,16 @@
 
 Logger applicatif partagé par les use cases et les adapters.
 
+## Objectif
+
+Fournir un port de logging commun pour les use cases, adapters et runners, avec
+des métadonnées exploitables par l'observabilité.
+
 ## Adapter
 
 | Adapter | Usage |
 |---|---|
-| `console` | logs Loguru vers `stderr` |
+| `console` | logs Loguru vers `stderr`, enrichis si OpenTelemetry est actif |
 
 ## Commande
 
@@ -21,9 +26,20 @@ arclith-cli add-adapter --capability logger --adapter console --yes
 logger: console
 ```
 
-## Règle
+## Utiliser
 
-Les use cases reçoivent un logger injecté. Ils n'utilisent pas `print()`.
+```python
+logger = arclith.logger
+logger.info("todo created", todo_uuid=str(todo.uuid))
+```
+
+## Règles
+
+- Les use cases reçoivent un logger injecté.
+- Ne pas utiliser `print()` pour les logs applicatifs.
+- Ne jamais logger de token, mot de passe ou payload sensible.
+- Ajouter `correlation_id`, `tenant_id` ou `trace_id` quand disponibles.
+- Laisser Uvicorn passer par l'interception Arclith.
 
 ## Validation
 

--- a/docs/capabilities/probe.md
+++ b/docs/capabilities/probe.md
@@ -2,6 +2,11 @@
 
 Serveur de probes `health`, `readiness`, `info` et `metrics`.
 
+## Objectif
+
+Exposer un canal opérationnel indépendant du transport métier pour vérifier la
+santé, la readiness, les transports actifs et les métriques.
+
 ## Adapter
 
 | Adapter | Usage |
@@ -25,10 +30,29 @@ enabled: true
 
 ## Endpoints
 
-- `/health`
-- `/ready`
-- `/info`
-- `/metrics`
+| Endpoint | Usage |
+|---|---|
+| `/health` | le processus répond |
+| `/ready` | le service est prêt à recevoir du trafic |
+| `/info` | nom, version et transports actifs |
+| `/metrics` | métriques API/MCP quand activées |
+
+## Readiness
+
+```python
+async def database_ready() -> bool:
+    return await repository.ping()
+
+arclith.add_readiness_check(database_ready)
+```
+
+## Règles
+
+- Utiliser un port de probe séparé du port métier.
+- Kubernetes doit router la readiness vers `/ready`.
+- Une dépendance critique indisponible doit rendre `/ready` négatif.
+- `/health` ne remplace pas `/ready`.
+- Les probes ne doivent pas exposer de secret.
 
 ## Validation
 
@@ -39,4 +63,4 @@ curl -fsS http://127.0.0.1:9000/ready
 
 ## Suite
 
-Lire [Docker](../runtime-docker.md).
+Lire [Runtime et probes](../production/runtime.md), puis [Docker](../runtime-docker.md).

--- a/docs/capabilities/runtime.md
+++ b/docs/capabilities/runtime.md
@@ -2,6 +2,11 @@
 
 Runtime de déploiement standardisé.
 
+## Objectif
+
+Générer une image unique capable de lancer les transports Arclith fréquents sans
+rebuild: API, MCP, bus et agent.
+
 ## Adapter
 
 | Adapter | Usage |
@@ -31,14 +36,34 @@ arclith-run
 | `bus` | `MODE=bus python main.py` |
 | `agent` | `langgraph dev` ou `ARCLITH_AGENT_COMMAND` |
 
+## Variables Utiles
+
+| Variable | Usage |
+|---|---|
+| `MODE` | mode par défaut si aucun argument n'est passé |
+| `ARCLITH_API_PORT` | port exposé API |
+| `ARCLITH_MCP_PORT` | port exposé MCP |
+| `ARCLITH_PROBE_PORT` | port probes |
+| `ARCLITH_AGENT_PORT` | port LangGraph |
+| `ARCLITH_AGENT_COMMAND` | commande agent personnalisée |
+
+## Règles
+
+- Une image par service, plusieurs modes de lancement.
+- Aucun secret dans les layers Docker.
+- Utilisateur non-root dans l'image finale.
+- Configuration et secrets injectés au runtime.
+- Readiness vérifiée via `probe/server`.
+
 ## Validation
 
 ```bash
 docker build -t my-service:local .
-docker run --rm -p 9000:9000 my-service:local api
+docker run --rm -d --name my-service -p 9000:9000 my-service:local api
 curl -fsS http://127.0.0.1:9000/health
+docker stop my-service
 ```
 
 ## Suite
 
-Lire [Tutoriel Docker](../runtime-docker.md).
+Lire [Runtime et probes](../production/runtime.md), puis [Tutoriel Docker](../runtime-docker.md).


### PR DESCRIPTION
## Summary
- Expands runtime, probe, HTTP, and logger capability pages.
- Adds concise operational guidance for runtime modes, probes/readiness, HTTP middleware behavior, and structured logs.
- Links these capability guides back to production runtime, Docker, API, and observability pages.

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md
- pre-push hook: ruff, mypy, bandit, pytest coverage: 358 passed, 1 skipped, 90.84%
