### PR TITLE
Add filesystem file storage adapter

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from arclith.adapters.inbound.schemas.base_schema import BaseSchema
+from arclith.adapters.outbound.filesystem import FilesystemFileStorage, FilesystemStorageConfig
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
 from arclith.application.command_bus import CommandDispatcher, CommandEnvelope
@@ -26,6 +27,11 @@ from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.adapter_registry import AdapterRegistry
 from arclith.infrastructure.config import AppConfig, LMSettings, export_config_yaml, load_config_dir, load_config_file
+from arclith.infrastructure.file_storage_factory import (
+    FileStorageRegistry,
+    build_file_storage,
+    default_file_storage_registry,
+)
 from arclith.infrastructure.project_layout import ProjectLayout, ProjectLayoutKind, canonical_project_layout
 from arclith.infrastructure.repository_factory import RepositoryRegistry, build_repository, default_repository_registry
 
@@ -46,6 +52,8 @@ __all__ = [
     "FileStorageUnavailable",
     "FileStoragePermissionDenied",
     "normalize_storage_key",
+    "FilesystemFileStorage",
+    "FilesystemStorageConfig",
     "Logger",
     "LogLevel",
     "BaseService",
@@ -66,6 +74,9 @@ __all__ = [
     "RepositoryRegistry",
     "build_repository",
     "default_repository_registry",
+    "FileStorageRegistry",
+    "build_file_storage",
+    "default_file_storage_registry",
     "ProjectLayout",
     "ProjectLayoutKind",
     "canonical_project_layout",

--- a/arclith/adapters/outbound/filesystem/__init__.py
+++ b/arclith/adapters/outbound/filesystem/__init__.py
@@ -1,0 +1,3 @@
+from arclith.adapters.outbound.filesystem.file_storage import FilesystemFileStorage, FilesystemStorageConfig
+
+__all__ = ["FilesystemFileStorage", "FilesystemStorageConfig"]

--- a/arclith/adapters/outbound/filesystem/file_storage.py
+++ b/arclith/adapters/outbound/filesystem/file_storage.py
@@ -68,8 +68,8 @@ class FilesystemFileStorage(FileStoragePort):
                             continue
                         digest.update(chunk)
                         size += len(chunk)
-                        file.write(chunk)
-                    file.flush()
+                        await asyncio.to_thread(file.write, chunk)
+                    await asyncio.to_thread(file.flush)
                 self._replace_file(tmp_path, target_path, normalized_key)
             finally:
                 if tmp_path.exists():
@@ -188,16 +188,22 @@ class FilesystemFileStorage(FileStoragePort):
         for part in relative_parent.parts:
             current = current / part
             if current.exists():
-                self._assert_contained(current, None)
-                if not current.is_dir():
-                    raise FileStorageConflict("filesystem storage parent path is not a directory")
+                self._assert_directory(current)
             else:
                 try:
-                    current.mkdir()
+                    current.mkdir(exist_ok=True)
+                    self._assert_directory(current)
+                except FileExistsError as e:
+                    raise FileStorageConflict("filesystem storage parent path is not a directory") from e
                 except PermissionError as e:
                     raise FileStoragePermissionDenied("filesystem storage parent is not writable") from e
                 except OSError as e:
                     raise FileStorageUnavailable("filesystem storage parent is unavailable") from e
+
+    def _assert_directory(self, path: Path) -> None:
+        self._assert_contained(path, None)
+        if not path.is_dir():
+            raise FileStorageConflict("filesystem storage parent path is not a directory")
 
     def _temporary_path(self, parent: Path) -> Path:
         with tempfile.NamedTemporaryFile(prefix=".arclith-", suffix=".tmp", dir=parent, delete=False) as file:

--- a/arclith/adapters/outbound/filesystem/file_storage.py
+++ b/arclith/adapters/outbound/filesystem/file_storage.py
@@ -1,0 +1,340 @@
+import asyncio
+import hashlib
+import json
+import tempfile
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from arclith.domain.ports.outbound.file_storage import (
+    FileStorageConflict,
+    FileStorageInvalidKey,
+    FileStorageNotFound,
+    FileStoragePermissionDenied,
+    FileStoragePort,
+    FileStorageUnavailable,
+    StoredObject,
+    StoredObjectMetadata,
+    StoredObjectStream,
+    normalize_storage_key,
+)
+
+_CHUNK_SIZE = 1024 * 1024
+_METADATA_ROOT = ".arclith-storage-metadata"
+
+
+@dataclass(frozen=True)
+class FilesystemStorageConfig:
+    root_path: str | Path
+    prefix: str = ""
+    create_root: bool = True
+
+
+class FilesystemFileStorage(FileStoragePort):
+    """Filesystem implementation of the FileStoragePort contract."""
+
+    def __init__(self, config: FilesystemStorageConfig) -> None:
+        self._prefix = _normalize_optional_prefix(config.prefix)
+        root_path = Path(config.root_path)
+        self._root_path = self._prepare_directory(root_path, create=config.create_root)
+        base_path = self._root_path / self._prefix if self._prefix else self._root_path
+        if self._prefix and config.create_root:
+            self._ensure_directory(base_path, base=self._root_path)
+        self._base_path = self._prepare_directory(base_path, create=False)
+        self._metadata_root = self._root_path / _METADATA_ROOT
+
+    async def put(
+        self,
+        key: str,
+        content: AsyncIterator[bytes],
+        *,
+        content_type: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> StoredObject:
+        normalized_key = _normalize_filesystem_key(key)
+        target_path = self._target_path(normalized_key)
+        self._ensure_parent_directory(target_path.parent)
+
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            tmp_path = self._temporary_path(target_path.parent)
+            try:
+                with tmp_path.open("wb") as file:
+                    async for chunk in content:
+                        if not chunk:
+                            continue
+                        digest.update(chunk)
+                        size += len(chunk)
+                        file.write(chunk)
+                    file.flush()
+                self._replace_file(tmp_path, target_path, normalized_key)
+            finally:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage write is not permitted", key=normalized_key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage write failed", key=normalized_key) from e
+
+        checksum = f"sha256:{digest.hexdigest()}"
+        stat = self._file_stat(target_path, normalized_key)
+        stored = StoredObject(
+            key=normalized_key,
+            content_type=content_type,
+            size=size,
+            checksum=checksum,
+            etag=checksum,
+            last_modified=datetime.fromtimestamp(stat.st_mtime, UTC),
+            custom=dict(metadata or {}),
+        )
+        self._write_metadata(stored)
+        return stored
+
+    async def get(self, key: str) -> StoredObjectStream:
+        metadata = await self.stat(key)
+        path = self._existing_object_path(metadata.key)
+        return StoredObjectStream(metadata=metadata, body=self._read_file(path, metadata.key))
+
+    async def delete(self, key: str) -> None:
+        normalized_key = _normalize_filesystem_key(key)
+        path = self._target_path(normalized_key)
+        if path.exists():
+            self._assert_contained(path, normalized_key)
+            if path.is_dir():
+                raise FileStorageConflict("filesystem storage object path is a directory", key=normalized_key)
+            try:
+                path.unlink()
+            except PermissionError as e:
+                raise FileStoragePermissionDenied("filesystem storage delete is not permitted", key=normalized_key) from e
+            except OSError as e:
+                raise FileStorageUnavailable("filesystem storage delete failed", key=normalized_key) from e
+
+        metadata_path = self._metadata_path(normalized_key)
+        if metadata_path.exists():
+            self._assert_contained(metadata_path, normalized_key)
+            try:
+                metadata_path.unlink()
+            except PermissionError as e:
+                raise FileStoragePermissionDenied("filesystem storage metadata delete is not permitted", key=normalized_key) from e
+            except OSError as e:
+                raise FileStorageUnavailable("filesystem storage metadata delete failed", key=normalized_key) from e
+
+    async def exists(self, key: str) -> bool:
+        normalized_key = _normalize_filesystem_key(key)
+        path = self._target_path(normalized_key)
+        if not path.exists():
+            return False
+        self._assert_contained(path, normalized_key)
+        return path.is_file()
+
+    async def stat(self, key: str) -> StoredObjectMetadata:
+        normalized_key = _normalize_filesystem_key(key)
+        path = self._existing_object_path(normalized_key)
+        stat = self._file_stat(path, normalized_key)
+        metadata = self._load_metadata(normalized_key)
+        return StoredObjectMetadata(
+            key=normalized_key,
+            content_type=metadata.get("content_type"),
+            size=stat.st_size,
+            checksum=metadata.get("checksum"),
+            etag=metadata.get("etag"),
+            last_modified=datetime.fromtimestamp(stat.st_mtime, UTC),
+            custom=metadata.get("custom", {}),
+        )
+
+    def _target_path(self, normalized_key: str) -> Path:
+        return self._base_path / normalized_key
+
+    def _existing_object_path(self, normalized_key: str) -> Path:
+        path = self._target_path(normalized_key)
+        if not path.exists():
+            raise FileStorageNotFound("filesystem storage object not found", key=normalized_key)
+        self._assert_contained(path, normalized_key)
+        if not path.is_file():
+            raise FileStorageConflict("filesystem storage object path is not a file", key=normalized_key)
+        return path
+
+    def _prepare_directory(self, path: Path, *, create: bool) -> Path:
+        try:
+            if create:
+                path.mkdir(parents=True, exist_ok=True)
+            if not path.exists() or not path.is_dir():
+                raise FileStorageUnavailable("filesystem storage root is unavailable")
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage root is not writable") from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage root is unavailable") from e
+
+        try:
+            resolved = path.resolve()
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage root is not readable") from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage root is unavailable") from e
+        if hasattr(self, "_root_path") and resolved != self._root_path:
+            self._assert_path_inside(resolved, self._root_path)
+        return resolved
+
+    def _ensure_parent_directory(self, parent: Path, *, base: Path | None = None) -> None:
+        base_path = base or self._base_path
+        self._ensure_directory(parent, base=base_path)
+
+    def _ensure_directory(self, directory: Path, *, base: Path) -> None:
+        relative_parent = directory.relative_to(base)
+        current = base
+        for part in relative_parent.parts:
+            current = current / part
+            if current.exists():
+                self._assert_contained(current, None)
+                if not current.is_dir():
+                    raise FileStorageConflict("filesystem storage parent path is not a directory")
+            else:
+                try:
+                    current.mkdir()
+                except PermissionError as e:
+                    raise FileStoragePermissionDenied("filesystem storage parent is not writable") from e
+                except OSError as e:
+                    raise FileStorageUnavailable("filesystem storage parent is unavailable") from e
+
+    def _temporary_path(self, parent: Path) -> Path:
+        with tempfile.NamedTemporaryFile(prefix=".arclith-", suffix=".tmp", dir=parent, delete=False) as file:
+            return Path(file.name)
+
+    def _replace_file(self, tmp_path: Path, target_path: Path, key: str) -> None:
+        if target_path.exists():
+            self._assert_contained(target_path, key)
+            if target_path.is_dir():
+                raise FileStorageConflict("filesystem storage object path is a directory", key=key)
+        tmp_path.replace(target_path)
+
+    def _file_stat(self, path: Path, key: str) -> Any:
+        try:
+            return path.stat()
+        except FileNotFoundError:
+            raise FileStorageNotFound("filesystem storage object not found", key=key) from None
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage object is not readable", key=key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage stat failed", key=key) from e
+
+    async def _read_file(self, path: Path, key: str) -> AsyncIterator[bytes]:
+        try:
+            with path.open("rb") as file:
+                while True:
+                    chunk = await asyncio.to_thread(file.read, _CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    yield chunk
+        except FileNotFoundError:
+            raise FileStorageNotFound("filesystem storage object not found", key=key) from None
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage object is not readable", key=key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage read failed", key=key) from e
+
+    def _metadata_path(self, normalized_key: str) -> Path:
+        return self._metadata_root / f"{normalized_key}.json"
+
+    def _load_metadata(self, normalized_key: str) -> dict[str, Any]:
+        metadata_path = self._metadata_path(normalized_key)
+        if not metadata_path.exists():
+            return {}
+        self._assert_contained(metadata_path, normalized_key)
+        raw_content = self._read_metadata_content(metadata_path, normalized_key)
+        if raw_content is None:
+            return {}
+
+        try:
+            return _normalize_metadata_payload(json.loads(raw_content))
+        except json.JSONDecodeError as e:
+            raise FileStorageUnavailable("filesystem storage metadata is invalid", key=normalized_key) from e
+
+    def _read_metadata_content(self, metadata_path: Path, normalized_key: str) -> str | None:
+        try:
+            return metadata_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage metadata is not readable", key=normalized_key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage metadata read failed", key=normalized_key) from e
+
+    def _write_metadata(self, metadata: StoredObjectMetadata) -> None:
+        metadata_path = self._metadata_path(metadata.key)
+        self._ensure_parent_directory(metadata_path.parent, base=self._root_path)
+        payload = {
+            "content_type": metadata.content_type,
+            "checksum": metadata.checksum,
+            "etag": metadata.etag,
+            "custom": dict(metadata.custom),
+        }
+        try:
+            tmp_path = self._temporary_path(metadata_path.parent)
+            try:
+                tmp_path.write_text(
+                    json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                    encoding="utf-8",
+                )
+                tmp_path.replace(metadata_path)
+            finally:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage metadata write is not permitted", key=metadata.key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage metadata write failed", key=metadata.key) from e
+
+    def _assert_contained(self, path: Path, key: str | None) -> None:
+        if not path.exists():
+            return
+        try:
+            resolved = path.resolve()
+        except PermissionError as e:
+            raise FileStoragePermissionDenied("filesystem storage path is not readable", key=key) from e
+        except OSError as e:
+            raise FileStorageUnavailable("filesystem storage path cannot be resolved", key=key) from e
+        self._assert_path_inside(resolved, self._root_path, key=key)
+
+    def _assert_path_inside(self, path: Path, root: Path, *, key: str | None = None) -> None:
+        if not path.is_relative_to(root):
+            raise FileStoragePermissionDenied("filesystem storage path escapes root", key=key)
+
+
+def _normalize_optional_prefix(prefix: str) -> str:
+    if not prefix:
+        return ""
+    normalized = normalize_storage_key(prefix)
+    if normalized == _METADATA_ROOT or normalized.startswith(f"{_METADATA_ROOT}/"):
+        raise FileStorageInvalidKey("filesystem storage prefix is reserved", key=prefix)
+    return normalized
+
+
+def _normalize_filesystem_key(key: str) -> str:
+    normalized = normalize_storage_key(key)
+    if normalized == _METADATA_ROOT or normalized.startswith(f"{_METADATA_ROOT}/"):
+        raise FileStorageInvalidKey("filesystem storage key uses reserved metadata prefix", key=key)
+    return normalized
+
+
+def _normalize_metadata_payload(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+
+    custom_raw = raw.get("custom", {})
+    custom = custom_raw if isinstance(custom_raw, dict) else {}
+    return {
+        "content_type": _metadata_string(raw, "content_type"),
+        "checksum": _metadata_string(raw, "checksum"),
+        "etag": _metadata_string(raw, "etag"),
+        "custom": {str(k): str(v) for k, v in custom.items() if isinstance(k, str) and isinstance(v, str)},
+    }
+
+
+def _metadata_string(raw: Mapping[str, Any], field: str) -> str | None:
+    value = raw.get(field)
+    if isinstance(value, str):
+        return value
+    return None

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, TypeVar, overload
 
 from arclith.adapters.outbound.opentelemetry.correlation import log_record_trace_metadata
 from arclith.domain.models.entity import Entity
+from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.config import AppConfig, load_config_dir, load_config_file
+from arclith.infrastructure.file_storage_factory import FileStorageRegistry
 from arclith.infrastructure.repository_factory import RepositoryRegistry
 
 if TYPE_CHECKING:
@@ -106,6 +108,15 @@ class Arclith:
         from arclith.infrastructure.repository_factory import build_repository
 
         return build_repository(self.config, entity_class, self.logger, registry=registry)
+
+    def file_storage(
+        self,
+        *,
+        registry: FileStorageRegistry | None = None,
+    ) -> FileStoragePort:
+        from arclith.infrastructure.file_storage_factory import build_file_storage
+
+        return build_file_storage(self.config, self.logger, registry=registry)
 
     def rabbitmq_command_bus(self) -> "RabbitMQCommandBus":
         if not self.config.command_bus.is_enabled("rabbitmq"):

--- a/arclith/infrastructure/file_storage_factory.py
+++ b/arclith/infrastructure/file_storage_factory.py
@@ -1,0 +1,62 @@
+from collections.abc import Callable
+
+from arclith.domain.ports.outbound.file_storage import FileStoragePort
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.infrastructure.config import AppConfig
+
+FileStorageFactory = Callable[[AppConfig, Logger], FileStoragePort]
+
+
+class FileStorageRegistry:
+    """Registry mapping file-storage adapter names to factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, FileStorageFactory] = {}
+
+    def register(self, name: str, factory: FileStorageFactory) -> "FileStorageRegistry":
+        self._factories[name] = factory
+        return self
+
+    def build(self, config: AppConfig, logger: Logger) -> FileStoragePort:
+        settings = config.adapters.storage
+        if settings is None:
+            raise ValueError("adapters.storage is required to build file storage")
+        if settings.adapter not in self._factories:
+            raise ValueError(
+                f"File storage adapter '{settings.adapter}' not registered. "
+                f"Available: {sorted(self._factories)}."
+            )
+        return self._factories[settings.adapter](config, logger)
+
+
+def build_file_storage(
+    config: AppConfig,
+    logger: Logger,
+    *,
+    registry: FileStorageRegistry | None = None,
+) -> FileStoragePort:
+    if registry is None:
+        return default_file_storage_registry().build(config, logger)
+    return registry.build(config, logger)
+
+
+def default_file_storage_registry() -> FileStorageRegistry:
+    return FileStorageRegistry().register("filesystem", _build_filesystem_file_storage)
+
+
+def _build_filesystem_file_storage(config: AppConfig, _logger: Logger) -> FileStoragePort:
+    from arclith.adapters.outbound.filesystem import FilesystemFileStorage, FilesystemStorageConfig
+
+    settings = config.adapters.storage
+    if settings is None:
+        raise ValueError("Filesystem storage settings are required")
+    if settings.root_path is None:
+        raise ValueError("Filesystem storage root_path is required")
+
+    return FilesystemFileStorage(
+        FilesystemStorageConfig(
+            root_path=settings.root_path,
+            prefix=settings.prefix,
+            create_root=settings.create_root,
+        )
+    )

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -949,17 +949,23 @@ def test_add_storage_adapter_generates_loadable_config_only(
 ) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "outbound" / "storage.yaml"
+    adapter_params = dict(params)
+    expected_config = dict(expected)
+    if adapter == "filesystem":
+        root_path = project_dir / "files"
+        adapter_params["root_path"] = str(root_path)
+        expected_config["root_path"] = str(root_path)
 
     add_adapter_cmd(
         project_dir=project_dir,
         capability_name="storage",
         adapter=adapter,
-        adapter_params=params,
+        adapter_params=adapter_params,
         yes=True,
     )
     config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-    assert config == expected
+    assert config == expected_config
     assert "storage:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
@@ -973,6 +979,10 @@ def test_add_storage_adapter_generates_loadable_config_only(
     assert arclith.config.adapters.storage is not None
     assert arclith.config.adapters.storage.adapter == adapter
     assert arclith.config.adapters.storage.prefix == "uploads"
+    if adapter == "filesystem":
+        from arclith.adapters.outbound.filesystem import FilesystemFileStorage
+
+        assert isinstance(arclith.file_storage(), FilesystemFileStorage)
 
 
 def test_add_openai_llm_adapter_generates_secret_mapping(

--- a/docs/capabilities/storage.md
+++ b/docs/capabilities/storage.md
@@ -102,6 +102,116 @@ multitenant: false
 Monter `/data/files` sur un volume persistant dans Docker ou Kubernetes.
 `prefix` reste relatif à `root_path`.
 
+### Utilisation Locale
+
+```python
+from arclith import Arclith
+
+app = Arclith("config")
+storage = app.file_storage()
+
+async def save_invoice(content: bytes) -> str:
+    await storage.put(
+        "invoices/2026-08.pdf",
+        _single_chunk(content),
+        content_type="application/pdf",
+        metadata={"kind": "invoice"},
+    )
+    return "invoices/2026-08.pdf"
+
+async def _single_chunk(content: bytes):
+    yield content
+```
+
+Le chemin `root_path` est un détail d'infrastructure. Les use cases manipulent
+uniquement des clés relatives comme `invoices/2026-08.pdf`.
+
+### Metadata Filesystem
+
+L'adapter filesystem stocke le contenu dans `root_path/prefix/<key>` et les
+métadonnées dans un sidecar JSON sous `.arclith-storage-metadata/`.
+
+Cette stratégie garde le contenu lisible comme des fichiers standards, tout en
+préservant `content_type`, `checksum`, `etag` et `custom`. Le répertoire
+`.arclith-storage-metadata/` est réservé: une clé utilisateur ne peut pas
+commencer par ce préfixe.
+
+### Docker Compose
+
+```yaml
+services:
+  api:
+    image: my-service:local
+    command: ["api"]
+    user: "1001:1001"
+    volumes:
+      - file-storage:/data/files
+
+volumes:
+  file-storage:
+```
+
+Pour un bind mount local:
+
+```yaml
+services:
+  api:
+    volumes:
+      - ./var/files:/data/files
+```
+
+Le dossier hôte doit appartenir à l'UID/GID utilisé dans le conteneur, par
+exemple `1001:1001` si l'image suit la baseline non-root.
+
+### Kubernetes
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-service-files
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service-api
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: api
+          image: ghcr.io/karned-rekipe/my-service:0.1.0
+          volumeMounts:
+            - name: file-storage
+              mountPath: /data/files
+      volumes:
+        - name: file-storage
+          persistentVolumeClaim:
+            claimName: my-service-files
+```
+
+Avec plusieurs réplicas, un filesystem local ou un volume `ReadWriteOnce` ne
+garantit pas le partage entre pods. Utiliser un stockage partagé compatible ou
+un provider objet pour les workloads multi-réplicas.
+
+### Production
+
+- Exécuter l'image avec un utilisateur non-root qui peut écrire dans le volume.
+- Sauvegarder le volume comme une donnée applicative.
+- Éviter les symlinks dans `root_path`: l'adapter refuse ceux qui sortent de la
+  racine, mais la plateforme doit aussi contrôler les permissions.
+- Ne pas exposer `root_path` dans les erreurs retournées aux clients.
+
 ## AWS S3
 
 ```yaml

--- a/docs/runtime-docker/docker-compose.md
+++ b/docs/runtime-docker/docker-compose.md
@@ -117,6 +117,38 @@ volumes:
   mongo-data:
 ```
 
+## Ajouter Un Volume Filesystem Storage
+
+Pour `storage/filesystem`, l'application voit un chemin conteneur stable,
+typiquement `/data/files`.
+
+```yaml
+services:
+  api:
+    <<: *arclith-service
+    command: ["api"]
+    user: "1001:1001"
+    volumes:
+      - file-storage:/data/files
+
+volumes:
+  file-storage:
+```
+
+La config Arclith correspondante:
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: filesystem
+root_path: "/data/files"
+prefix: ""
+create_root: true
+multitenant: false
+```
+
+Pour un bind mount local, remplacer le volume nommé par `./var/files:/data/files`
+et ajuster les droits du dossier hôte pour l'UID/GID du conteneur.
+
 ## Réseaux Et Exposition
 
 Par défaut, Compose crée un réseau privé par projet. Exposer sur le host uniquement les transports

--- a/docs/runtime-docker/kubernetes.md
+++ b/docs/runtime-docker/kubernetes.md
@@ -145,6 +145,54 @@ spec:
       targetPort: http
 ```
 
+## Persistent Volume Pour Storage Filesystem
+
+Quand la capability `storage/filesystem` est activée, monter un volume persistant
+sur le même chemin que `root_path`, par exemple `/data/files`.
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-service-files
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service-api
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: api
+          image: ghcr.io/karned-rekipe/my-service:0.1.0
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /data/files
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: file-storage
+          persistentVolumeClaim:
+            claimName: my-service-files
+```
+
+Un PVC `ReadWriteOnce` convient à un seul writer. Pour plusieurs réplicas qui
+doivent partager les mêmes fichiers, choisir un storage class compatible
+`ReadWriteMany` ou basculer vers un provider objet.
+
 ## MCP, Agent Et Worker
 
 MCP réutilise l'image avec un autre argument:

--- a/tests/units/adapters/outbound/filesystem/test_file_storage.py
+++ b/tests/units/adapters/outbound/filesystem/test_file_storage.py
@@ -1,0 +1,255 @@
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from arclith.adapters.outbound.filesystem import FilesystemFileStorage, FilesystemStorageConfig
+from arclith.domain.ports.outbound.file_storage import (
+    FileStorageConflict,
+    FileStorageInvalidKey,
+    FileStorageNotFound,
+    FileStoragePermissionDenied,
+    FileStorageUnavailable,
+)
+
+
+async def _chunks(*items: bytes) -> AsyncIterator[bytes]:
+    for item in items:
+        yield item
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> bytes:
+    body = bytearray()
+    async for chunk in stream:
+        body.extend(chunk)
+    return bytes(body)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_round_trips_file_and_metadata(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path, prefix="uploads"))
+
+    stored = await storage.put(
+        "tenant-a/docs/readme.txt",
+        _chunks(b"", b"hello ", b"filesystem"),
+        content_type="text/plain",
+        metadata={"owner": "tenant-a"},
+    )
+    stream = await storage.get("tenant-a/docs/readme.txt")
+    stat = await storage.stat("tenant-a/docs/readme.txt")
+
+    assert stored.key == "tenant-a/docs/readme.txt"
+    assert stored.size == 16
+    assert stored.content_type == "text/plain"
+    assert stored.checksum is not None
+    assert stored.etag == stored.checksum
+    assert stored.custom == {"owner": "tenant-a"}
+    assert await _collect(stream.body) == b"hello filesystem"
+    assert stream.metadata == stat
+    assert stat.size == 16
+    assert stat.content_type == "text/plain"
+    assert stat.custom == {"owner": "tenant-a"}
+    assert await storage.exists("tenant-a/docs/readme.txt") is True
+    assert (tmp_path / "uploads" / "tenant-a" / "docs" / "readme.txt").read_bytes() == b"hello filesystem"
+    assert (tmp_path / ".arclith-storage-metadata" / "tenant-a" / "docs" / "readme.txt.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_delete_is_idempotent(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+
+    await storage.put("docs/readme.txt", _chunks(b"content"))
+    await storage.delete("docs/readme.txt")
+    await storage.delete("docs/readme.txt")
+
+    assert await storage.exists("docs/readme.txt") is False
+    with pytest.raises(FileStorageNotFound):
+        await storage.stat("docs/readme.txt")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_overwrites_existing_file(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+
+    await storage.put("docs/readme.txt", _chunks(b"first"))
+    stored = await storage.put("docs/readme.txt", _chunks(b"second"))
+    stream = await storage.get("docs/readme.txt")
+
+    assert stored.size == 6
+    assert await _collect(stream.body) == b"second"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "../secret.txt",
+        "/etc/passwd",
+        "folder/../secret.txt",
+        "folder\\secret.txt",
+        ".arclith-storage-metadata/readme.txt",
+    ],
+)
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_unsafe_keys(tmp_path: Path, key: str) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+
+    with pytest.raises(FileStorageInvalidKey):
+        await storage.put(key, _chunks(b"blocked"))
+
+
+def test_filesystem_file_storage_creates_root_when_configured(tmp_path: Path) -> None:
+    root_path = tmp_path / "missing" / "files"
+
+    FilesystemFileStorage(FilesystemStorageConfig(root_path=root_path, create_root=True))
+
+    assert root_path.is_dir()
+
+
+def test_filesystem_file_storage_rejects_missing_root_without_create(tmp_path: Path) -> None:
+    root_path = tmp_path / "missing" / "files"
+
+    with pytest.raises(FileStorageUnavailable, match="root"):
+        FilesystemFileStorage(FilesystemStorageConfig(root_path=root_path, create_root=False))
+
+
+def test_filesystem_file_storage_rejects_file_root(tmp_path: Path) -> None:
+    root_path = tmp_path / "files"
+    root_path.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(FileStorageUnavailable, match="root"):
+        FilesystemFileStorage(FilesystemStorageConfig(root_path=root_path))
+
+
+def test_filesystem_file_storage_rejects_reserved_prefix(tmp_path: Path) -> None:
+    with pytest.raises(FileStorageInvalidKey, match="reserved"):
+        FilesystemFileStorage(
+            FilesystemStorageConfig(root_path=tmp_path, prefix=".arclith-storage-metadata/public")
+        )
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_does_not_follow_symlink_outside_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root_path = tmp_path / "root"
+    root_path.mkdir()
+    (root_path / "escape").symlink_to(outside, target_is_directory=True)
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=root_path))
+
+    with pytest.raises(FileStoragePermissionDenied, match="escapes root") as exc_info:
+        await storage.put("escape/secret.txt", _chunks(b"blocked"))
+
+    assert str(root_path) not in str(exc_info.value)
+    assert str(outside) not in str(exc_info.value)
+    assert not (outside / "secret.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_directory_object_path(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    (tmp_path / "docs").mkdir()
+
+    with pytest.raises(FileStorageConflict):
+        await storage.stat("docs")
+
+    assert await storage.exists("docs") is False
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_delete_directory_object_path(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    (tmp_path / "docs").mkdir()
+
+    with pytest.raises(FileStorageConflict, match="directory"):
+        await storage.delete("docs")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_put_when_target_is_directory(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    (tmp_path / "docs").mkdir()
+
+    with pytest.raises(FileStorageConflict, match="directory"):
+        await storage.put("docs", _chunks(b"blocked"))
+
+    assert not list(tmp_path.glob(".arclith-*.tmp"))
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_file_parent_path(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    (tmp_path / "docs").write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(FileStorageConflict, match="parent"):
+        await storage.put("docs/readme.txt", _chunks(b"blocked"))
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_stat_without_metadata_sidecar(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "readme.txt").write_text("raw", encoding="utf-8")
+
+    stat = await storage.stat("docs/readme.txt")
+
+    assert stat.size == 3
+    assert stat.content_type is None
+    assert stat.checksum is None
+    assert stat.etag is None
+    assert stat.custom == {}
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_rejects_invalid_metadata_sidecar(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    await storage.put("docs/readme.txt", _chunks(b"content"))
+    (tmp_path / ".arclith-storage-metadata" / "docs" / "readme.txt.json").write_text("{", encoding="utf-8")
+
+    with pytest.raises(FileStorageUnavailable, match="metadata"):
+        await storage.stat("docs/readme.txt")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_ignores_malformed_metadata_payload(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    await storage.put("docs/list.txt", _chunks(b"list"))
+    await storage.put("docs/types.txt", _chunks(b"types"))
+    metadata_root = tmp_path / ".arclith-storage-metadata" / "docs"
+    (metadata_root / "list.txt.json").write_text("[]", encoding="utf-8")
+    (metadata_root / "types.txt.json").write_text(
+        '{"content_type": 42, "checksum": 42, "etag": 42, "custom": "bad"}',
+        encoding="utf-8",
+    )
+
+    list_stat = await storage.stat("docs/list.txt")
+    types_stat = await storage.stat("docs/types.txt")
+
+    assert list_stat.content_type is None
+    assert list_stat.custom == {}
+    assert types_stat.content_type is None
+    assert types_stat.checksum is None
+    assert types_stat.etag is None
+    assert types_stat.custom == {}
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_wraps_metadata_write_errors(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    metadata_path = tmp_path / ".arclith-storage-metadata" / "docs" / "readme.txt.json"
+    metadata_path.mkdir(parents=True)
+
+    with pytest.raises(FileStorageUnavailable, match="metadata write") as exc_info:
+        await storage.put("docs/readme.txt", _chunks(b"content"))
+
+    assert str(tmp_path) not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_read_reports_missing_file(tmp_path: Path) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    await storage.put("docs/readme.txt", _chunks(b"content"))
+    stream = await storage.get("docs/readme.txt")
+    (tmp_path / "docs" / "readme.txt").unlink()
+
+    with pytest.raises(FileStorageNotFound):
+        await _collect(stream.body)

--- a/tests/units/adapters/outbound/filesystem/test_file_storage.py
+++ b/tests/units/adapters/outbound/filesystem/test_file_storage.py
@@ -1,5 +1,7 @@
-from collections.abc import AsyncIterator
+import asyncio
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -77,6 +79,27 @@ async def test_filesystem_file_storage_overwrites_existing_file(tmp_path: Path) 
 
     assert stored.size == 6
     assert await _collect(stream.body) == b"second"
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_offloads_write_operations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    calls: list[str] = []
+    original_to_thread = asyncio.to_thread
+
+    async def spy_to_thread(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(func, "__name__", type(func).__name__))
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", spy_to_thread)
+
+    await storage.put("docs/readme.txt", _chunks(b"first", b"second"))
+
+    assert calls.count("write") == 2
+    assert "flush" in calls
 
 
 @pytest.mark.parametrize(
@@ -182,6 +205,32 @@ async def test_filesystem_file_storage_rejects_file_parent_path(tmp_path: Path) 
 
     with pytest.raises(FileStorageConflict, match="parent"):
         await storage.put("docs/readme.txt", _chunks(b"blocked"))
+
+
+@pytest.mark.asyncio
+async def test_filesystem_file_storage_tolerates_concurrent_parent_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = FilesystemFileStorage(FilesystemStorageConfig(root_path=tmp_path))
+    raced_parent = tmp_path / "docs"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_race(
+        self: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        if self == raced_parent and not raced_parent.exists():
+            original_mkdir(self, mode=mode, parents=parents, exist_ok=False)
+        original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_race)
+
+    await storage.put("docs/readme.txt", _chunks(b"content"))
+
+    assert (tmp_path / "docs" / "readme.txt").read_bytes() == b"content"
 
 
 @pytest.mark.asyncio

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -662,6 +662,12 @@ def test_export_config_yaml_round_trip():
         "soft_delete.yaml": {"retention_days": 14},
         "adapters/adapters.yaml": {"repository": "duckdb"},
         "adapters/outbound/duckdb.yaml": {"path": "data/"},
+        "adapters/outbound/storage.yaml": {
+            "adapter": "filesystem",
+            "root_path": "/data/files",
+            "prefix": "uploads",
+            "create_root": True,
+        },
         "adapters/inbound/fastapi.yaml": {"port": 8765},
     })
     out = config_dir / "config.yaml"
@@ -673,6 +679,7 @@ def test_export_config_yaml_round_trip():
     assert from_dir.app.name == from_file.app.name
     assert from_dir.soft_delete.retention_days == from_file.soft_delete.retention_days
     assert from_dir.adapters.repository == from_file.adapters.repository
+    assert from_dir.adapters.storage == from_file.adapters.storage
     assert from_dir.api.port == from_file.api.port
 
 

--- a/tests/units/infrastructure/test_file_storage_factory.py
+++ b/tests/units/infrastructure/test_file_storage_factory.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+from arclith import Arclith
+from arclith.adapters.outbound.filesystem import FilesystemFileStorage
+from arclith.domain.ports.outbound.file_storage import FileStoragePort
+from arclith.infrastructure.config import AppConfig, StorageSettings
+from arclith.infrastructure.file_storage_factory import (
+    FileStorageRegistry,
+    build_file_storage,
+    default_file_storage_registry,
+)
+
+
+def test_build_file_storage_returns_filesystem_adapter(logger, tmp_path: Path) -> None:
+    config = AppConfig.model_validate({
+        "adapters": {
+            "storage": {
+                "adapter": "filesystem",
+                "root_path": str(tmp_path),
+                "prefix": "uploads",
+            }
+        }
+    })
+
+    storage = build_file_storage(config, logger)
+
+    assert isinstance(storage, FilesystemFileStorage)
+
+
+def test_build_file_storage_requires_storage_config(logger) -> None:
+    with pytest.raises(ValueError, match="adapters.storage"):
+        build_file_storage(AppConfig(), logger)
+
+
+def test_custom_file_storage_registry_builds_adapter(logger) -> None:
+    expected = object()
+    config = AppConfig.model_construct(
+        adapters=AppConfig().adapters.model_copy(
+            update={"storage": StorageSettings.model_construct(adapter="custom")}
+        )
+    )
+    registry = FileStorageRegistry().register(
+        "custom",
+        lambda cfg, log: expected,  # type: ignore[return-value]
+    )
+
+    storage = build_file_storage(config, logger, registry=registry)
+
+    assert storage is expected
+
+
+def test_default_file_storage_registry_rejects_unknown_adapter(logger) -> None:
+    config = AppConfig.model_construct(
+        adapters=AppConfig().adapters.model_copy(
+            update={"storage": StorageSettings.model_construct(adapter="custom")}
+        )
+    )
+
+    with pytest.raises(ValueError, match="custom"):
+        default_file_storage_registry().build(config, logger)
+
+
+def test_arclith_builds_configured_file_storage(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config" / "adapters" / "outbound"
+    config_dir.mkdir(parents=True)
+    (tmp_path / "config" / "adapters" / "adapters.yaml").write_text(
+        "logger: console\n"
+        "repository: memory\n"
+        "observability:\n"
+        "  enabled: []\n",
+        encoding="utf-8",
+    )
+    (config_dir / "storage.yaml").write_text(
+        "adapter: filesystem\n"
+        f"root_path: {tmp_path / 'files'}\n"
+        "prefix: uploads\n"
+        "create_root: true\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    app = Arclith(tmp_path / "config")
+    storage = app.file_storage()
+
+    assert isinstance(storage, FileStoragePort)
+    assert isinstance(storage, FilesystemFileStorage)

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -26,3 +26,11 @@ def test_public_repository_registry_exports():
 
     assert isinstance(registry, arclith.RepositoryRegistry)
     assert arclith.build_repository is not None
+
+
+def test_public_file_storage_exports():
+    registry = arclith.default_file_storage_registry()
+
+    assert isinstance(registry, arclith.FileStorageRegistry)
+    assert arclith.build_file_storage is not None
+    assert arclith.FilesystemFileStorage is not None


### PR DESCRIPTION
## Summary
- Add the filesystem implementation of the file storage port with root/prefix isolation, atomic file replacement, sidecar metadata, and symlink traversal protection.
- Add a storage factory and `Arclith.file_storage()` for configured adapter construction.
- Document filesystem config, Docker volume/bind mounts, Kubernetes PVC usage, and production notes.
- Address Copilot review feedback by offloading write/flush calls to the threadpool and making parent directory creation concurrency-safe.

## Validation
- `make quality` (414 passed, 1 skipped, coverage 90.41%)
- `make docs`
- `cd cli && uv run ruff check .`
- `cd cli && uv run pytest tests/test_capabilities.py tests/test_add_adapter.py` (81 passed, 1 skipped)

Closes #141