### PR TITLE
docs: add documentation map

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ Le chemin recommandé est simple :
 4. ajouter les capacités de production ;
 5. approfondir seulement quand le besoin apparaît.
 
+Pour choisir directement la bonne page, lire la
+[carte de la documentation](map.md).
+
 ## Démarrer
 
 - [Quickstart API](quickstarts/api.md)
@@ -21,6 +24,7 @@ Le chemin recommandé est simple :
 
 - [C'est quoi Arclith ?](foundations/what-is-arclith.md)
 - [Le chemin hexagonal](foundations/hexagonal-flow.md)
+- [Parcours de formation](learning/training-path.md)
 - [Structure d'une page de formation](learning/page-format.md)
 - [Parcours Todo](tutorials/todo-list/index.md)
 
@@ -32,6 +36,7 @@ Le chemin recommandé est simple :
 
 ## Référence
 
+- [Carte de la documentation](map.md)
 - [Catalogue des capabilities](capabilities.md)
 - [Auth](auth.md)
 - [Command Bus](command-bus.md)

--- a/docs/map.md
+++ b/docs/map.md
@@ -1,0 +1,73 @@
+# Carte De La Documentation
+
+Cette page aide à choisir la bonne entrée dans la documentation Arclith.
+
+## Je Veux Démarrer Vite
+
+| Besoin | Page |
+|---|---|
+| exposer une API | [Quickstart API](quickstarts/api.md) |
+| exposer un serveur MCP | [Quickstart MCP](quickstarts/mcp.md) |
+| publier et consommer des commandes | [Quickstart bus](quickstarts/bus.md) |
+| lancer un agent | [Quickstart agent](quickstarts/agent.md) |
+
+## Je Veux Me Former
+
+| Besoin | Page |
+|---|---|
+| suivre le parcours complet | [Parcours de formation](learning/training-path.md) |
+| préparer le poste | [Préparer son poste](learning/setup.md) |
+| comprendre le modèle hexagonal | [Comprendre le modèle](learning/foundations.md) |
+| construire un projet guidé | [Tutoriel Todo](tutorials/todo-list/index.md) |
+| valider l'autonomie | [Validation finale](learning/validation.md) |
+
+## Je Veux Produire
+
+| Besoin | Page |
+|---|---|
+| config de base prod | [Baseline production](production/baseline.md) |
+| auth JWT et Keycloak | [Auth](production/auth.md) |
+| cache Redis | [Cache](production/cache.md) |
+| secrets et Vault | [Secrets et Vault](production/secrets.md) |
+| traces, métriques et logs | [Observabilité](production/observability.md) |
+| probes et runtime | [Runtime et probes](production/runtime.md) |
+| Docker | [Docker](runtime-docker.md) |
+| Kubernetes | [Kubernetes](runtime-docker/kubernetes.md) |
+
+## Je Veux Comprendre Une Capability
+
+Commencer par le [catalogue des capabilities](capabilities.md), puis ouvrir la
+fiche dédiée:
+
+- [API](capabilities/api.md)
+- [MCP](capabilities/mcp.md)
+- [Agent](capabilities/agent.md)
+- [Command Bus](capabilities/command-bus.md)
+- [Repository](capabilities/repository.md)
+- [Auth](capabilities/auth.md)
+- [Tenant](capabilities/tenant.md)
+- [License](capabilities/license.md)
+- [LLM](capabilities/llm.md)
+
+## Je Veux Approfondir
+
+| Sujet | Page |
+|---|---|
+| API | [Deep dive API](deep-dives/api.md) |
+| MCP | [Deep dive MCP](deep-dives/mcp.md) |
+| Bus | [Deep dive bus](deep-dives/bus.md) |
+| Agent | [Deep dive agent](deep-dives/agent.md) |
+| Configuration | [Deep dive configuration](deep-dives/configuration.md) |
+
+## Je Maintiens Le Projet
+
+| Besoin | Page |
+|---|---|
+| publier une version | [Release](release.md) |
+| décisions techniques | [Décisions](decisions.md) |
+| conventions HTTP historiques | [HTTP](http-conventions.md) |
+| idempotence | [Idempotence](idempotency.md) |
+
+## Suite
+
+Retourner à [l'accueil](index.md) ou au [parcours de formation](learning/training-path.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ extra_css:
 
 nav:
   - Accueil: index.md
+  - Carte: map.md
   - Quickstarts:
       - Vue d'ensemble: quickstarts/index.md
       - API: quickstarts/api.md


### PR DESCRIPTION
## Summary
- add a concise documentation map to orient quickstart, training, production, capabilities, and deep dive readers
- link the map from the homepage
- expose the map in the MkDocs navigation

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md || true
- pre-push hooks: ruff, bandit, mypy, pytest --cov --cov-report=term-missing --cov-report=html
