### PR TITLE
docs: expand bus agent and configuration deep dives

### DIFF
--- a/docs/deep-dives/agent.md
+++ b/docs/deep-dives/agent.md
@@ -1,21 +1,112 @@
 # Deep Dive Agent
 
-Cette page regroupe les points à approfondir pour LangGraph.
+Cette page explique comment construire un agent Arclith sans casser la frontière
+métier.
 
-## À Comprendre
+## Position
 
-- état du graphe ;
-- nœuds ;
-- transitions ;
-- interpréteur d'intention ;
-- appel des use cases ;
-- traces LangSmith.
+Un agent est un adapter inbound. Il reçoit une intention utilisateur, maintient
+un état, puis appelle les use cases.
+
+```text
+message utilisateur
+  -> graphe LangGraph
+  -> node d'interprétation
+  -> node d'action
+  -> use case Arclith
+  -> réponse agent
+```
+
+Le LLM aide à interpréter. Il ne remplace pas les règles métier.
+
+## État Du Graphe
+
+L'état doit être typé et limité aux informations utiles au parcours.
+
+```python
+class AgentState(TypedDict, total=False):
+    messages: list[dict[str, Any]]
+    intent: str
+    draft: dict[str, Any]
+    created_uuid: str
+```
+
+Éviter un état fourre-tout. Chaque champ doit avoir un producteur et un
+consommateur identifiables.
+
+## Nodes
+
+Un node doit faire une action claire:
+
+| Node | Rôle |
+|---|---|
+| interprétation | classifier ou extraire une intention |
+| validation | vérifier que les champs requis existent |
+| action | appeler un use case |
+| réponse | formater le retour utilisateur |
+
+Un node d'action ne doit pas construire de repository concret.
+
+## LLM
+
+Utiliser le LLM pour les zones incertaines:
+
+- comprendre une demande libre;
+- extraire des champs depuis une phrase;
+- choisir un chemin de graphe;
+- reformuler une réponse.
+
+Éviter le LLM quand une règle déterministe suffit. Une date déjà structurée ou
+un statut connu ne nécessite pas un appel modèle.
+
+## Appel Des Use Cases
+
+```python
+async def create_todo(state: AgentState) -> AgentState:
+    command = CreateTodoCommand(title=state["draft"]["title"])
+    todo = await create_todo_use_case.execute(command)
+    return {**state, "created_uuid": str(todo.uuid)}
+```
+
+Le use case reste la seule couche qui orchestre le métier. L'agent prépare une
+commande, puis délègue.
+
+## Observabilité
+
+Activer LangSmith pour inspecter:
+
+| Signal | Utilité |
+|---|---|
+| messages | comprendre l'entrée utilisateur |
+| choix de route | valider le graphe |
+| appels LLM | suivre coût et latence |
+| erreurs node | diagnostiquer un blocage |
+| sorties use case | vérifier l'action réelle |
+
+## Validation
+
+```bash
+uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
+Tester aussi les nodes sans serveur LangGraph quand c'est possible. Les tests
+unitaires doivent pouvoir utiliser un fake LLM.
+
+## Erreurs Fréquentes
+
+| Erreur | Correction |
+|---|---|
+| prompt qui écrit en base | passer par un use case |
+| état non typé | définir un `TypedDict` explicite |
+| node trop large | découper interprétation, validation et action |
+| test dépendant du réseau | injecter un fake LLM |
+| trace absente | vérifier la config LangSmith et `.env` |
 
 ## Pages Liées
 
-- [agent/langgraph](../capabilities/agent.md)
-- [llm](../capabilities/llm.md)
-- [observability](../capabilities/observability.md)
+- [Capability Agent](../capabilities/agent.md)
+- [Capability LLM](../capabilities/llm.md)
+- [Capability Observability](../capabilities/observability.md)
 - [Tutoriel Todo Agent](../tutorials/todo-list/06-agent.md)
 
 ## Média

--- a/docs/deep-dives/bus.md
+++ b/docs/deep-dives/bus.md
@@ -1,20 +1,127 @@
 # Deep Dive Bus
 
-Cette page regroupe les points à approfondir pour le command bus.
+Cette page explique comment utiliser le command bus sans déplacer le métier dans
+RabbitMQ.
 
-## À Comprendre
+## Position
 
-- `CommandEnvelope` ;
-- `CommandDispatcher` ;
-- `CommandHandler` ;
-- ack manuel ;
-- publisher confirms ;
-- DLX et retry.
+Le bus est un adapter de coordination. Il transporte une intention vers un
+handler applicatif.
+
+```text
+publisher
+  -> CommandEnvelope
+  -> RabbitMQ
+  -> consumer
+  -> CommandDispatcher
+  -> CommandHandler
+  -> use case
+```
+
+Le message ne doit pas contenir une implémentation métier. Il décrit une
+commande.
+
+## Envelope
+
+Une commande doit transporter au minimum:
+
+| Champ | Rôle |
+|---|---|
+| `command_type` | nom stable de la commande |
+| `payload` | données de la commande |
+| `correlation_id` | suivi bout en bout |
+| `traceparent` | propagation OpenTelemetry si disponible |
+
+Le `command_type` doit être versionnable si le contrat peut changer.
+
+## Publisher
+
+```python
+await bus.publish(
+    "todo.create",
+    {"title": "Documenter le bus"},
+    correlation_id="todo-doc-1",
+)
+```
+
+Le publisher doit rester proche de l'événement applicatif qui déclenche la
+commande. Il ne doit pas connaître le handler consommateur.
+
+## Consumer
+
+```python
+dispatcher = CommandDispatcher()
+dispatcher.register("todo.create", CreateTodoCommandHandler(create_todo_use_case))
+
+app.run_command_bus(dispatcher)
+```
+
+Le handler transforme l'envelope en commande métier, puis appelle le use case.
+
+## Ack Et Retry
+
+| Situation | Comportement attendu |
+|---|---|
+| dispatch réussi | `ack` |
+| payload invalide | `nack(requeue=False)` |
+| erreur temporaire | retry borné |
+| erreur persistante | DLX |
+| shutdown | ne pas perdre les messages en cours |
+
+Éviter le requeue infini. Une DLX doit permettre d'inspecter les messages qui
+échouent durablement.
+
+## Idempotence
+
+Un consumer peut recevoir une commande plusieurs fois. Le handler doit donc
+supporter les retries:
+
+- clé idempotente dans le payload ou les métadonnées;
+- use case tolérant aux doublons;
+- logs corrélés avec `correlation_id`;
+- métrique d'échec exploitable.
+
+## Observabilité
+
+Suivre au minimum:
+
+| Signal | Utilité |
+|---|---|
+| message publié | vérifier la sortie |
+| message consommé | vérifier l'entrée worker |
+| durée handler | repérer les blocages |
+| nack | diagnostiquer les erreurs |
+| DLX | traiter les messages bloqués |
+
+## Validation Locale
+
+```bash
+docker run --rm -d --name arclith-rabbitmq \
+  -p 5672:5672 -p 15672:15672 \
+  rabbitmq:4-management
+
+uv run pytest
+docker stop arclith-rabbitmq
+```
+
+Pour un test d'intégration manuel, publier une commande, vérifier que le handler
+s'exécute, puis inspecter RabbitMQ Management sur `http://127.0.0.1:15672`.
+
+## Erreurs Fréquentes
+
+| Erreur | Correction |
+|---|---|
+| payload sans version | versionner le `command_type` ou le schéma |
+| handler non idempotent | ajouter une clé de déduplication |
+| retry infini | configurer DLX et alerte |
+| secret dans le payload | passer par la capability `secrets` |
+| queue trop permissive | régler `prefetch` et `concurrency` |
 
 ## Pages Liées
 
-- [command-bus/rabbitmq](../capabilities/command-bus.md)
+- [Capability Command Bus](../capabilities/command-bus.md)
 - [Command Bus RabbitMQ](../command-bus.md)
+- [Capability Observability](../capabilities/observability.md)
 
 ## Média
 

--- a/docs/deep-dives/configuration.md
+++ b/docs/deep-dives/configuration.md
@@ -1,19 +1,105 @@
 # Deep Dive Configuration
 
-Cette page regroupe les points à approfondir pour la configuration.
+Cette page explique comment organiser la configuration Arclith.
 
-## À Comprendre
+## Position
 
-- fichiers `config/` ;
-- chargement par `Arclith("config")` ;
-- secrets ;
-- overrides runtime ;
-- configuration par environnement.
+La configuration décrit les adapters actifs et leurs paramètres. Elle ne doit
+pas contenir de vraie valeur secrète.
+
+```text
+config/
+  app.yaml
+  adapters/
+    inbound/
+    outbound/
+  command_bus.yaml
+```
+
+`Arclith("config")` charge ces fichiers, applique les mappings de secrets, puis
+construit `AppConfig`.
+
+## Fichiers Par Capability
+
+Chaque capability possède son propre fichier quand c'est pertinent:
+
+| Capability | Exemple |
+|---|---|
+| API | `config/adapters/inbound/fastapi.yaml` |
+| MCP | `config/adapters/inbound/fastmcp.yaml` |
+| Agent | `config/adapters/inbound/langgraph.yaml` |
+| Repository | `config/adapters/outbound/mongodb.yaml` |
+| LLM | `config/adapters/outbound/lm.yaml` |
+| Command Bus | `config/command_bus.yaml` |
+
+Ce découpage garde les changements lisibles en revue de code.
+
+## Secrets
+
+Un fichier versionné peut déclarer qu'une valeur est fournie par l'environnement
+ou par Vault, mais ne doit pas contenir la vraie valeur.
+
+```yaml
+# config/secrets.yaml
+provider: env
+```
+
+Les mappings de secret permettent de remplir des champs comme
+`adapters.lm.api_key` depuis `OPENAI_API_KEY` ou `ANTHROPIC_API_KEY`.
+
+## Environnements
+
+Garder la même structure entre local, staging et production. Les différences
+doivent porter sur les valeurs, pas sur l'architecture.
+
+| Environnement | Exemple |
+|---|---|
+| local | memory, LM Studio, Redis local |
+| staging | services managés ou namespace dédié |
+| production | Vault, Redis HA, observabilité complète |
+
+## Overrides
+
+Utiliser les overrides pour adapter le runtime sans modifier le coeur du projet:
+
+- port API;
+- URL d'un service externe;
+- provider de secrets;
+- endpoint LLM;
+- flags d'observabilité.
+
+Les overrides ne doivent pas servir à contourner une capability manquante.
+
+## Validation
+
+```bash
+uv run python - <<'PY'
+from arclith import Arclith
+
+app = Arclith("config")
+print(app.config.app.name)
+print(app.config.adapters)
+PY
+```
+
+La validation doit échouer tôt si un secret requis manque ou si un adapter est
+mal configuré.
+
+## Erreurs Fréquentes
+
+| Erreur | Correction |
+|---|---|
+| vraie clé API dans YAML | utiliser `secrets.yaml` et `.env` |
+| config différente par environnement | garder la même structure |
+| fichier géant | découper par capability |
+| valeur par défaut dangereuse | expliciter la valeur de production |
+| doc oubliée après ajout capability | documenter la capability dans la même PR |
 
 ## Pages Liées
 
-- [secrets](../capabilities/secrets.md)
-- [tenant](../capabilities/tenant.md)
+- [Capability Secrets](../capabilities/secrets.md)
+- [Capability Tenant](../capabilities/tenant.md)
+- [Capability LLM](../capabilities/llm.md)
 - [Baseline production](../production/baseline.md)
 
 ## Média


### PR DESCRIPTION
## Summary
- expand the command bus deep dive with envelope, publisher, consumer, ack/retry, idempotence, observability, and validation guidance
- expand the agent deep dive with graph state, node boundaries, LLM usage, use case calls, observability, and validation guidance
- expand the configuration deep dive with config layout, secrets, environments, overrides, and validation guidance

## Validation
- make docs
- git diff --check
- rg -n "Wiki|wiki|oauth2-troubleshooting" README.md docs mkdocs.yml AGENTS.md || true
- pre-push hooks: ruff, bandit, mypy, pytest --cov --cov-report=term-missing --cov-report=html
