### PR TITLE
docs: add learning path pages

### DIFF
--- a/docs/learning/foundations.md
+++ b/docs/learning/foundations.md
@@ -1,0 +1,62 @@
+# Comprendre Le Modèle
+
+Cette page pose le vocabulaire minimal avant les quickstarts.
+
+## Idée Centrale
+
+Arclith sépare le métier des outils.
+
+Le métier définit les entités, les ports et les use cases. Les adapters
+branchent ensuite FastAPI, MCP, LangGraph, les repositories, le cache, les
+secrets, le bus ou l'observabilité.
+
+## Chemin Standard
+
+```text
+client
+  -> adapter inbound
+  -> port inbound
+  -> use case
+  -> port outbound
+  -> adapter outbound
+```
+
+Le même use case peut donc être appelé depuis une API, un serveur MCP, un worker
+ou un agent.
+
+## À Retenir
+
+| Terme | Rôle |
+|---|---|
+| entité | objet métier |
+| port inbound | intention exposée par l'application |
+| use case | orchestration métier |
+| port outbound | besoin du métier vers l'extérieur |
+| adapter inbound | entrée technique comme API ou MCP |
+| adapter outbound | sortie technique comme repository ou LLM |
+| capability | bloc activable par la CLI |
+
+## Validation
+
+Lire ces deux pages:
+
+- [C'est quoi Arclith ?](../foundations/what-is-arclith.md)
+- [Le chemin hexagonal](../foundations/hexagonal-flow.md)
+
+Pouvoir expliquer en une phrase pourquoi un handler FastAPI ne doit pas parler
+directement au repository.
+
+## Erreur Fréquente
+
+Éviter de démarrer par le framework HTTP. Commencer par le use case force une
+frontière propre et rend l'API remplaçable.
+
+## Média
+
+!!! note "Média à produire"
+    Capture attendue : schéma du chemin client vers adapter outbound.
+    Vidéo attendue : explication courte du vocabulaire sur un exemple Todo.
+
+## Suite
+
+Lire [Quickstarts essentiels](quickstarts.md).

--- a/docs/learning/quickstarts.md
+++ b/docs/learning/quickstarts.md
@@ -1,0 +1,49 @@
+# Quickstarts Essentiels
+
+Cette page regroupe les démarrages rapides les plus utilisés.
+
+## Objectif
+
+Exécuter les quatre modes fréquents sans entrer encore dans tous les détails:
+API, MCP, bus et agent.
+
+## Ordre Recommandé
+
+1. [Quickstart API](../quickstarts/api.md)
+2. [Quickstart MCP](../quickstarts/mcp.md)
+3. [Quickstart bus](../quickstarts/bus.md)
+4. [Quickstart agent](../quickstarts/agent.md)
+
+Chaque quickstart est volontairement court. Les explications longues sont dans
+les pages capabilities et deep dives.
+
+## Validations
+
+| Mode | Validation minimale |
+|---|---|
+| API | `curl -fsS http://127.0.0.1:8000/health` |
+| MCP | tool MCP visible depuis le client choisi |
+| Bus | message publié puis consommé |
+| Agent | graphe lancé et premier échange exécuté |
+
+## Quand S'arrêter
+
+Si un quickstart échoue, rester sur ce mode avant de passer au suivant. La
+formation doit produire un service qui tourne, pas seulement des fichiers.
+
+## Liens D'approfondissement
+
+- [Capability API](../capabilities/api.md)
+- [Capability MCP](../capabilities/mcp.md)
+- [Capability Command Bus](../capabilities/command-bus.md)
+- [Capability Agent](../capabilities/agent.md)
+
+## Média
+
+!!! note "Média à produire"
+    Capture attendue : un terminal par quickstart avec la commande de validation.
+    Vidéo attendue : enchaînement API, MCP, bus, agent sans approfondissement.
+
+## Suite
+
+Suivre le [projet Todo](../tutorials/todo-list/index.md).

--- a/docs/learning/setup.md
+++ b/docs/learning/setup.md
@@ -1,0 +1,73 @@
+# Préparer Son Poste
+
+Cette page vérifie que l'environnement local peut suivre les tutoriels Arclith.
+
+## Prérequis
+
+- Python 3.13;
+- `uv`;
+- `git`;
+- Docker Desktop ou un moteur Docker compatible;
+- accès au dépôt GitHub Arclith;
+- LM Studio si le parcours agent est prévu.
+
+## Installer La CLI
+
+```bash
+uv tool install --force arclith-cli
+arclith-cli version
+```
+
+Pour travailler depuis le dépôt Arclith:
+
+```bash
+git clone https://github.com/karned-rekipe/arclith.git
+cd arclith
+uv sync --all-extras
+```
+
+## Vérifier Docker
+
+```bash
+docker version
+docker compose version
+```
+
+Docker est requis pour MongoDB, Redis, Vault, RabbitMQ, OpenTelemetry Collector
+et les tutoriels de déploiement.
+
+## Préparer LM Studio
+
+LM Studio est utile pour les quickstarts MCP et agent avec un modèle local.
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/models
+```
+
+Si la commande échoue, ouvrir LM Studio, charger un modèle, puis activer le
+serveur local OpenAI-compatible.
+
+## Validation
+
+```bash
+arclith-cli version
+uv --version
+docker version
+```
+
+Chaque commande doit répondre sans erreur.
+
+## Erreur Fréquente
+
+`curl: (7) Failed to connect` sur LM Studio signifie que le serveur local n'est
+pas lancé ou n'écoute pas sur `127.0.0.1:1234`.
+
+## Média
+
+!!! note "Média à produire"
+    Capture attendue : terminal avec `arclith-cli version`, `uv --version` et `docker version`.
+    Vidéo attendue : installation de la CLI puis vérification Docker.
+
+## Suite
+
+Lire [Comprendre le modèle](foundations.md).

--- a/docs/learning/training-path.md
+++ b/docs/learning/training-path.md
@@ -8,13 +8,38 @@ Comprendre Arclith en construisant progressivement un service réel.
 
 ## Progression
 
-1. Lire [C'est quoi Arclith ?](../foundations/what-is-arclith.md).
-2. Lire [Le chemin hexagonal](../foundations/hexagonal-flow.md).
-3. Exécuter [Quickstart API](../quickstarts/api.md).
-4. Exécuter [Quickstart MCP](../quickstarts/mcp.md).
-5. Suivre le [parcours Todo](../tutorials/todo-list/index.md).
-6. Ajouter la [baseline production](../production/baseline.md).
-7. Dockeriser avec le [tutoriel Docker](../runtime-docker.md).
+1. préparer l'environnement local;
+2. comprendre les fondations;
+3. exécuter les quickstarts;
+4. construire le service Todo;
+5. ajouter la baseline production;
+6. lancer avec Docker;
+7. lire les approfondissements selon le besoin.
+
+Chaque bloc produit un résultat vérifiable. Ne pas avancer si la validation de
+la page courante échoue.
+
+## Parcours Court
+
+| Étape | Page | Résultat |
+|---|---|---|
+| 1 | [Préparer son poste](setup.md) | CLI, Python et Docker prêts |
+| 2 | [Comprendre le modèle](foundations.md) | vocabulaire commun |
+| 3 | [Quickstarts essentiels](quickstarts.md) | API, MCP, bus et agent lancés |
+| 4 | [Projet Todo](../tutorials/todo-list/index.md) | service complet |
+| 5 | [Validation finale](validation.md) | critères de passage validés |
+
+## Parcours Production
+
+Après le parcours court:
+
+1. appliquer la [baseline production](../production/baseline.md);
+2. lire [Auth](../production/auth.md);
+3. lire [Cache](../production/cache.md);
+4. lire [Secrets et Vault](../production/secrets.md);
+5. lire [Observabilité](../production/observability.md);
+6. lancer le [tutoriel Docker](../runtime-docker.md);
+7. lire [Kubernetes](../runtime-docker/kubernetes.md).
 
 ## Règle De Passage
 
@@ -24,4 +49,8 @@ Ne pas passer à l'étape suivante tant que la validation de la page courante ne
 
 !!! note "Média à produire"
     Vidéo courte : dérouler le parcours complet jusqu'à l'API locale.
-    Capture : navigation du site avec les sections Quickstarts, Foundations, Projects et Production.
+    Capture : navigation du site avec les sections Quickstarts, Foundations, Formation et Production.
+
+## Suite
+
+Commencer par [Préparer son poste](setup.md).

--- a/docs/learning/validation.md
+++ b/docs/learning/validation.md
@@ -1,0 +1,64 @@
+# Validation Finale
+
+Cette page sert de grille de sortie pour un nouvel arrivant.
+
+## Objectif
+
+Valider que la personne sait utiliser Arclith pour créer, exposer, tester et
+opérer un service simple.
+
+## Critères
+
+| Domaine | Attendu |
+|---|---|
+| CLI | créer un projet et ajouter une capability |
+| Métier | écrire une entité et un use case sans dépendance technique |
+| API | exposer un use case via FastAPI |
+| MCP | exposer le même use case via un tool |
+| Agent | brancher un graphe qui appelle le use case |
+| Tests | tester le domaine sans serveur externe |
+| Production | expliquer auth, cache, secrets, observabilité et probes |
+| Docker | builder et lancer un runtime local |
+
+## Exercice
+
+Créer un service minimal avec:
+
+1. une entité;
+2. un use case de création;
+3. un use case de lecture;
+4. une API locale;
+5. un tool MCP;
+6. un repository `memory`;
+7. une validation Docker locale.
+
+## Validation Technique
+
+```bash
+uv run pytest
+curl -fsS http://127.0.0.1:8000/health
+docker build -t arclith-training:local .
+```
+
+Adapter le port HTTP si le projet généré utilise une autre valeur.
+
+## Revue
+
+La revue doit vérifier:
+
+- pas de logique métier dans les routes ou tools;
+- pas de secret versionné;
+- validation d'entrée explicite;
+- erreurs HTTP cohérentes;
+- tests reproductibles;
+- documentation de chaque capability activée.
+
+## Média
+
+!!! note "Média à produire"
+    Capture attendue : résultat des tests, healthcheck API et build Docker.
+    Vidéo attendue : soutenance courte du projet d'exercice.
+
+## Suite
+
+Lire les [deep dives](../deep-dives/api.md) selon le besoin du projet.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,10 @@ nav:
       - Modes runtime: foundations/runtime-modes.md
   - Formation:
       - Parcours: learning/training-path.md
+      - Préparer son poste: learning/setup.md
+      - Comprendre le modèle: learning/foundations.md
+      - Quickstarts essentiels: learning/quickstarts.md
+      - Validation finale: learning/validation.md
       - Format d'une page: learning/page-format.md
   - Tutoriel Todo:
       - Vue d'ensemble: tutorials/todo-list/index.md


### PR DESCRIPTION
## Summary
- add short learning pages for local setup, foundations, essential quickstarts, and final validation
- restructure the training path around small verifiable steps
- expose the new learning pages in the MkDocs navigation

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md || true
- pre-push hooks: ruff, bandit, mypy, pytest --cov --cov-report=term-missing --cov-report=html
