### PR TITLE
docs: expand domain capability guides

### DIFF
--- a/docs/capabilities/license.md
+++ b/docs/capabilities/license.md
@@ -2,6 +2,15 @@
 
 Autorisation par rôle realm Keycloak.
 
+## Objectif
+
+`license` ajoute un contrôle d'accès simple au pipeline d'authentification.
+Le cas fourni par Arclith vérifie qu'un rôle realm Keycloak est présent dans le
+token avant de laisser l'appel atteindre le cas d'usage.
+
+Cette capability sert à bloquer l'accès global à une fonctionnalité ou à un
+produit. Les règles métier fines restent dans les use cases.
+
 ## Adapter
 
 | Adapter | Usage |
@@ -25,9 +34,40 @@ arclith-cli add-adapter \
 role: "rekipe:licensed"
 ```
 
-## Règle
+## Flux
+
+Le contrôle licence se place après le décodage du JWT:
+
+1. l'adapter `auth` valide la signature et les claims de base;
+2. `license` lit `realm_access.roles`;
+3. le rôle configuré doit être présent;
+4. la requête continue vers la route ou le tool MCP.
+
+Le même validateur peut être branché côté API et côté MCP pour garder une règle
+identique quel que soit le point d'entrée.
+
+## Règles
 
 `401` signifie authentification absente ou invalide. `403` signifie token valide mais rôle manquant.
+
+Le nom du rôle doit être stable et explicite. Préférer un rôle comme
+`rekipe:licensed` ou `todo:agent:enabled` à un rôle vague comme `user`.
+
+Ne pas dupliquer le nom du rôle dans les routes. Le rôle doit venir de
+`config/adapters/inbound/license.yaml` pour rester modifiable par environnement.
+
+Ne pas confondre licence et autorisation métier. Une licence peut dire
+"ce compte a accès au produit"; un use case doit encore vérifier les règles
+comme propriétaire de ressource, quota, statut ou périmètre tenant.
+
+## Erreurs attendues
+
+| Situation | Statut |
+|---|---:|
+| token absent | `401` |
+| token invalide | `401` |
+| rôle absent | `403` |
+| rôle présent | accès autorisé |
 
 ## Validation
 
@@ -35,6 +75,19 @@ role: "rekipe:licensed"
 uv run pytest
 ```
 
+Tester au minimum:
+
+| Cas | Résultat attendu |
+|---|---|
+| rôle configuré présent | accès autorisé |
+| rôle configuré absent | `403` |
+| `realm_access` absent | `403` |
+| config `license.yaml` absente | contrôle licence désactivé |
+
 ## Suite
 
-Lire [auth/keycloak](auth.md).
+Lire aussi:
+
+- [Capability Auth](auth.md)
+- [API - Auth et sécurité](../production/auth.md)
+- [Capability Tenant](tenant.md)

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -2,6 +2,16 @@
 
 Configuration du modèle utilisé par les interpréteurs d'intention et agents.
 
+## Objectif
+
+`llm` configure le modèle utilisé par les adapters d'intelligence applicative:
+interpréteur d'intention, agent LangGraph, classification, extraction ou aide à
+la décision.
+
+Le LLM reste un adapter outbound. Il peut proposer une action, structurer une
+intention ou produire une réponse, mais l'écriture en base passe toujours par un
+use case métier explicite.
+
 ## Adapters
 
 | Adapter | Usage |
@@ -10,7 +20,9 @@ Configuration du modèle utilisé par les interpréteurs d'intention et agents.
 | `openai` | modèle OpenAI |
 | `anthropic` | modèle Claude |
 
-## Commande
+## Commandes
+
+LM Studio local:
 
 ```bash
 arclith-cli add-adapter \
@@ -20,7 +32,31 @@ arclith-cli add-adapter \
   --yes
 ```
 
+OpenAI:
+
+```bash
+arclith-cli add-adapter \
+  --capability llm \
+  --adapter openai \
+  --param model_name="<model-id>" \
+  --param api_key="$OPENAI_API_KEY" \
+  --yes
+```
+
+Anthropic:
+
+```bash
+arclith-cli add-adapter \
+  --capability llm \
+  --adapter anthropic \
+  --param model_name="<model-id>" \
+  --param api_key="$ANTHROPIC_API_KEY" \
+  --yes
+```
+
 ## Configuration
+
+LM Studio génère une configuration OpenAI-compatible:
 
 ```yaml
 # config/adapters/outbound/lm.yaml
@@ -30,16 +66,91 @@ api_key: "lm-studio"
 base_url: "http://127.0.0.1:1234/v1"
 ```
 
-## Règle
+OpenAI garde la clé dans `.env` via un mapping de secret:
+
+```yaml
+# config/adapters/outbound/lm.yaml
+provider: openai
+model_name: "<model-id>"
+api_key: ""
+base_url: "https://api.openai.com/v1"
+```
+
+```dotenv
+OPENAI_API_KEY=...
+```
+
+Anthropic suit le même principe:
+
+```yaml
+# config/adapters/outbound/lm.yaml
+provider: anthropic
+model_name: "<model-id>"
+api_key: ""
+```
+
+```dotenv
+ANTHROPIC_API_KEY=...
+```
+
+## Usage applicatif
+
+Injecter le LLM dans un adapter outbound dédié, puis exposer au domaine une
+interface stable comme `LLMPort`. Le use case garde la décision finale.
+
+Exemple de règle:
+
+```python
+intent = await intent_interpreter.classify(message)
+command = build_command_from_intent(intent)
+result = await use_case.execute(command)
+```
+
+Éviter le chemin inverse où le prompt appelle directement le repository.
+
+## Règles
 
 Le LLM interprète ou assiste. Il n'écrit pas directement dans la persistance.
 
+Le provider doit rester interchangeable. Ne pas exposer un type SDK OpenAI,
+Anthropic ou Pydantic AI dans le domaine.
+
+La clé API doit venir d'un secret ou de l'environnement, jamais d'un fichier
+versionné avec une vraie valeur.
+
+Les tests unitaires des use cases ne doivent pas dépendre du réseau. Utiliser un
+fake de `LLMPort` pour les cas déterministes.
+
+Documenter le `model_name` réellement utilisé par environnement, car les
+résultats et les coûts changent avec le modèle.
+
 ## Validation
+
+LM Studio:
 
 ```bash
 curl -fsS http://127.0.0.1:1234/v1/models
 ```
 
+Tests:
+
+```bash
+uv run pytest
+```
+
+Vérifier au minimum:
+
+| Cas | Résultat attendu |
+|---|---|
+| provider OpenAI-compatible sans `base_url` | erreur de configuration |
+| secret absent pour OpenAI ou Anthropic | erreur explicite |
+| fake LLM en test unitaire | aucun appel réseau |
+| agent avec observabilité active | traces visibles dans LangSmith |
+
 ## Suite
 
-Lire [agent/langgraph](agent.md).
+Lire aussi:
+
+- [Capability Agent](agent.md)
+- [Capability Observability](observability.md)
+- [Tutoriel agent](../tutorials/todo-list/06-agent-config.md)

--- a/docs/capabilities/tenant.md
+++ b/docs/capabilities/tenant.md
@@ -2,6 +2,17 @@
 
 Résolution multitenant depuis un claim JWT et Vault.
 
+## Objectif
+
+`tenant` permet de convertir une identité authentifiée en coordonnées techniques
+par adaptateur. Le cas standard est un token JWT qui contient un identifiant
+tenant, puis une lecture Vault KV v2 qui retourne les paramètres nécessaires aux
+repositories multitenant.
+
+Cette capability ne choisit pas le tenant depuis une route ou un header libre.
+Elle part d'un claim signé pour éviter qu'un appelant puisse changer de tenant
+en modifiant une entrée HTTP non vérifiée.
+
 ## Adapter
 
 | Adapter | Usage |
@@ -21,6 +32,16 @@ arclith-cli add-adapter \
   --yes
 ```
 
+Paramètres utiles:
+
+| Paramètre | Rôle |
+|---|---|
+| `addr` | URL du serveur Vault |
+| `mount` | mount KV v2 |
+| `path_prefix` | préfixe où sont stockées les entrées tenant |
+| `tenant_claim` | claim JWT utilisé comme identifiant tenant |
+| `tenant_uri_ttl` | durée de cache locale de la résolution |
+
 ## Configuration
 
 ```yaml
@@ -31,9 +52,62 @@ vault_path_prefix: "rekipe/tenants"
 tenant_claim: "tenant_id"
 ```
 
-## Règle
+La commande complète aussi le cache applicatif:
+
+```yaml
+# config/adapters/inbound/cache.yaml
+tenant_uri_ttl: 300
+```
+
+## Stockage Vault
+
+Le resolver lit le chemin `{path_prefix}/{tenant_id}` dans le mount configuré.
+Chaque entrée doit exposer les champs attendus par l'adapter concerné. Exemple
+pour MongoDB:
+
+```bash
+vault kv put kv/rekipe/tenants/tenant-a \
+  uri="mongodb://mongo-tenant-a:27017" \
+  db_name="todo_tenant_a"
+```
+
+Exemple pour un adapter S3:
+
+```bash
+vault kv put kv/rekipe/tenants/tenant-a \
+  endpoint_url="https://s3.example.test" \
+  bucket_name="tenant-a-assets" \
+  region="eu-west-1"
+```
+
+## Pipeline HTTP
+
+En API FastAPI, le pipeline attendu est:
+
+1. décoder le JWT;
+2. valider la licence si `license` est configurée;
+3. lire le claim `tenant_claim`;
+4. résoudre tous les `TenantResolver` configurés;
+5. poser le `TenantContext` dans le contexte de requête.
+
+Les repositories multitenant lisent ensuite leurs coordonnées via le contexte
+Arclith. Le coeur métier ne reçoit pas directement d'URI, de mot de passe ou de
+nom de base tenant.
+
+## Règles
 
 Activer cette capability quand un repository fonctionne en `multitenant: true`.
+
+Le claim tenant doit être stable, non ambigu, et émis par l'Identity Provider.
+Éviter les claims descriptifs comme `email` si le tenant doit survivre aux
+changements de compte ou de domaine.
+
+Ne jamais écrire les coordonnées tenant dans les logs. Les messages d'erreur
+peuvent mentionner le tenant logique, mais pas les URI ou secrets récupérés dans
+Vault.
+
+Le TTL de cache doit rester court en environnement sensible. Il réduit la charge
+Vault, mais retarde la prise en compte d'une rotation de coordonnées.
 
 ## Validation
 
@@ -41,6 +115,21 @@ Activer cette capability quand un repository fonctionne en `multitenant: true`.
 uv run pytest
 ```
 
+Tester au minimum:
+
+| Cas | Résultat attendu |
+|---|---|
+| repository single-tenant | aucun resolver requis |
+| repository multitenant sans JWT decoder | erreur de configuration |
+| token sans claim tenant | `401` |
+| tenant inconnu dans Vault | erreur d'accès au tenant |
+| tenant valide | repository initialisé avec les coordonnées du tenant |
+
 ## Suite
 
-Lire [Multitenant](../multitenant.md).
+Lire aussi:
+
+- [Multitenant](../multitenant.md)
+- [Capability Auth](auth.md)
+- [Capability Secrets](secrets.md)
+- [Capability Repository](repository.md)


### PR DESCRIPTION
## Summary
- expand the tenant capability guide with Vault storage, auth pipeline, cache TTL, and validation cases
- expand the license capability guide with role-based flow, expected status codes, and validation cases
- expand the LLM capability guide with LM Studio, OpenAI, Anthropic, secret handling, and test boundaries

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md || true
- pre-push hooks: ruff, bandit, mypy, pytest --cov --cov-report=term-missing --cov-report=html
