### PR TITLE
feat: add storage capability foundation

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -9,6 +9,19 @@ from arclith.arclith import Arclith
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.inbound.command_bus import CommandHandler
 from arclith.domain.ports.outbound.command_bus import CommandPublisher
+from arclith.domain.ports.outbound.file_storage import (
+    FileStorageConflict,
+    FileStorageError,
+    FileStorageInvalidKey,
+    FileStorageNotFound,
+    FileStoragePermissionDenied,
+    FileStoragePort,
+    FileStorageUnavailable,
+    StoredObject,
+    StoredObjectMetadata,
+    StoredObjectStream,
+    normalize_storage_key,
+)
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.adapter_registry import AdapterRegistry
@@ -22,6 +35,17 @@ if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
 __all__ = [
     "Entity",
     "Repository",
+    "FileStoragePort",
+    "StoredObject",
+    "StoredObjectMetadata",
+    "StoredObjectStream",
+    "FileStorageError",
+    "FileStorageInvalidKey",
+    "FileStorageNotFound",
+    "FileStorageConflict",
+    "FileStorageUnavailable",
+    "FileStoragePermissionDenied",
+    "normalize_storage_key",
     "Logger",
     "LogLevel",
     "BaseService",

--- a/arclith/domain/ports/outbound/file_storage.py
+++ b/arclith/domain/ports/outbound/file_storage.py
@@ -1,0 +1,120 @@
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import PurePosixPath
+from types import MappingProxyType
+
+
+class FileStorageError(Exception):
+    """Base error for file storage adapters."""
+
+    def __init__(self, message: str, *, key: str | None = None) -> None:
+        super().__init__(message)
+        self.key = key
+
+
+class FileStorageInvalidKey(FileStorageError):
+    """Raised when an object key is empty, absolute, or attempts traversal."""
+
+
+class FileStorageNotFound(FileStorageError):
+    """Raised when an object does not exist."""
+
+
+class FileStorageConflict(FileStorageError):
+    """Raised when an object write conflicts with backend state."""
+
+
+class FileStorageUnavailable(FileStorageError):
+    """Raised when the backend is unavailable."""
+
+
+class FileStoragePermissionDenied(FileStorageError):
+    """Raised when credentials or backend policy reject the operation."""
+
+
+@dataclass(frozen=True)
+class StoredObjectMetadata:
+    """Provider-neutral object metadata returned by storage adapters."""
+
+    key: str
+    content_type: str | None = None
+    size: int | None = None
+    checksum: str | None = None
+    etag: str | None = None
+    last_modified: datetime | None = None
+    custom: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "custom", MappingProxyType(dict(self.custom)))
+
+
+@dataclass(frozen=True)
+class StoredObject(StoredObjectMetadata):
+    """Metadata returned after a successful write."""
+
+
+@dataclass(frozen=True)
+class StoredObjectStream:
+    """Object metadata plus an async byte stream."""
+
+    metadata: StoredObjectMetadata
+    body: AsyncIterator[bytes]
+
+
+def normalize_storage_key(key: str) -> str:
+    """Validate and return a relative POSIX object key."""
+    if not key:
+        raise FileStorageInvalidKey("storage key must not be empty", key=key)
+    if key != key.strip():
+        raise FileStorageInvalidKey("storage key must not contain surrounding whitespace", key=key)
+    if "\\" in key:
+        raise FileStorageInvalidKey("storage key must use POSIX '/' separators", key=key)
+    if key.startswith("/") or key.endswith("/") or "//" in key:
+        raise FileStorageInvalidKey("storage key must be a normalized relative path", key=key)
+
+    parts = key.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise FileStorageInvalidKey("storage key must not contain empty, '.', or '..' segments", key=key)
+
+    normalized = PurePosixPath(key).as_posix()
+    if normalized != key:
+        raise FileStorageInvalidKey("storage key must already be normalized", key=key)
+    return normalized
+
+
+class FileStoragePort(ABC):
+    """Outbound port for binary object storage."""
+
+    @abstractmethod
+    async def put(
+        self,
+        key: str,
+        content: AsyncIterator[bytes],
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> StoredObject:
+        """Store object content and return provider-neutral metadata."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def get(self, key: str) -> StoredObjectStream:
+        """Return object metadata and an async byte stream."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Delete an object if the backend accepts the operation."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        """Return whether an object exists."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def stat(self, key: str) -> StoredObjectMetadata:
+        """Return metadata without downloading object content."""
+        pass  # pragma: no cover

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -6,6 +6,8 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from arclith.domain.ports.outbound.file_storage import FileStorageInvalidKey, normalize_storage_key
+
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
 
 
@@ -124,6 +126,57 @@ class LangGraphSettings(BaseModel):
     env: str = ".env"
 
 
+StorageAdapter = Literal["filesystem", "s3", "azure-blob", "gcs"]
+
+
+class StorageSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter: StorageAdapter
+    prefix: str = ""
+    multitenant: bool = False
+    root_path: str | None = None
+    create_root: bool = True
+    bucket_name: str | None = None
+    region_name: str | None = None
+    endpoint_url: str | None = None
+    force_path_style: bool = False
+    account_url: str | None = None
+    container_name: str | None = None
+    project_id: str | None = None
+
+    @field_validator("prefix")
+    @classmethod
+    def must_be_valid_prefix(cls, v: str) -> str:
+        if not v:
+            return v
+        try:
+            return normalize_storage_key(v)
+        except FileStorageInvalidKey as e:
+            raise ValueError(str(e)) from e
+
+    @model_validator(mode="after")
+    def validate_selected_adapter_fields(self) -> "StorageSettings":
+        if self.multitenant:
+            return self
+
+        required_fields_by_adapter: dict[StorageAdapter, tuple[str, ...]] = {
+            "filesystem": ("root_path",),
+            "s3": ("bucket_name",),
+            "azure-blob": ("account_url", "container_name"),
+            "gcs": ("bucket_name",),
+        }
+        missing = [
+            field_name
+            for field_name in required_fields_by_adapter[self.adapter]
+            if not getattr(self, field_name)
+        ]
+        if missing:
+            joined = ", ".join(missing)
+            raise ValueError(f"storage adapter {self.adapter} requires: {joined}")
+        return self
+
+
 _REPOSITORY_CONFIG_SECTIONS: dict[str, str] = {
     "mongodb": "mongodb",
     "duckdb": "duckdb",
@@ -154,6 +207,7 @@ class AdaptersSettings(BaseModel):
     mongodb: MongoDBSettings | None = None
     duckdb: DuckDBSettings | None = None
     mariadb: MariaDBSettings | None = None
+    storage: StorageSettings | None = None
     lm: LMSettings | None = None
     langsmith: LangSmithSettings | None = None
     opentelemetry: OpenTelemetrySettings | None = None

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -287,6 +287,193 @@ multitenant: false
     ),
 )
 
+STORAGE_CAPABILITY = CapabilitySpec(
+    name="storage",
+    layer="outbound",
+    description="Stockage de fichiers et blobs derrière un port FileStoragePort.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="filesystem",
+            capability="storage",
+            layer="outbound",
+            description="Stockage fichier local, typiquement monté dans Docker via un volume.",
+            config_path="config/adapters/outbound/storage.yaml",
+            config_template="""\
+adapter: filesystem
+root_path: "{root_path}"
+prefix: "{prefix}"
+create_root: {create_root}
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="root_path",
+                    kind="string",
+                    prompt="Chemin conteneur du dossier de fichiers",
+                    default="/data/files",
+                ),
+                ParameterSpec(
+                    name="prefix",
+                    kind="string",
+                    prompt="Préfixe d'objets",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="create_root",
+                    kind="boolean",
+                    prompt="Créer le dossier racine au démarrage",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Résoudre le stockage par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+        AdapterSpec(
+            name="s3",
+            capability="storage",
+            layer="outbound",
+            description="Stockage objet AWS S3 compatible MinIO via endpoint custom.",
+            config_path="config/adapters/outbound/storage.yaml",
+            config_template="""\
+adapter: s3
+bucket_name: "{bucket_name}"
+prefix: "{prefix}"
+region_name: "{region_name}"
+endpoint_url: {endpoint_url}
+force_path_style: {force_path_style}
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="bucket_name",
+                    kind="string",
+                    prompt="Bucket S3",
+                    default="my-bucket",
+                ),
+                ParameterSpec(
+                    name="prefix",
+                    kind="string",
+                    prompt="Préfixe d'objets",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="region_name",
+                    kind="string",
+                    prompt="Région AWS",
+                    default="eu-west-3",
+                ),
+                ParameterSpec(
+                    name="endpoint_url",
+                    kind="string",
+                    prompt="Endpoint S3 custom ou null",
+                    default="null",
+                ),
+                ParameterSpec(
+                    name="force_path_style",
+                    kind="boolean",
+                    prompt="Forcer le path-style S3",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Résoudre le stockage par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+        AdapterSpec(
+            name="azure-blob",
+            capability="storage",
+            layer="outbound",
+            description="Stockage objet Azure Blob Storage.",
+            config_path="config/adapters/outbound/storage.yaml",
+            config_template="""\
+adapter: azure-blob
+account_url: "{account_url}"
+container_name: "{container_name}"
+prefix: "{prefix}"
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="account_url",
+                    kind="string",
+                    prompt="URL du compte Azure Blob",
+                    default="https://<account>.blob.core.windows.net",
+                ),
+                ParameterSpec(
+                    name="container_name",
+                    kind="string",
+                    prompt="Container Azure Blob",
+                    default="my-container",
+                ),
+                ParameterSpec(
+                    name="prefix",
+                    kind="string",
+                    prompt="Préfixe d'objets",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Résoudre le stockage par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+        AdapterSpec(
+            name="gcs",
+            capability="storage",
+            layer="outbound",
+            description="Stockage objet Google Cloud Storage.",
+            config_path="config/adapters/outbound/storage.yaml",
+            config_template="""\
+adapter: gcs
+bucket_name: "{bucket_name}"
+prefix: "{prefix}"
+project_id: {project_id}
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="bucket_name",
+                    kind="string",
+                    prompt="Bucket Google Cloud Storage",
+                    default="my-bucket",
+                ),
+                ParameterSpec(
+                    name="prefix",
+                    kind="string",
+                    prompt="Préfixe d'objets",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="project_id",
+                    kind="string",
+                    prompt="Project ID GCP ou null",
+                    default="null",
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Résoudre le stockage par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
 CACHE_CAPABILITY = CapabilitySpec(
     name="cache",
     layer="outbound",
@@ -1478,6 +1665,7 @@ OTEL_EXPORTER_OTLP_HEADERS={headers}
 
 CAPABILITY_CATALOG = (
     REPOSITORY_CAPABILITY,
+    STORAGE_CAPABILITY,
     CACHE_CAPABILITY,
     LOGGER_CAPABILITY,
     SECRETS_CAPABILITY,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -868,6 +868,113 @@ def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> No
     assert arclith.config.adapters.lm.base_url == "http://127.0.0.1:1234/v1"
 
 
+@pytest.mark.parametrize(
+    ("adapter", "params", "expected"),
+    [
+        (
+            "filesystem",
+            {
+                "root_path": "/data/files",
+                "prefix": "uploads",
+                "create_root": "true",
+                "multitenant": "false",
+            },
+            {
+                "adapter": "filesystem",
+                "root_path": "/data/files",
+                "prefix": "uploads",
+                "create_root": True,
+                "multitenant": False,
+            },
+        ),
+        (
+            "s3",
+            {
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "region_name": "eu-west-3",
+                "endpoint_url": "null",
+                "force_path_style": "false",
+                "multitenant": "false",
+            },
+            {
+                "adapter": "s3",
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "region_name": "eu-west-3",
+                "endpoint_url": None,
+                "force_path_style": False,
+                "multitenant": False,
+            },
+        ),
+        (
+            "azure-blob",
+            {
+                "account_url": "https://account.blob.core.windows.net",
+                "container_name": "arclith-files",
+                "prefix": "uploads",
+                "multitenant": "false",
+            },
+            {
+                "adapter": "azure-blob",
+                "account_url": "https://account.blob.core.windows.net",
+                "container_name": "arclith-files",
+                "prefix": "uploads",
+                "multitenant": False,
+            },
+        ),
+        (
+            "gcs",
+            {
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "project_id": "null",
+                "multitenant": "false",
+            },
+            {
+                "adapter": "gcs",
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "project_id": None,
+                "multitenant": False,
+            },
+        ),
+    ],
+)
+def test_add_storage_adapter_generates_loadable_config_only(
+    tmp_path: Path,
+    adapter: str,
+    params: dict[str, str],
+    expected: dict[str, object],
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config" / "adapters" / "outbound" / "storage.yaml"
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="storage",
+        adapter=adapter,
+        adapter_params=params,
+        yes=True,
+    )
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert config == expected
+    assert "storage:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    )
+    package_root = project_dir / "src" / "demo_service"
+    assert not (package_root / "adapters" / "outbound" / adapter).exists()
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.storage is not None
+    assert arclith.config.adapters.storage.adapter == adapter
+    assert arclith.config.adapters.storage.prefix == "uploads"
+
+
 def test_add_openai_llm_adapter_generates_secret_mapping(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -432,6 +432,56 @@ def test_repository_adapter_specs_include_config_and_parameters() -> None:
     ]
 
 
+def test_storage_capability_catalog_declares_object_storage_adapters() -> None:
+    capability = get_capability("storage")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("filesystem", "s3", "azure-blob", "gcs")
+
+    filesystem = capability.get_adapter("filesystem")
+    s3 = capability.get_adapter("s3")
+    azure_blob = capability.get_adapter("azure-blob")
+    gcs = capability.get_adapter("gcs")
+
+    assert filesystem is not None
+    assert filesystem.config_path == "config/adapters/outbound/storage.yaml"
+    assert filesystem.entity_scoped is False
+    assert [parameter.name for parameter in filesystem.parameters] == [
+        "root_path",
+        "prefix",
+        "create_root",
+        "multitenant",
+    ]
+    assert s3 is not None
+    assert s3.config_path == "config/adapters/outbound/storage.yaml"
+    assert [parameter.name for parameter in s3.parameters] == [
+        "bucket_name",
+        "prefix",
+        "region_name",
+        "endpoint_url",
+        "force_path_style",
+        "multitenant",
+    ]
+    assert azure_blob is not None
+    assert azure_blob.config_path == "config/adapters/outbound/storage.yaml"
+    assert [parameter.name for parameter in azure_blob.parameters] == [
+        "account_url",
+        "container_name",
+        "prefix",
+        "multitenant",
+    ]
+    assert gcs is not None
+    assert gcs.config_path == "config/adapters/outbound/storage.yaml"
+    assert [parameter.name for parameter in gcs.parameters] == [
+        "bucket_name",
+        "prefix",
+        "project_id",
+        "multitenant",
+    ]
+
+
 def test_capability_catalog_is_json_serializable() -> None:
     payload = capability_catalog_as_dict()
 
@@ -439,6 +489,10 @@ def test_capability_catalog_is_json_serializable() -> None:
 
     assert "repository" in encoded
     assert "mongodb" in encoded
+    assert "storage" in encoded
+    assert "filesystem" in encoded
+    assert "azure-blob" in encoded
+    assert "gcs" in encoded
     assert "cache" in encoded
     assert "redis" in encoded
     assert "logger" in encoded
@@ -500,6 +554,34 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [mapping["secret_key"] for mapping in mariadb["secret_mappings"]] == [
         "MARIADB_URL",
         "MARIADB_PASSWORD",
+    ]
+    storage = payload_by_name["storage"]
+    assert storage["layer"] == "outbound"
+    assert storage["activation_config_key"] is None
+    assert [adapter["name"] for adapter in storage["adapters"]] == [
+        "filesystem",
+        "s3",
+        "azure-blob",
+        "gcs",
+    ]
+    filesystem = storage["adapters"][0]
+    assert filesystem["config_path"] == "config/adapters/outbound/storage.yaml"
+    assert filesystem["entity_scoped"] is False
+    assert [parameter["name"] for parameter in filesystem["parameters"]] == [
+        "root_path",
+        "prefix",
+        "create_root",
+        "multitenant",
+    ]
+    s3 = storage["adapters"][1]
+    assert s3["config_path"] == "config/adapters/outbound/storage.yaml"
+    assert [parameter["name"] for parameter in s3["parameters"]] == [
+        "bucket_name",
+        "prefix",
+        "region_name",
+        "endpoint_url",
+        "force_path_style",
+        "multitenant",
     ]
     cache = payload_by_name["cache"]
     assert [adapter["name"] for adapter in cache["adapters"]] == ["memory", "redis"]

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -25,6 +25,7 @@ arclith-cli capabilities --json
 | [probe](capabilities/probe.md) | inbound | `server` | exposer `/health` et `/ready` |
 | [http](capabilities/http.md) | inbound | `idempotency`, `etag`, `cache-control` | durcir les conventions HTTP |
 | [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb` | persister les entités |
+| [storage](capabilities/storage.md) | outbound | `filesystem`, `s3`, `azure-blob`, `gcs` | stocker fichiers et blobs |
 | [cache](capabilities/cache.md) | outbound | `memory`, `redis` | partager JWKS, tenants et idempotence |
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |
 | [secrets](capabilities/secrets.md) | outbound | `env`, `yaml`, `vault`, `chain` | résoudre les secrets |
@@ -41,6 +42,7 @@ arclith-cli capabilities --json
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
 | Agent local | [Quickstart Agent](quickstarts/agent.md), puis [agent/langgraph](capabilities/agent.md) |
+| Fichiers et blobs | [storage](capabilities/storage.md), puis [secrets](capabilities/secrets.md) pour les credentials |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |
 | Déploiement | [Runtime Docker](runtime-docker.md), puis [Docker Compose](runtime-docker/docker-compose.md) |
 

--- a/docs/capabilities/storage.md
+++ b/docs/capabilities/storage.md
@@ -1,0 +1,181 @@
+# Capability Storage
+
+Stockage de fichiers et blobs derrière un port `FileStoragePort`.
+
+## Objectif
+
+`storage` est une capability outbound distincte de `repository`.
+
+- `repository` persiste les entités métier.
+- `storage` persiste des contenus binaires: documents, exports, images, archives.
+
+Le domaine dépend du port `FileStoragePort`; l'adapter concret reste dans
+l'infrastructure et la configuration.
+
+## Contrat Commun
+
+Le port expose cinq opérations:
+
+| Méthode | Rôle |
+|---|---|
+| `put(key, content, ...)` | écrire un flux de bytes |
+| `get(key)` | lire les métadonnées et le flux |
+| `delete(key)` | supprimer un objet |
+| `exists(key)` | tester l'existence |
+| `stat(key)` | lire les métadonnées sans télécharger le contenu |
+
+Les modèles provider-neutral sont:
+
+- `StoredObjectMetadata`: clé, type MIME, taille, checksum, ETag,
+  date de modification et métadonnées custom;
+- `StoredObject`: métadonnées retournées après écriture;
+- `StoredObjectStream`: métadonnées plus flux async de bytes.
+
+## Clés D'objets
+
+Une clé de stockage est un chemin POSIX relatif. Elle ne doit jamais dépendre
+d'un chemin absolu local ou d'une URL provider.
+
+Exemples valides:
+
+```text
+tenant-a/invoices/2026-08.pdf
+exports/monthly/report.parquet
+avatars/user-123.png
+```
+
+Exemples refusés:
+
+```text
+/absolute/file.txt
+../private/file.txt
+folder/../file.txt
+folder//file.txt
+folder\file.txt
+```
+
+Utiliser `normalize_storage_key()` avant de joindre une clé avec un chemin local
+ou un préfixe backend. Cette règle protège les adapters filesystem contre la
+traversée de dossiers et garde les adapters cloud interchangeables.
+
+## Erreurs Communes
+
+Tous les adapters storage doivent traduire leurs erreurs provider vers ces
+exceptions:
+
+| Erreur | Usage |
+|---|---|
+| `FileStorageInvalidKey` | clé vide, absolue, non normalisée ou avec traversée |
+| `FileStorageNotFound` | objet absent |
+| `FileStorageConflict` | conflit d'écriture ou condition backend non satisfaite |
+| `FileStorageUnavailable` | backend indisponible |
+| `FileStoragePermissionDenied` | credentials ou policy refusés |
+
+Chaque erreur peut porter `key` pour aider les logs, sans exposer de secret.
+
+## Installer
+
+```bash
+arclith-cli add-adapter --capability storage --adapter filesystem --yes
+arclith-cli add-adapter --capability storage --adapter s3 --yes
+arclith-cli add-adapter --capability storage --adapter azure-blob --yes
+arclith-cli add-adapter --capability storage --adapter gcs --yes
+```
+
+Cette capability génère uniquement `config/adapters/outbound/storage.yaml`.
+Elle ne modifie pas `config/adapters/adapters.yaml`, car il n'y a pas de
+sélecteur repository à activer.
+
+## Filesystem
+
+Adapter cible pour un dossier monté dans Docker via volume.
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: filesystem
+root_path: "/data/files"
+prefix: ""
+create_root: true
+multitenant: false
+```
+
+Monter `/data/files` sur un volume persistant dans Docker ou Kubernetes.
+`prefix` reste relatif à `root_path`.
+
+## AWS S3
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: s3
+bucket_name: "my-bucket"
+prefix: ""
+region_name: "eu-west-3"
+endpoint_url: null
+force_path_style: false
+multitenant: false
+```
+
+`endpoint_url` permet de viser un backend compatible S3 comme MinIO.
+Les credentials AWS doivent venir de l'environnement, d'un secret manager ou de
+la capability [secrets](secrets.md).
+
+## Azure Blob
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: azure-blob
+account_url: "https://<account>.blob.core.windows.net"
+container_name: "my-container"
+prefix: ""
+multitenant: false
+```
+
+Les credentials Azure ne doivent pas être versionnés dans ce fichier.
+
+## Google Cloud Storage
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: gcs
+bucket_name: "my-bucket"
+prefix: ""
+project_id: null
+multitenant: false
+```
+
+`project_id: null` laisse le SDK ou l'environnement résoudre le projet courant.
+
+## Multitenant
+
+En mode single-tenant, la configuration doit contenir la cible backend minimale:
+
+| Adapter | Champs requis |
+|---|---|
+| `filesystem` | `root_path` |
+| `s3` | `bucket_name` |
+| `azure-blob` | `account_url`, `container_name` |
+| `gcs` | `bucket_name` |
+
+En mode `multitenant: true`, l'adapter peut résoudre bucket, container ou
+racine filesystem depuis le contexte tenant. Le contrat reste le même pour les
+use cases.
+
+## Règles
+
+- Les use cases parlent au port `FileStoragePort`, jamais au SDK cloud.
+- Les clés sont toujours relatives, normalisées et sans traversée.
+- Les streams restent async pour éviter de charger les gros fichiers en mémoire.
+- Les secrets provider ne sont pas stockés dans `storage.yaml`.
+- Les adapters concrets traduisent leurs erreurs vers les exceptions communes.
+
+## Validation
+
+```bash
+uv run pytest
+uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+```
+
+## Suite
+
+Ajouter ensuite l'adapter concret voulu: filesystem, Azure Blob, Google Cloud
+Storage ou AWS S3.

--- a/docs/deep-dives/configuration.md
+++ b/docs/deep-dives/configuration.md
@@ -29,6 +29,7 @@ Chaque capability possède son propre fichier quand c'est pertinent:
 | MCP | `config/adapters/inbound/fastmcp.yaml` |
 | Agent | `config/adapters/inbound/langgraph.yaml` |
 | Repository | `config/adapters/outbound/mongodb.yaml` |
+| Storage | `config/adapters/outbound/storage.yaml` |
 | LLM | `config/adapters/outbound/lm.yaml` |
 | Command Bus | `config/command_bus.yaml` |
 
@@ -99,6 +100,7 @@ mal configuré.
 
 - [Capability Secrets](../capabilities/secrets.md)
 - [Capability Tenant](../capabilities/tenant.md)
+- [Capability Storage](../capabilities/storage.md)
 - [Capability LLM](../capabilities/llm.md)
 - [Baseline production](../production/baseline.md)
 

--- a/docs/map.md
+++ b/docs/map.md
@@ -44,6 +44,7 @@ fiche dédiée:
 - [Agent](capabilities/agent.md)
 - [Command Bus](capabilities/command-bus.md)
 - [Repository](capabilities/repository.md)
+- [Storage](capabilities/storage.md)
 - [Auth](capabilities/auth.md)
 - [Tenant](capabilities/tenant.md)
 - [License](capabilities/license.md)

--- a/docs/production/baseline.md
+++ b/docs/production/baseline.md
@@ -12,6 +12,7 @@ Cette page donne la configuration de base à viser pour un service Arclith de pr
 | Secrets | [secrets/vault](../capabilities/secrets.md) ou [secrets/chain](../capabilities/secrets.md) |
 | Cache partagé | [cache/redis](../capabilities/cache.md) |
 | Repository | [repository/mongodb](../capabilities/repository.md) ou [repository/mariadb](../capabilities/repository.md) |
+| Fichiers et blobs | [storage](../capabilities/storage.md), si le service manipule des fichiers |
 | Probes | [probe/server](../capabilities/probe.md) |
 | Observabilité | [observability/opentelemetry](../capabilities/observability.md) |
 | Runtime | [runtime/docker-image](../capabilities/runtime.md) |
@@ -44,6 +45,7 @@ arclith-cli add-adapter --capability runtime --adapter docker-image --yes
 
 - Aucun secret réel dans Git.
 - `cache/redis` dès qu'il y a plusieurs workers, réplicas ou processus.
+- `storage` dès qu'un fichier doit survivre au processus ou être partagé entre replicas.
 - `probe/server` obligatoire avant Docker ou Kubernetes.
 - Les adapters inbound appellent les use cases, jamais les repositories concrets.
 - L'image Docker reçoit les secrets au runtime, jamais au build.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Probe: capabilities/probe.md
       - Runtime: capabilities/runtime.md
       - Repository: capabilities/repository.md
+      - Storage: capabilities/storage.md
       - Cache: capabilities/cache.md
       - Logger: capabilities/logger.md
       - Secrets: capabilities/secrets.md

--- a/tests/units/domain/ports/test_file_storage.py
+++ b/tests/units/domain/ports/test_file_storage.py
@@ -1,0 +1,150 @@
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+
+import pytest
+
+from arclith.domain.ports.outbound.file_storage import (
+    FileStorageInvalidKey,
+    FileStorageNotFound,
+    FileStoragePort,
+    StoredObject,
+    StoredObjectMetadata,
+    StoredObjectStream,
+    normalize_storage_key,
+)
+
+
+async def _chunks(*items: bytes) -> AsyncIterator[bytes]:
+    for item in items:
+        yield item
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> bytes:
+    body = bytearray()
+    async for chunk in stream:
+        body.extend(chunk)
+    return bytes(body)
+
+
+@dataclass(frozen=True)
+class _StoredPayload:
+    body: bytes
+    metadata: StoredObjectMetadata
+
+
+class InMemoryFileStorage(FileStoragePort):
+    def __init__(self) -> None:
+        self._objects: dict[str, _StoredPayload] = {}
+
+    async def put(
+        self,
+        key: str,
+        content: AsyncIterator[bytes],
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> StoredObject:
+        normalized_key = normalize_storage_key(key)
+        body = await _collect(content)
+        object_metadata = StoredObjectMetadata(
+            key=normalized_key,
+            content_type=content_type,
+            size=len(body),
+            custom=dict(metadata or {}),
+        )
+        self._objects[normalized_key] = _StoredPayload(body=body, metadata=object_metadata)
+        return StoredObject(
+            key=object_metadata.key,
+            content_type=object_metadata.content_type,
+            size=object_metadata.size,
+            custom=object_metadata.custom,
+        )
+
+    async def get(self, key: str) -> StoredObjectStream:
+        payload = self._payload_for(key)
+        return StoredObjectStream(metadata=payload.metadata, body=_chunks(payload.body))
+
+    async def delete(self, key: str) -> None:
+        normalized_key = normalize_storage_key(key)
+        self._objects.pop(normalized_key, None)
+
+    async def exists(self, key: str) -> bool:
+        return normalize_storage_key(key) in self._objects
+
+    async def stat(self, key: str) -> StoredObjectMetadata:
+        return self._payload_for(key).metadata
+
+    def _payload_for(self, key: str) -> _StoredPayload:
+        normalized_key = normalize_storage_key(key)
+        try:
+            return self._objects[normalized_key]
+        except KeyError:
+            raise FileStorageNotFound("object not found", key=normalized_key) from None
+
+
+def test_normalize_storage_key_accepts_relative_posix_keys() -> None:
+    assert normalize_storage_key("tenant-a/invoices/2026-08.pdf") == "tenant-a/invoices/2026-08.pdf"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        " leading",
+        "trailing ",
+        "/absolute",
+        "folder/",
+        "folder//file.txt",
+        "folder/./file.txt",
+        "folder/../file.txt",
+        "folder\\file.txt",
+    ],
+)
+def test_normalize_storage_key_rejects_unsafe_keys(key: str) -> None:
+    with pytest.raises(FileStorageInvalidKey) as exc_info:
+        normalize_storage_key(key)
+
+    assert getattr(exc_info.value, "key") == key
+
+
+def test_stored_object_metadata_custom_is_immutable() -> None:
+    custom = {"owner": "tenant-a"}
+
+    metadata = StoredObjectMetadata(key="tenant-a/docs/readme.txt", custom=custom)
+    custom["owner"] = "tenant-b"
+
+    assert metadata.custom["owner"] == "tenant-a"
+    with pytest.raises(TypeError):
+        metadata.custom["owner"] = "tenant-c"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_file_storage_port_contract_round_trips_metadata_and_stream() -> None:
+    storage = InMemoryFileStorage()
+
+    stored = await storage.put(
+        "tenant-a/docs/readme.txt",
+        _chunks(b"hello ", b"storage"),
+        content_type="text/plain",
+        metadata={"owner": "tenant-a"},
+    )
+    stream = await storage.get("tenant-a/docs/readme.txt")
+    stat = await storage.stat("tenant-a/docs/readme.txt")
+
+    assert stored.key == "tenant-a/docs/readme.txt"
+    assert stored.content_type == "text/plain"
+    assert stored.size == 13
+    assert stored.custom == {"owner": "tenant-a"}
+    assert await _collect(stream.body) == b"hello storage"
+    assert stream.metadata == stat
+    assert await storage.exists("tenant-a/docs/readme.txt") is True
+
+
+@pytest.mark.asyncio
+async def test_file_storage_port_contract_raises_not_found_with_key() -> None:
+    storage = InMemoryFileStorage()
+
+    with pytest.raises(FileStorageNotFound) as exc_info:
+        await storage.get("missing/object.bin")
+
+    assert exc_info.value.key == "missing/object.bin"

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -16,6 +16,7 @@ from arclith.infrastructure.config import (
     OpenTelemetrySettings,
     RabbitMQCommandBusSettings,
     SoftDeleteSettings,
+    StorageSettings,
     _deep_merge,
     _resolve_key_path,
     export_config_yaml,
@@ -28,6 +29,7 @@ from arclith.infrastructure.config import (
 
 def test_default_config_uses_memory():
     assert AppConfig().adapters.repository == "memory"
+    assert AppConfig().adapters.storage is None
     assert AppConfig().adapters.observability.enabled == []
     assert AppConfig().command_bus.enabled == []
 
@@ -70,6 +72,7 @@ def test_resolve_output_adapter():
     assert _resolve_key_path(Path("adapters/outbound/mongodb.yaml")) == ["adapters", "mongodb"]
     assert _resolve_key_path(Path("adapters/outbound/duckdb.yaml")) == ["adapters", "duckdb"]
     assert _resolve_key_path(Path("adapters/outbound/mariadb.yaml")) == ["adapters", "mariadb"]
+    assert _resolve_key_path(Path("adapters/outbound/storage.yaml")) == ["adapters", "storage"]
 
 
 def test_resolve_input_alias_fastapi():
@@ -238,6 +241,58 @@ def test_load_config_dir_mariadb_scoped():
     assert config.adapters.mariadb is not None
     assert config.adapters.mariadb.database == "demo"
     assert config.adapters.mariadb.user == "app"
+
+
+def test_load_config_dir_storage_filesystem_scoped():
+    path = _make_config_dir({
+        "adapters/outbound/storage.yaml": {
+            "adapter": "filesystem",
+            "root_path": "/data/files",
+            "prefix": "uploads",
+            "create_root": False,
+            "multitenant": False,
+        },
+    })
+    config = load_config_dir(path)
+
+    assert config.adapters.storage is not None
+    assert config.adapters.storage.adapter == "filesystem"
+    assert config.adapters.storage.root_path == "/data/files"
+    assert config.adapters.storage.prefix == "uploads"
+    assert config.adapters.storage.create_root is False
+    assert config.adapters.storage.multitenant is False
+
+
+@pytest.mark.parametrize(
+    ("payload", "missing"),
+    [
+        ({"adapter": "filesystem"}, "root_path"),
+        ({"adapter": "s3"}, "bucket_name"),
+        ({"adapter": "gcs"}, "bucket_name"),
+        ({"adapter": "azure-blob", "account_url": "https://account.blob.core.windows.net"}, "container_name"),
+    ],
+)
+def test_storage_single_tenant_requires_backend_target(payload: dict[str, str], missing: str) -> None:
+    with pytest.raises(ValidationError, match=missing):
+        StorageSettings.model_validate(payload)
+
+
+@pytest.mark.parametrize("adapter", ["filesystem", "s3", "azure-blob", "gcs"])
+def test_storage_multitenant_allows_tenant_resolved_target(adapter: str) -> None:
+    settings = StorageSettings.model_validate({"adapter": adapter, "multitenant": True})
+
+    assert settings.adapter == adapter
+    assert settings.multitenant is True
+
+
+@pytest.mark.parametrize("prefix", ["../uploads", "uploads/../private", "/uploads", "uploads//drafts"])
+def test_storage_prefix_rejects_traversal(prefix: str) -> None:
+    with pytest.raises(ValidationError, match="storage key"):
+        StorageSettings.model_validate({
+            "adapter": "filesystem",
+            "root_path": "/data/files",
+            "prefix": prefix,
+        })
 
 
 def test_load_config_dir_langsmith_scoped():


### PR DESCRIPTION
## Summary
- Add the provider-neutral `FileStoragePort` contract, metadata/stream models, key normalization, and common storage errors.
- Add `StorageSettings` under `adapters.storage` with validated configs for `filesystem`, `s3`, `azure-blob`, and `gcs`.
- Register the `storage` CLI capability and document the contract/configuration model.

Closes #139

## Validation
- `uv run pytest tests/units/domain/ports/test_file_storage.py tests/units/infrastructure/test_config.py`
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py`
- `make docs`
- `make quality`
- `cd cli && uv run ruff check arclith_cli tests`
- `cd cli && uv run pytest tests/`
