### PR TITLE
docs: expand api and mcp deep dives

### DIFF
--- a/docs/deep-dives/api.md
+++ b/docs/deep-dives/api.md
@@ -1,21 +1,131 @@
 # Deep Dive API
 
-Cette page regroupe les points à approfondir pour FastAPI.
+Cette page explique comment penser une API FastAPI dans Arclith.
 
-## À Comprendre
+## Position
 
-- création de l'application avec `Arclith.fastapi()` ;
-- injection auth ;
-- conventions HTTP ;
-- middlewares idempotency, ETag et Cache-Control ;
-- séparation route/use case.
+L'API est un adapter inbound. Elle reçoit HTTP, valide le contrat externe, puis
+appelle un port inbound ou un use case.
+
+```text
+HTTP request
+  -> FastAPI route
+  -> schéma d'entrée
+  -> use case
+  -> schéma de sortie
+  -> HTTP response
+```
+
+La route ne contient pas la règle métier. Elle traduit un protocole.
+
+## Création De L'application
+
+```python
+from arclith import Arclith
+
+arclith = Arclith("config")
+app = arclith.fastapi()
+```
+
+`Arclith.fastapi()` applique les conventions transverses disponibles:
+configuration de l'application, middlewares HTTP, instrumentation OpenTelemetry
+si activée, et patch Swagger OAuth2 quand Keycloak est configuré.
+
+## Route Propre
+
+Une route propre fait trois choses:
+
+1. valider l'entrée HTTP;
+2. appeler le use case;
+3. convertir le résultat en réponse HTTP.
+
+```python
+@router.post("/", status_code=201)
+async def create_todo(payload: CreateTodoRequest) -> TodoResponse:
+    command = payload.to_command()
+    todo = await create_todo_use_case.execute(command)
+    return TodoResponse.from_entity(todo)
+```
+
+Le use case ne doit pas recevoir `Request`, `Response`, `Depends`, `HTTPException`
+ou un repository concret.
+
+## Auth Et Licence
+
+```python
+from fastapi import APIRouter, Depends
+
+require_auth = arclith.auth_dependency()
+
+router = APIRouter(
+    prefix="/v1/todos",
+    dependencies=[Depends(require_auth)],
+)
+```
+
+Le pipeline JWT peut aussi vérifier la capability `license` si elle est
+configurée. Une erreur d'authentification donne `401`; une licence manquante
+donne `403`.
+
+## Multitenant
+
+En mode multitenant, brancher la dépendance de résolution tenant sur les routes
+qui accèdent à un repository multitenant. Le tenant vient d'un claim JWT signé,
+puis les coordonnées techniques sont résolues via les resolvers configurés.
+
+Le handler API ne doit pas accepter une URI tenant depuis le client.
+
+## HTTP Transverse
+
+Les concerns HTTP transverses restent dans la capability [HTTP](../capabilities/http.md):
+
+| Concern | Rôle |
+|---|---|
+| idempotence | sécuriser les retries de commandes |
+| ETag | gérer les lectures conditionnelles |
+| Cache-Control | expliciter le comportement de cache client |
+| timing | mesurer la latence des routes |
+
+## Observabilité
+
+Quand les probes sont activées, séparer le port métier du port d'observation.
+
+```python
+arclith.run_with_probes(lambda: arclith.run_api("main:app"), transports=["api"])
+```
+
+Le port API sert `/v1/...`. Le port probe sert `/health`, `/ready`, `/info` et
+`/metrics`.
+
+## Erreurs Fréquentes
+
+| Erreur | Correction |
+|---|---|
+| route qui instancie un repository | injecter un use case déjà câblé |
+| `HTTPException` dans le domaine | lever une erreur métier puis convertir en API |
+| secret dans le schéma de réponse | filtrer dans `TodoResponse.from_entity` |
+| Swagger auth ambigu | vérifier la config Keycloak et `client_id` |
+| healthcheck sur le port API | utiliser le port probe si `run_with_probes` est actif |
+
+## Validation
+
+```bash
+MODE=api uv run python main.py
+curl -fsS http://127.0.0.1:9000/health
+curl -fsS http://127.0.0.1:8000/docs
+uv run pytest
+```
+
+Un test API minimal doit vérifier le statut, le JSON de sortie et l'appel réel
+du use case avec une dépendance de test.
 
 ## Pages Liées
 
-- [api/fastapi](../capabilities/api.md)
-- [auth/keycloak](../capabilities/auth.md)
-- [http](../capabilities/http.md)
+- [Capability API](../capabilities/api.md)
+- [Capability Auth](../capabilities/auth.md)
+- [Capability HTTP](../capabilities/http.md)
 - [Conventions HTTP](../http-conventions.md)
+- [Tutoriel Todo API](../tutorials/todo-list/04-api.md)
 
 ## Média
 

--- a/docs/deep-dives/mcp.md
+++ b/docs/deep-dives/mcp.md
@@ -1,24 +1,119 @@
 # Deep Dive MCP
 
-Cette page regroupe les points à approfondir pour FastMCP.
+Cette page explique comment exposer un service Arclith via MCP.
 
-## À Comprendre
+## Position
 
-- création du serveur avec `Arclith.fastmcp()` ;
-- transport streamable HTTP ;
-- tools MCP ;
-- auth partagée avec l'API ;
-- instrumentation des tools.
+Le MCP est un adapter inbound. Il expose des tools à un client MCP, puis ces
+tools appellent les mêmes use cases que l'API.
+
+```text
+MCP client
+  -> tool FastMCP
+  -> arguments typés
+  -> use case
+  -> réponse sérialisable
+```
+
+Le tool n'est pas un deuxième coeur métier. Il est une façade de protocole.
+
+## Création Du Serveur
+
+```python
+from arclith import Arclith
+
+arclith = Arclith("config")
+mcp = arclith.fastmcp("todo-service")
+```
+
+La configuration `config/adapters/inbound/fastmcp.yaml` définit le host et le
+port du transport HTTP streamable.
+
+## Tool Propre
+
+Un tool propre reçoit des arguments explicites, construit une commande métier,
+appelle le use case, puis retourne un dictionnaire ou un type sérialisable.
+
+```python
+@mcp.tool
+async def create_todo(title: str, due_date: str) -> dict:
+    command = CreateTodoCommand(title=title, due_date=due_date)
+    todo = await create_todo_use_case.execute(command)
+    return {"uuid": str(todo.uuid), "title": todo.title}
+```
+
+Éviter les tools qui font plusieurs intentions à la fois. Un tool doit avoir une
+responsabilité claire.
+
+## Auth
+
+```python
+from fastmcp import Context
+
+require_auth = arclith.auth_dependency(transport="mcp")
+
+@mcp.tool
+async def secure_tool(title: str, ctx: Context) -> dict:
+    claims = await require_auth(ctx)
+    return {"sub": claims.get("sub"), "title": title}
+```
+
+L'auth MCP utilise les headers HTTP disponibles avec le transport HTTP/SSE. En
+transport `stdio`, sécuriser le processus qui lance le serveur plutôt que de
+compter sur des headers absents.
+
+## Multitenant
+
+Le pipeline tenant MCP suit le même principe que l'API: JWT, licence éventuelle,
+claim tenant, résolution des coordonnées, puis contexte de requête.
+
+Utiliser la même convention de claim que l'API pour éviter deux modèles de
+sécurité différents.
+
+## Instrumentation
+
+Appeler l'instrumentation après l'enregistrement des tools:
+
+```python
+arclith.instrument_mcp(mcp)
+```
+
+L'instrumentation enveloppe les fonctions FastMCP et alimente les métriques
+exposées par le serveur de probes.
+
+## Lancement
+
+```python
+arclith.run_with_probes(
+    lambda: arclith.run_mcp_http(mcp),
+    transports=["mcp_http"],
+)
+```
+
+Le transport HTTP streamable écoute par défaut sur
+`http://127.0.0.1:8001/mcp/`.
+
+## Erreurs Fréquentes
+
+| Erreur | Correction |
+|---|---|
+| tool qui accède au repository | appeler un use case |
+| retour non sérialisable | convertir en dict, liste ou type simple |
+| auth testée en `stdio` comme en HTTP | distinguer le modèle de transport |
+| instrumentation appelée trop tôt | appeler `instrument_mcp` après les tools |
+| client sur mauvais chemin | utiliser `/mcp/` avec le slash final |
 
 ## Pages Liées
 
-- [mcp/fastmcp](../capabilities/mcp.md)
-- [auth/keycloak](../capabilities/auth.md)
+- [Capability MCP](../capabilities/mcp.md)
+- [Capability Auth](../capabilities/auth.md)
+- [Capability Probe](../capabilities/probe.md)
 - [Tutoriel Todo MCP](../tutorials/todo-list/05-mcp.md)
 
 ## Validation Protocolaire
 
-Attendre que le terminal serveur affiche l'URL FastMCP, puis tester le protocole avec un client :
+Attendre que le terminal serveur affiche l'URL FastMCP, puis tester le protocole
+avec un client:
 
 ```bash
 uv run python - <<'PY'
@@ -35,6 +130,14 @@ PY
 ```
 
 Si la connexion échoue, vérifier d'abord qu'aucun autre service n'écoute sur `8001`.
+
+Vérifier aussi les probes:
+
+```bash
+curl -fsS http://127.0.0.1:9000/info
+```
+
+`active_transports` doit contenir `mcp_http`.
 
 ## Média
 


### PR DESCRIPTION
## Summary
- expand the API deep dive with request flow, clean route boundaries, auth, multitenant, HTTP middleware, observability, and validation
- expand the MCP deep dive with tool boundaries, auth, multitenant, instrumentation, runtime launch, and protocol validation

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md || true
- pre-push hooks: ruff, bandit, mypy, pytest --cov --cov-report=term-missing --cov-report=html
