### PR TITLE
Document FileStorage guide

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -42,7 +42,7 @@ arclith-cli capabilities --json
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
 | Agent local | [Quickstart Agent](quickstarts/agent.md), puis [agent/langgraph](capabilities/agent.md) |
-| Fichiers et blobs | [storage](capabilities/storage.md), puis [secrets](capabilities/secrets.md) pour les credentials |
+| Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |
 | Déploiement | [Runtime Docker](runtime-docker.md), puis [Docker Compose](runtime-docker/docker-compose.md) |
 

--- a/docs/capabilities/storage.md
+++ b/docs/capabilities/storage.md
@@ -1,761 +1,84 @@
 # Capability Storage
 
-Stockage de fichiers et blobs derrière un port `FileStoragePort`.
+`storage` ajoute un port outbound pour stocker des fichiers et des blobs sans
+coupler les use cases a un SDK cloud ou au filesystem local.
 
-## Objectif
+## Pourquoi Un Port Dedie
 
-`storage` est une capability outbound distincte de `repository`.
+`Repository[T]` persiste des entites metier: identifiants, statut, proprietaire,
+droits, index et metadonnees utiles aux requetes. `FileStoragePort` persiste un
+flux binaire: PDF, image, export, piece jointe ou resultat volumineux.
 
-- `repository` persiste les entités métier.
-- `storage` persiste des contenus binaires: documents, exports, images, archives.
+Les deux responsabilites restent separees:
 
-Le domaine dépend du port `FileStoragePort`; l'adapter concret reste dans
-l'infrastructure et la configuration.
+| Besoin | Primitive |
+|---|---|
+| rechercher, filtrer, auditer une entite | `Repository[T]` |
+| ecrire, lire ou supprimer un flux binaire | `FileStoragePort` |
+| conserver le nom original, le statut, le tenant, l'auteur | entite metier |
+| connaitre taille, checksum, etag, content-type provider | metadata storage |
+
+Cette separation garde le domaine testable et rend le backend de fichiers
+interchangeable: `filesystem` en local, puis S3, Azure Blob ou GCS en production.
+
+## Guide
+
+| Page | Contenu |
+|---|---|
+| [Quickstart filesystem](storage/quickstart.md) | config locale, volume Docker et smoke test executable |
+| [Architecture](storage/architecture.md) | flux use case -> port -> adapter et frontiere avec `Repository[T]` |
+| [Configuration](storage/configuration.md) | YAML, secrets, export config et validation Pydantic |
+| [Securite](storage/security.md) | path traversal, noms utilisateurs, content-type, taille et permissions |
+| [Multitenant](storage/multitenant.md) | bucket/container/prefix par tenant et implications d'isolation |
+| [Use case complet](storage/use-case.md) | upload, metadata metier, download et delete |
+| [Filesystem](storage/filesystem.md) | adapter local et volumes Docker/Kubernetes |
+| [AWS S3](storage/s3.md) | config, MinIO, credentials, IAM minimal et smoke |
+| [Azure Blob](storage/azure-blob.md) | config, secrets, RBAC, Azurite et smoke |
+| [Google Cloud Storage](storage/gcs.md) | config, ADC/secrets, IAM et smoke |
 
 ## Contrat Commun
 
-Le port expose cinq opérations:
+Le domaine depend uniquement de `FileStoragePort`:
 
-| Méthode | Rôle |
+| Methode | Role |
 |---|---|
-| `put(key, content, ...)` | écrire un flux de bytes |
-| `get(key)` | lire les métadonnées et le flux |
-| `delete(key)` | supprimer un objet |
-| `exists(key)` | tester l'existence |
-| `stat(key)` | lire les métadonnées sans télécharger le contenu |
-
-Les modèles provider-neutral sont:
-
-- `StoredObjectMetadata`: clé, type MIME, taille, checksum, ETag,
-  date de modification et métadonnées custom;
-- `StoredObject`: métadonnées retournées après écriture;
-- `StoredObjectStream`: métadonnées plus flux async de bytes.
-
-## Clés D'objets
-
-Une clé de stockage est un chemin POSIX relatif. Elle ne doit jamais dépendre
-d'un chemin absolu local ou d'une URL provider.
-
-Exemples valides:
-
-```text
-tenant-a/invoices/2026-08.pdf
-exports/monthly/report.parquet
-avatars/user-123.png
-```
-
-Exemples refusés:
-
-```text
-/absolute/file.txt
-../private/file.txt
-folder/../file.txt
-folder//file.txt
-folder\file.txt
-```
-
-Utiliser `normalize_storage_key()` avant de joindre une clé avec un chemin local
-ou un préfixe backend. Cette règle protège les adapters filesystem contre la
-traversée de dossiers et garde les adapters cloud interchangeables.
-
-## Erreurs Communes
-
-Tous les adapters storage doivent traduire leurs erreurs provider vers ces
-exceptions:
-
-| Erreur | Usage |
-|---|---|
-| `FileStorageInvalidKey` | clé vide, absolue, non normalisée ou avec traversée |
-| `FileStorageNotFound` | objet absent |
-| `FileStorageConflict` | conflit d'écriture ou condition backend non satisfaite |
-| `FileStorageUnavailable` | backend indisponible |
-| `FileStoragePermissionDenied` | credentials ou policy refusés |
-
-Chaque erreur peut porter `key` pour aider les logs, sans exposer de secret.
-
-## Installer
-
-```bash
-arclith-cli add-adapter --capability storage --adapter filesystem --yes
-arclith-cli add-adapter --capability storage --adapter s3 --yes
-arclith-cli add-adapter --capability storage --adapter azure-blob --yes
-arclith-cli add-adapter --capability storage --adapter gcs --yes
-```
-
-Cette capability génère uniquement `config/adapters/outbound/storage.yaml`.
-Elle ne modifie pas `config/adapters/adapters.yaml`, car il n'y a pas de
-sélecteur repository à activer.
-
-## Filesystem
-
-Adapter cible pour un dossier monté dans Docker via volume.
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: filesystem
-root_path: "/data/files"
-prefix: ""
-create_root: true
-multitenant: false
-```
-
-Monter `/data/files` sur un volume persistant dans Docker ou Kubernetes.
-`prefix` reste relatif à `root_path`.
-
-### Utilisation Locale
-
-```python
-from arclith import Arclith
-
-app = Arclith("config")
-storage = app.file_storage()
-
-async def save_invoice(content: bytes) -> str:
-    await storage.put(
-        "invoices/2026-08.pdf",
-        _single_chunk(content),
-        content_type="application/pdf",
-        metadata={"kind": "invoice"},
-    )
-    return "invoices/2026-08.pdf"
-
-async def _single_chunk(content: bytes):
-    yield content
-```
-
-Le chemin `root_path` est un détail d'infrastructure. Les use cases manipulent
-uniquement des clés relatives comme `invoices/2026-08.pdf`.
-
-### Metadata Filesystem
-
-L'adapter filesystem stocke le contenu dans `root_path/prefix/<key>` et les
-métadonnées dans un sidecar JSON sous `.arclith-storage-metadata/`.
-
-Cette stratégie garde le contenu lisible comme des fichiers standards, tout en
-préservant `content_type`, `checksum`, `etag` et `custom`. Le répertoire
-`.arclith-storage-metadata/` est réservé: une clé utilisateur ne peut pas
-commencer par ce préfixe.
-
-### Docker Compose
-
-```yaml
-services:
-  api:
-    image: my-service:local
-    command: ["api"]
-    user: "1001:1001"
-    volumes:
-      - file-storage:/data/files
-
-volumes:
-  file-storage:
-```
-
-Pour un bind mount local:
-
-```yaml
-services:
-  api:
-    volumes:
-      - ./var/files:/data/files
-```
-
-Le dossier hôte doit appartenir à l'UID/GID utilisé dans le conteneur, par
-exemple `1001:1001` si l'image suit la baseline non-root.
-
-### Kubernetes
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: my-service-files
-spec:
-  accessModes: ["ReadWriteOnce"]
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-service-api
-spec:
-  template:
-    spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1001
-        runAsGroup: 1001
-        fsGroup: 1001
-      containers:
-        - name: api
-          image: ghcr.io/karned-rekipe/my-service:0.1.0
-          volumeMounts:
-            - name: file-storage
-              mountPath: /data/files
-      volumes:
-        - name: file-storage
-          persistentVolumeClaim:
-            claimName: my-service-files
-```
-
-Avec plusieurs réplicas, un filesystem local ou un volume `ReadWriteOnce` ne
-garantit pas le partage entre pods. Utiliser un stockage partagé compatible ou
-un provider objet pour les workloads multi-réplicas.
-
-### Production
-
-- Exécuter l'image avec un utilisateur non-root qui peut écrire dans le volume.
-- Sauvegarder le volume comme une donnée applicative.
-- Éviter les symlinks dans `root_path`: l'adapter refuse ceux qui sortent de la
-  racine, mais la plateforme doit aussi contrôler les permissions.
-- Ne pas exposer `root_path` dans les erreurs retournées aux clients.
-
-## AWS S3
-
-Installer l'extra uniquement dans les services qui utilisent S3:
-
-```bash
-uv add "arclith[s3]"
-```
-
-L'installation de base d'Arclith ne charge pas `boto3`.
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: s3
-bucket_name: "my-bucket"
-prefix: ""
-region_name: "eu-west-3"
-endpoint_url: null
-force_path_style: false
-multitenant: false
-```
-
-`endpoint_url: null` utilise AWS S3. Une URL explicite permet de viser MinIO ou
-un backend compatible S3. `force_path_style: true` est requis par beaucoup de
-backends locaux.
-
-### Credentials
-
-L'adapter garde la chaîne standard du SDK AWS par défaut. Ne pas écrire de clés
-dans `storage.yaml`.
-
-Sources courantes:
-
-- rôle IAM de la plateforme;
-- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`;
-- `AWS_PROFILE`;
-- `AWS_REGION` ou `AWS_DEFAULT_REGION` si `region_name` n'est pas configuré.
-
-En multitenant, le resolver tenant peut fournir les paramètres `bucket_name`,
-`prefix`, `endpoint_url`, `region_name`, `force_path_style`, `profile_name`,
-`aws_access_key_id`, `aws_secret_access_key` et `aws_session_token` dans
-`AdapterTenantCoords` pour l'adapter `s3`.
-
-### MinIO Local
-
-```yaml
-services:
-  minio:
-    image: quay.io/minio/minio:latest
-    command: ["server", "/data", "--console-address", ":9001"]
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - minio-data:/data
-
-  minio-init:
-    image: quay.io/minio/mc:latest
-    depends_on: [minio]
-    entrypoint: >
-      /bin/sh -c "
-      until mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done &&
-      mc mb -p local/arclith-files || true
-      "
-
-volumes:
-  minio-data:
-```
-
-Configuration Arclith depuis un conteneur du même compose:
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: s3
-bucket_name: "arclith-files"
-prefix: "uploads"
-region_name: "eu-west-3"
-endpoint_url: "http://minio:9000"
-force_path_style: true
-multitenant: false
-```
-
-Variables locales:
-
-```bash
-export AWS_ACCESS_KEY_ID=minioadmin
-export AWS_SECRET_ACCESS_KEY=minioadmin
-export AWS_DEFAULT_REGION=eu-west-3
-```
-
-Depuis la machine hôte hors Docker, utiliser
-`endpoint_url: "http://127.0.0.1:9000"`.
-
-### Use Case
-
-```python
-from collections.abc import AsyncIterator
-
-from arclith import FileStoragePort, StoredObjectStream
-
-
-class InvoiceStorageUseCase:
-    def __init__(self, storage: FileStoragePort) -> None:
-        self._storage = storage
-
-    async def upload_pdf(self, invoice_id: str, content: AsyncIterator[bytes]) -> str:
-        key = f"invoices/{invoice_id}.pdf"
-        await self._storage.put(
-            key,
-            content,
-            content_type="application/pdf",
-            metadata={"kind": "invoice"},
-        )
-        return key
-
-    async def download(self, key: str) -> StoredObjectStream:
-        return await self._storage.get(key)
-```
-
-Le use case dépend de `FileStoragePort`, jamais de `boto3`. La route FastAPI ou
-le tool MCP injecte le use case, pas le SDK S3.
-
-### IAM Minimal
-
-Pour un préfixe `uploads/` dans le bucket `my-bucket`, donner les permissions
-objet minimales:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
-      "Resource": "arn:aws:s3:::my-bucket/uploads/*"
-    }
-  ]
-}
-```
-
-`HeadObject` est couvert par `s3:GetObject`. Ajouter `s3:ListBucket` uniquement
-si un use case applicatif liste des objets; le port `FileStoragePort` actuel ne
-liste pas.
-
-## Azure Blob
-
-Installer l'extra uniquement dans les services qui utilisent Azure Blob Storage:
-
-```bash
-uv add "arclith[azure-blob]"
-```
-
-L'installation de base d'Arclith ne charge pas `azure-storage-blob` ni
-`azure-identity`.
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: azure-blob
-account_url: "https://<account>.blob.core.windows.net"
-container_name: "my-container"
-prefix: ""
-connection_string: null
-account_key: null
-sas_token: null
-use_default_credential: false
-multitenant: false
-```
-
-`account_url` cible le service Blob. `container_name` cible le container.
-`prefix` borne les objets applicatifs, comme pour S3/GCS.
-
-### Credentials
-
-Les credentials Azure ne doivent pas être versionnés dans `storage.yaml`.
-Arclith expose des champs de configuration, puis laisse le resolver de secrets
-habituel les alimenter depuis `config/secrets.yaml`, Vault, YAML local
-gitignoré ou le resolver `env`.
-
-Modes supportés:
-
-- `use_default_credential: true`: délègue au SDK Azure `DefaultAzureCredential`
-  pour Managed Identity, Workload Identity, Azure CLI ou environnement Azure;
-- `connection_string`: pratique pour Azurite ou certains déploiements legacy;
-- `account_key`: construit une credential Azure à partir du nom de compte
-  dérivé de `account_url`;
-- `sas_token`: token SAS sans l'écrire en clair dans Git.
-
-Un seul mode de credential doit être configuré à la fois.
-
-Exemple avec le resolver `env` explicite:
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: azure-blob
-account_url: "https://myaccount.blob.core.windows.net"
-container_name: "arclith-files"
-prefix: "uploads"
-connection_string: null
-account_key: null
-sas_token: null
-use_default_credential: false
-multitenant: false
-```
-
-```yaml
-# config/secrets.yaml
-resolver: env
-mappings:
-  adapters.storage.connection_string: AZURE_STORAGE_CONNECTION_STRING
-```
-
-Exemple avec Vault KV v2:
-
-```yaml
-# config/secrets.yaml
-resolver: vault
-vault:
-  addr: "http://vault:8200"
-  mount: "kv"
-mappings:
-  adapters.storage.sas_token: apps/my-service/azure-blob-sas-token
-```
-
-Le secret Vault doit exposer sa valeur dans le champ `value`, comme les autres
-secrets Arclith.
-
-En multitenant, le resolver tenant peut fournir `account_url`, `container_name`,
-`prefix`, `connection_string`, `account_key`, `sas_token` ou
-`use_default_credential` dans `AdapterTenantCoords` pour l'adapter
-`azure-blob`. Les alias `blob_service_url`, `container`, `conn_str`,
-`storage_account_key`, `default_credential` et `managed_identity` sont aussi
-acceptés.
-
-### Metadata Azure
-
-L'adapter retourne les métadonnées provider-neutral quand elles sont
-disponibles:
-
-- `content_type`, `size`, `etag`, `last_modified`;
-- checksum `md5:<value>` si Azure retourne `content_md5`;
-- metadata utilisateur;
-- `azure_blob_type` et `azure_version_id` dans `custom` si fournis par le SDK.
-
-Le checksum applicatif SHA-256 est utilisé comme fallback après `put()` si le
-SDK ne fournit pas encore de checksum provider sur le blob.
-
-### Use Case
-
-Le use case reste identique à S3, GCS ou filesystem: il dépend de
-`FileStoragePort`, jamais de `azure.storage.blob`.
-
-```python
-from collections.abc import AsyncIterator
-
-from arclith import FileStoragePort
-
-
-class AttachmentUseCase:
-    def __init__(self, storage: FileStoragePort) -> None:
-        self._storage = storage
-
-    async def save(self, ticket_id: str, content: AsyncIterator[bytes]) -> str:
-        key = f"tickets/{ticket_id}/attachment.bin"
-        await self._storage.put(
-            key,
-            content,
-            content_type="application/octet-stream",
-            metadata={"kind": "attachment"},
-        )
-        return key
-```
-
-### RBAC Minimal
-
-Pour le port actuel, l'identité Azure doit pouvoir créer, lire, mettre à jour
-les métadonnées et supprimer des blobs dans le container cible. Une base simple
-est le rôle `Storage Blob Data Contributor` sur le container ou sur un scope
-plus étroit.
-
-Pour un rôle custom, borner les actions au flux applicatif:
-
-- lire les propriétés et le contenu des blobs;
-- écrire ou remplacer un blob;
-- supprimer un blob.
-
-Ajouter la permission de lister les blobs uniquement si un futur use case liste
-des objets; `FileStoragePort` ne liste pas aujourd'hui.
-
-### Azurite Local
-
-Azurite donne un smoke test local sans compte Azure réel.
-
-```yaml
-services:
-  azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
-    command: ["azurite-blob", "--blobHost", "0.0.0.0"]
-    ports:
-      - "10000:10000"
-    volumes:
-      - azurite-data:/data
-
-volumes:
-  azurite-data:
-```
-
-Configuration Arclith depuis la machine hôte:
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: azure-blob
-account_url: "http://127.0.0.1:10000/devstoreaccount1"
-container_name: "arclith-files"
-prefix: "uploads"
-connection_string: null
-account_key: null
-sas_token: null
-use_default_credential: false
-multitenant: false
-```
-
-```yaml
-# config/secrets.yaml
-resolver: env
-mappings:
-  adapters.storage.connection_string: AZURE_STORAGE_CONNECTION_STRING
-```
-
-```bash
-export AZURE_STORAGE_CONNECTION_STRING="UseDevelopmentStorage=true"
-```
-
-Créer le container `arclith-files`, puis exécuter un smoke test applicatif qui
-écrit, lit, stat, vérifie `exists`, supprime puis revérifie `exists`.
-
-## Google Cloud Storage
-
-Installer l'extra uniquement dans les services qui utilisent GCS:
-
-```bash
-uv add "arclith[gcs]"
-```
-
-L'installation de base d'Arclith ne charge pas `google-cloud-storage`.
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: gcs
-bucket_name: "my-bucket"
-prefix: ""
-project_id: null
-credentials_path: null
-credentials_json: null
-credentials_json_b64: null
-multitenant: false
-```
-
-`project_id: null` laisse le SDK ou l'environnement résoudre le projet courant.
-Définir `project_id` quand l'identité de runtime peut voir plusieurs projets
-ou quand les credentials ne portent pas de projet par défaut fiable.
-
-### Credentials
-
-L'adapter utilise Application Default Credentials par défaut. Ne pas écrire de
-clé de service account dans `storage.yaml`.
-
-Sources courantes:
-
-- Workload Identity sur GKE ou identité managée de la plateforme;
-- `GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp-service-account.json`, chaîne
-  standard du SDK Google;
-- `credentials_path`, `credentials_json` ou `credentials_json_b64` résolus par
-  `config/secrets.yaml`, Vault, YAML local gitignoré ou le resolver `env`;
-- `credentials_path`, `credentials_json` ou `credentials_json_b64` fournis par
-  `TenantContext` en multitenant.
-
-Exemple avec le resolver `env`:
-
-```yaml
-# config/adapters/outbound/storage.yaml
-adapter: gcs
-bucket_name: "my-bucket"
-prefix: ""
-project_id: "my-project"
-credentials_json_b64: null
-multitenant: false
-```
-
-```yaml
-# config/secrets.yaml
-resolver: env
-mappings:
-  adapters.storage.credentials_json_b64: GCS_SERVICE_ACCOUNT_JSON_B64
-```
-
-Exemple avec Vault KV v2:
-
-```yaml
-# config/secrets.yaml
-resolver: vault
-vault:
-  addr: "http://vault:8200"
-  mount: "kv"
-mappings:
-  adapters.storage.credentials_json_b64: apps/my-service/gcs-service-account
-```
-
-Le secret Vault doit exposer sa valeur dans le champ `value`, comme les autres
-secrets Arclith.
-
-En multitenant, le resolver tenant peut fournir `bucket_name`, `prefix`,
-`project_id`, `credentials_path`, `credentials_json` ou `credentials_json_b64`
-dans `AdapterTenantCoords` pour l'adapter `gcs`. Les alias
-`service_account_file`, `service_account_json` et `service_account_json_b64`
-sont aussi acceptés.
-
-### Metadata GCS
-
-L'adapter retourne les métadonnées provider-neutral quand elles sont disponibles:
-
-- `content_type`, `size`, `etag`, `last_modified`;
-- checksum `crc32c:<value>` ou `md5:<value>`;
-- metadata utilisateur;
-- `gcs_generation` et `gcs_metageneration` dans `custom`.
-
-Le checksum applicatif SHA-256 est utilisé comme fallback après `put()` si le
-SDK ne fournit pas encore de checksum provider sur le blob.
-
-### Use Case
-
-Le use case reste identique à S3 ou filesystem: il dépend de `FileStoragePort`,
-jamais de `google.cloud.storage`.
-
-```python
-from collections.abc import AsyncIterator
-
-from arclith import FileStoragePort
-
-
-class AttachmentUseCase:
-    def __init__(self, storage: FileStoragePort) -> None:
-        self._storage = storage
-
-    async def save(self, ticket_id: str, content: AsyncIterator[bytes]) -> str:
-        key = f"tickets/{ticket_id}/attachment.bin"
-        await self._storage.put(
-            key,
-            content,
-            content_type="application/octet-stream",
-            metadata={"kind": "attachment"},
-        )
-        return key
-```
-
-### IAM Minimal
-
-Pour le port actuel, l'identité doit pouvoir créer, lire, mettre à jour les
-métadonnées et supprimer des objets dans le bucket cible. Une base simple côté
-bucket est `roles/storage.objectUser`. Pour un périmètre plus strict, créer un
-rôle custom avec les permissions nécessaires au flux applicatif:
-
-- `storage.objects.create`;
-- `storage.objects.get`;
-- `storage.objects.update`;
-- `storage.objects.delete`.
-
-Ajouter `storage.objects.list` uniquement si un futur use case liste les objets;
-`FileStoragePort` ne liste pas aujourd'hui.
-
-### Smoke Test
-
-GCS n'a pas d'émulateur officiel équivalent à MinIO pour S3. Le smoke test
-fiable vise donc un bucket sandbox réel, avec credentials de test et un préfixe
-temporaire:
-
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.secrets/gcs-sa.json"
-export GCS_SMOKE_BUCKET="arclith-storage-smoke"
-```
-
-Le test doit écrire, lire, stat, vérifier `exists`, supprimer puis revérifier
-`exists`. Ne jamais lancer ce smoke test contre un bucket de production.
-
-## Multitenant
-
-En mode single-tenant, la configuration doit contenir la cible backend minimale:
-
-| Adapter | Champs requis |
-|---|---|
-| `filesystem` | `root_path` |
-| `s3` | `bucket_name` |
-| `azure-blob` | `account_url`, `container_name` |
-| `gcs` | `bucket_name` |
-
-En mode `multitenant: true`, l'adapter peut résoudre bucket, container ou
-racine filesystem depuis le contexte tenant. Le contrat reste le même pour les
-use cases.
-
-Pour S3, deux modèles sont recommandés:
-
-- bucket par tenant: isolation forte, IAM plus simple par bucket;
-- préfixe par tenant: mutualise le bucket, mais exige des policies bornées sur
-  `arn:aws:s3:::bucket/<tenant-prefix>/*`.
-
-Pour GCS, les mêmes modèles s'appliquent:
-
-- bucket par tenant pour isoler IAM, lifecycle et quotas;
-- préfixe par tenant pour mutualiser un bucket avec des policies conditionnées.
-
-Pour Azure Blob, les mêmes modèles s'appliquent aussi:
-
-- container par tenant pour isoler RBAC, lifecycle et quotas;
-- préfixe par tenant pour mutualiser un container avec des policies ou SAS
-  bornées par préfixe quand le modèle de sécurité le permet.
-
-Si les credentials sont résolus par tenant, stocker les clés dans le resolver
-tenant, pas dans Git. Les coordonnées S3 attendues dans `TenantContext` sont
-celles de l'adapter `s3`: `bucket_name`, `prefix`, `endpoint_url`,
-`region_name`, `force_path_style`, `profile_name`, `aws_access_key_id`,
-`aws_secret_access_key`, `aws_session_token`.
-Pour Azure Blob, les coordonnées attendues sont `account_url`,
-`container_name`, `prefix`, `connection_string`, `account_key`, `sas_token` et
-`use_default_credential`.
-Pour GCS, les coordonnées attendues sont `bucket_name`, `prefix`, `project_id`,
-`credentials_path`, `credentials_json` et `credentials_json_b64`.
-
-## Règles
-
-- Les use cases parlent au port `FileStoragePort`, jamais au SDK cloud.
-- Les clés sont toujours relatives, normalisées et sans traversée.
-- Les streams restent async pour éviter de charger les gros fichiers en mémoire.
-- Les secrets provider ne sont pas stockés dans `storage.yaml`.
-- Les adapters concrets traduisent leurs erreurs vers les exceptions communes.
+| `put(key, content, content_type=None, metadata=None)` | stocke un flux async et retourne `StoredObject` |
+| `get(key)` | retourne `StoredObjectStream` avec metadata et flux async |
+| `stat(key)` | lit les metadata sans telecharger le contenu |
+| `exists(key)` | teste l'existence d'un objet |
+| `delete(key)` | supprime l'objet; les adapters cloud restent idempotents sur absent |
+
+Les metadata exposees sont neutres: `key`, `content_type`, `size`, `checksum`,
+`etag`, `last_modified` et `custom`.
+
+## Adapters Disponibles
+
+| Adapter | Extra | Usage |
+|---|---|---|
+| `filesystem` | aucun | dev local, tests, Docker volume |
+| `s3` | `arclith[s3]` | AWS S3 ou endpoint compatible comme MinIO |
+| `azure-blob` | `arclith[azure-blob]` | Azure Blob Storage |
+| `gcs` | `arclith[gcs]` | Google Cloud Storage |
+
+## Limites Hors Scope
+
+Le port couvre les operations objet minimales. Les sujets suivants doivent etre
+traites dans le service consommateur ou dans l'infrastructure:
+
+- antivirus et analyse de contenu;
+- quotas par utilisateur ou tenant;
+- lifecycle policies, retention legale et archivage froid;
+- CDN, cache HTTP et invalidation edge;
+- URLs signees et delegation de download direct;
+- listing, recherche et indexation des objets;
+- multipart/resumable upload expose au client final.
 
 ## Validation
 
 ```bash
-uv run pytest
+make docs
 uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
 ```
 
-## Adapters Disponibles
-
-Les adapters concrets disponibles sont `filesystem`, `s3`, `azure-blob` et
-`gcs`.
+Pour un premier flux executable, suivre le
+[quickstart filesystem](storage/quickstart.md).

--- a/docs/capabilities/storage/architecture.md
+++ b/docs/capabilities/storage/architecture.md
@@ -1,0 +1,98 @@
+# Architecture Storage
+
+`FileStoragePort` est un port outbound de stockage binaire. Il ne remplace pas
+les repositories et ne connait pas les entites metier.
+
+## Flux Canonique
+
+```text
+handler HTTP/MCP/worker
+  -> use case applicatif
+  -> FileStoragePort
+  -> adapter filesystem, s3, azure-blob ou gcs
+  -> backend de fichiers
+
+use case applicatif
+  -> Repository[T]
+  -> metadata metier, droits, statut, audit, index
+```
+
+La route FastAPI ou le tool MCP adapte le transport. La decision metier reste
+dans le use case, qui recoit `FileStoragePort` et `Repository[T]` en dependances.
+
+## Responsabilites
+
+| Couche | Responsabilite |
+|---|---|
+| domaine | definir l'entite et les regles metier |
+| application | orchestrer upload/download/delete |
+| `FileStoragePort` | contrat binaire provider-neutral |
+| adapter storage | parler au SDK ou au filesystem |
+| repository | persister les metadata metier |
+
+## Cles D'objet
+
+Les cles sont relatives et POSIX. `normalize_storage_key()` rejette:
+
+- chaine vide;
+- espace autour de la cle;
+- separateur Windows `\`;
+- chemin absolu;
+- segment vide, `.`, `..`;
+- chemin qui termine par `/`.
+
+Exemples valides:
+
+```text
+tenant-a/invoices/2026-08.pdf
+uploads/avatar.png
+exports/report.csv
+```
+
+Exemples invalides:
+
+```text
+/tmp/file.txt
+../secret.txt
+tenant-a//file.txt
+tenant-a/
+```
+
+## Metadata
+
+`StoredObjectMetadata` expose les champs communs:
+
+| Champ | Source typique |
+|---|---|
+| `key` | cle logique demandee au port |
+| `content_type` | argument `put()` ou metadata provider |
+| `size` | filesystem stat, S3/GCS/Azure properties |
+| `checksum` | sha256 local ou checksum provider |
+| `etag` | etag provider ou checksum local |
+| `last_modified` | horodatage provider ou filesystem |
+| `custom` | metadata custom mappees chez le provider |
+
+Les metadata metier restent ailleurs: nom original, statut de validation,
+proprietaire, visibilite, lien vers une entite parent, politique de retention.
+
+## Factory
+
+`Arclith("config").file_storage()` lit `config.adapters.storage`, puis delegue a
+`build_file_storage()`. Le registre par defaut sait construire `filesystem`,
+`s3`, `azure-blob` et `gcs`.
+
+Un service peut injecter directement un fake `FileStoragePort` en test unitaire,
+ou fournir un `FileStorageRegistry` dedie pour un adapter specifique.
+
+## Erreurs Communes
+
+| Erreur | Sens |
+|---|---|
+| `FileStorageInvalidKey` | cle invalide ou tentative de traversal |
+| `FileStorageNotFound` | objet absent sur `get()` ou `stat()` |
+| `FileStorageConflict` | conflit backend, par exemple repertoire a la place d'un fichier |
+| `FileStoragePermissionDenied` | credentials ou permissions insuffisantes |
+| `FileStorageUnavailable` | backend indisponible, config incomplete ou dependance absente |
+
+Les use cases attrapent ces erreurs metier, pas les exceptions `boto3`,
+`azure-storage-blob` ou `google-cloud-storage`.

--- a/docs/capabilities/storage/azure-blob.md
+++ b/docs/capabilities/storage/azure-blob.md
@@ -1,0 +1,145 @@
+# Azure Blob Storage
+
+`azure-blob` stocke les objets dans un container Azure Blob Storage.
+
+## Installer
+
+```bash
+uv add "arclith[azure-blob]"
+```
+
+## Configuration
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: azure-blob
+account_url: "https://<account>.blob.core.windows.net"
+container_name: "arclith-files"
+prefix: "uploads"
+connection_string: null
+account_key: null
+sas_token: null
+use_default_credential: true
+multitenant: false
+```
+
+| Champ | Role |
+|---|---|
+| `account_url` | URL du service Blob |
+| `container_name` | container cible |
+| `prefix` | prefixe applique devant les blobs |
+| `connection_string` | mode connection string |
+| `account_key` | mode cle de compte |
+| `sas_token` | mode SAS |
+| `use_default_credential` | utilise `DefaultAzureCredential` |
+| `multitenant` | autorise les coordonnees Azure dans `TenantContext` |
+
+Choisir un seul mode de credentials parmi `connection_string`, `account_key`,
+`sas_token` et `use_default_credential`. L'adapter rejette une configuration
+ambigue.
+
+## Secrets
+
+Mapper les secrets Azure dans `config/secrets.yaml`:
+
+```yaml
+# config/secrets.yaml
+resolver: chain
+chain:
+  - env
+  - vault
+  - yaml
+vault:
+  addr: "http://vault:8200"
+  mount: "kv"
+yaml:
+  path: "secrets.yaml"
+mappings:
+  adapters.storage.connection_string: AZURE_STORAGE_CONNECTION_STRING
+  adapters.storage.account_key: AZURE_STORAGE_ACCOUNT_KEY
+  adapters.storage.sas_token: AZURE_STORAGE_SAS_TOKEN
+```
+
+Conserver les champs correspondants a `null` dans `storage.yaml` quand ils sont
+resolus par secret mapping.
+
+## RBAC Minimal
+
+Avec Microsoft Entra ID et `use_default_credential: true`, assigner un role de
+donnees Blob au principal applicatif. Une base simple est
+`Storage Blob Data Contributor` au scope du container. Microsoft documente ce
+role pour lire, ecrire et supprimer des containers/blobs, et recommande de
+borner le scope au plus proche du besoin. Voir
+[Assign an Azure role for access to blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access).
+
+Si la politique de securite exige moins large, creer un role custom limite aux
+operations de donnees necessaires au port: upload, download, properties, exists
+et delete.
+
+## Azurite Local
+
+```yaml
+# docker-compose.azurite.yml
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    command: azurite-blob --blobHost 0.0.0.0 --loose
+    ports:
+      - "10000:10000"
+    volumes:
+      - azurite-data:/data
+
+volumes:
+  azurite-data:
+```
+
+Config locale:
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: azure-blob
+account_url: "http://127.0.0.1:10000/devstoreaccount1"
+container_name: "arclith-files"
+prefix: "uploads"
+connection_string: null
+account_key: null
+sas_token: null
+use_default_credential: false
+multitenant: false
+```
+
+Secret local:
+
+```yaml
+# config/secrets.yaml
+resolver: env
+mappings:
+  adapters.storage.connection_string: AZURE_STORAGE_CONNECTION_STRING
+```
+
+Injecter la connection string Azurite via l'environnement, creer le container
+`arclith-files`, puis lancer le smoke test du [quickstart](quickstart.md).
+
+## Multitenant
+
+En `multitenant: true`, le contexte tenant peut fournir `account_url`,
+`container_name`, `prefix`, `connection_string`, `account_key`, `sas_token` et
+`use_default_credential`. Les alias `blob_service_url`, `container`, `conn_str`,
+`storage_account_key`, `default_credential` et `managed_identity` sont acceptes.
+
+## Limites Connues
+
+- Pas de creation automatique de container.
+- Pas de generation de SAS ou d'URL signee.
+- Pas de lifecycle policy.
+- Pas de CDN Azure Front Door.
+- Pas de listing blob dans le port initial.
+
+## Validation
+
+```bash
+uv run python -c "from arclith import Arclith; Arclith('config').file_storage()"
+uv run python scripts/storage_smoke.py
+```
+
+Attendre la propagation RBAC avant de diagnostiquer un `FileStoragePermissionDenied`.

--- a/docs/capabilities/storage/configuration.md
+++ b/docs/capabilities/storage/configuration.md
@@ -36,9 +36,9 @@ normalise et sans segment `..`.
 | `azure-blob` | `account_url`, `container_name` | `prefix`, `connection_string`, `account_key`, `sas_token`, `use_default_credential`, `multitenant` |
 | `gcs` | `bucket_name` | `prefix`, `project_id`, `credentials_path`, `credentials_json`, `credentials_json_b64`, `multitenant` |
 
-En `multitenant: true`, la cible minimale peut venir du contexte tenant. La
-config de base peut donc omettre bucket, container ou root path si le resolver
-tenant les fournit a chaque requete.
+En `multitenant: true`, la cible minimale peut venir du contexte tenant pour les adapters cloud.
+La config de base peut donc omettre bucket ou container si le resolver tenant les fournit.
+L'adapter `filesystem` reste mono-cible: `root_path` doit toujours etre configure.
 
 ## Secrets
 

--- a/docs/capabilities/storage/configuration.md
+++ b/docs/capabilities/storage/configuration.md
@@ -1,0 +1,100 @@
+# Configuration Storage
+
+La configuration storage est portee par `StorageSettings` et chargee depuis
+`config/adapters/outbound/storage.yaml`.
+
+## Fichier Scoped
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: filesystem
+root_path: "/data/files"
+prefix: "uploads"
+create_root: true
+multitenant: false
+```
+
+Dans un dossier `config/`, ce fichier est merge sous `adapters.storage`.
+
+## Champs Communs
+
+| Champ | Type | Description |
+|---|---|---|
+| `adapter` | `filesystem`, `s3`, `azure-blob`, `gcs` | backend selectionne |
+| `prefix` | string | prefixe applique devant chaque cle objet |
+| `multitenant` | bool | autorise la resolution de cible via `TenantContext` |
+
+`prefix` utilise la meme validation que les cles objet. Il doit rester relatif,
+normalise et sans segment `..`.
+
+## Champs Par Adapter
+
+| Adapter | Champs requis en single-tenant | Champs optionnels |
+|---|---|---|
+| `filesystem` | `root_path` | `prefix`, `create_root`, `multitenant` |
+| `s3` | `bucket_name` | `prefix`, `region_name`, `endpoint_url`, `force_path_style`, `multitenant` |
+| `azure-blob` | `account_url`, `container_name` | `prefix`, `connection_string`, `account_key`, `sas_token`, `use_default_credential`, `multitenant` |
+| `gcs` | `bucket_name` | `prefix`, `project_id`, `credentials_path`, `credentials_json`, `credentials_json_b64`, `multitenant` |
+
+En `multitenant: true`, la cible minimale peut venir du contexte tenant. La
+config de base peut donc omettre bucket, container ou root path si le resolver
+tenant les fournit a chaque requete.
+
+## Secrets
+
+Les secrets ne doivent pas etre mis directement dans `storage.yaml`. Utiliser
+`config/secrets.yaml` pour mapper un champ Arclith vers un resolver `env`,
+`yaml`, `vault` ou `chain`.
+
+```yaml
+# config/secrets.yaml
+resolver: chain
+chain:
+  - env
+  - vault
+  - yaml
+vault:
+  addr: "http://vault:8200"
+  mount: "kv"
+yaml:
+  path: "secrets.yaml"
+mappings:
+  adapters.storage.connection_string: AZURE_STORAGE_CONNECTION_STRING
+  adapters.storage.credentials_json_b64: GCS_SERVICE_ACCOUNT_JSON_B64
+```
+
+La valeur de gauche est le champ Arclith a alimenter. La valeur de droite est la
+reference lue par le resolver. Avec `env`, Arclith essaie la cle explicite puis
+la cle derivee du champ.
+
+S3 suit la chaine de credentials standard `boto3` en single-tenant. Les champs
+AWS access key ne sont pas dans `StorageSettings`; utiliser un role IAM, un
+profil AWS, les variables standard du SDK ou des credentials par tenant via
+`TenantContext`.
+
+## Export Config
+
+Pour Kubernetes ou un runtime qui consomme un seul fichier YAML:
+
+```bash
+uv run python - <<'PY'
+from pathlib import Path
+
+from arclith import export_config_yaml
+
+export_config_yaml(Path("config"), Path("dist/config.yaml"))
+PY
+```
+
+`export_config_yaml()` merge la config versionnee et conserve les mappings de
+secrets. Il n'ecrit pas les valeurs secretes resolues dans le fichier exporte.
+
+## Validation
+
+```bash
+uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+uv run python -c "from arclith.infrastructure.config import load_config_file; load_config_file('dist/config.yaml')"
+```
+
+La validation Pydantic echoue si un champ inconnu est present ou si la cible
+requise du backend manque en single-tenant.

--- a/docs/capabilities/storage/filesystem.md
+++ b/docs/capabilities/storage/filesystem.md
@@ -1,0 +1,119 @@
+# Filesystem Storage
+
+`filesystem` stocke les objets dans un dossier local. C'est l'adapter de
+developpement, de test et de deploiement simple avec volume Docker.
+
+## Installer
+
+Aucune dependance optionnelle n'est necessaire.
+
+## Configuration
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: filesystem
+root_path: "/data/files"
+prefix: "uploads"
+create_root: true
+multitenant: false
+```
+
+| Champ | Role |
+|---|---|
+| `root_path` | dossier racine du stockage |
+| `prefix` | sous-prefixe logique ajoute devant les objets |
+| `create_root` | cree le dossier racine si absent |
+| `multitenant` | conserve pour symetrie config; l'adapter filesystem utilise `root_path` |
+
+Avec cette config, la cle logique `invoices/a.pdf` est ecrite sous
+`/data/files/uploads/invoices/a.pdf`.
+
+## Metadata Locales
+
+L'adapter conserve les metadata custom dans un dossier technique sous la racine:
+`.arclith-storage-metadata`. Ce dossier appartient a l'implementation et ne doit
+pas etre lu par les use cases.
+
+Les fichiers visibles dans `root_path` restent les objets eux-memes. La metadata
+metier durable reste dans un `Repository[T]`.
+
+## Docker
+
+Utiliser un volume persistant sur `/data/files`:
+
+```yaml
+services:
+  app:
+    image: my-service:local
+    volumes:
+      - file-storage:/data/files
+
+volumes:
+  file-storage:
+```
+
+Pour debugger depuis l'hote:
+
+```yaml
+services:
+  app:
+    volumes:
+      - ./var/files:/data/files
+```
+
+Le dossier monte doit etre accessible en lecture/ecriture par l'utilisateur du
+conteneur.
+
+## Kubernetes
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: file-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: my-service:latest
+          volumeMounts:
+            - name: file-storage
+              mountPath: /data/files
+      volumes:
+        - name: file-storage
+          persistentVolumeClaim:
+            claimName: file-storage
+```
+
+Adapter `accessModes`, `storageClassName` et strategie de backup aux contraintes
+du cluster.
+
+## Securite
+
+- Ne pas reutiliser le nom utilisateur comme chemin.
+- Monter uniquement le dossier necessaire, pas tout le filesystem hote.
+- Appliquer des permissions Unix strictes au volume.
+- Sauvegarder le volume si les fichiers sont critiques.
+- Ne pas partager le meme root path entre environnements.
+
+## Validation
+
+```bash
+uv run python -c "from arclith import Arclith; Arclith('config').file_storage()"
+uv run python scripts/storage_smoke.py
+```
+
+Le smoke test complet est decrit dans le
+[quickstart filesystem](quickstart.md).

--- a/docs/capabilities/storage/gcs.md
+++ b/docs/capabilities/storage/gcs.md
@@ -1,0 +1,118 @@
+# Google Cloud Storage
+
+`gcs` stocke les objets dans Google Cloud Storage.
+
+## Installer
+
+```bash
+uv add "arclith[gcs]"
+```
+
+## Configuration
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: gcs
+bucket_name: "arclith-files"
+prefix: "uploads"
+project_id: "my-project"
+credentials_path: null
+credentials_json: null
+credentials_json_b64: null
+multitenant: false
+```
+
+| Champ | Role |
+|---|---|
+| `bucket_name` | bucket cible |
+| `prefix` | prefixe applique devant les objets |
+| `project_id` | projet GCP passe au client |
+| `credentials_path` | chemin vers un service account JSON monte |
+| `credentials_json` | service account JSON injecte par secret |
+| `credentials_json_b64` | service account JSON encode en base64 |
+| `multitenant` | autorise les coordonnees GCS dans `TenantContext` |
+
+Si aucun credential explicite n'est fourni, le SDK utilise les Application
+Default Credentials du runtime.
+
+## ADC Et Secrets
+
+Preferer ADC sur Cloud Run, GKE ou Compute Engine. Pour un service account JSON
+local ou CI, ne jamais commiter le JSON. Mapper plutot le champ Arclith:
+
+```yaml
+# config/secrets.yaml
+resolver: chain
+chain:
+  - env
+  - vault
+  - yaml
+vault:
+  addr: "http://vault:8200"
+  mount: "kv"
+yaml:
+  path: "secrets.yaml"
+mappings:
+  adapters.storage.credentials_json_b64: GCS_SERVICE_ACCOUNT_JSON_B64
+```
+
+`credentials_path` doit pointer vers un fichier monte par le runtime. Le chemin
+peut etre versionne; le contenu du fichier ne doit pas l'etre.
+
+## IAM Minimal
+
+Une base simple au niveau bucket est `roles/storage.objectUser`, qui donne acces
+a la creation, lecture, mise a jour et suppression d'objets. Google documente
+aussi les permissions fines comme `storage.objects.create`,
+`storage.objects.get`, `storage.objects.update` et `storage.objects.delete`.
+Voir
+[IAM roles for Cloud Storage](https://docs.cloud.google.com/storage/docs/access-control/iam-roles).
+
+Pour un perimetre plus strict, creer un role custom limite aux operations du
+port. `FileStoragePort` ne liste pas les objets; ne pas ajouter
+`storage.objects.list` sauf si un use case de listing est introduit.
+
+## Smoke Test
+
+Google ne fournit pas d'emulateur GCS officiel equivalent a Azurite ou MinIO
+pour ce flux. Utiliser un bucket sandbox reel et un prefixe dedie:
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: gcs
+bucket_name: "arclith-storage-sandbox"
+prefix: "smoke"
+project_id: "my-project"
+credentials_path: null
+credentials_json: null
+credentials_json_b64: null
+multitenant: false
+```
+
+Lancer ensuite le smoke test du [quickstart](quickstart.md). Le script ecrit,
+lit, verifie `exists`, supprime puis reverifie `exists`.
+
+## Multitenant
+
+En `multitenant: true`, le contexte tenant peut fournir `bucket_name`, `prefix`,
+`project_id`, `credentials_path`, `credentials_json` et `credentials_json_b64`.
+Les alias `project`, `service_account_file`, `service_account_json` et
+`service_account_json_b64` sont acceptes.
+
+## Limites Connues
+
+- Pas de creation automatique de bucket.
+- Pas de signed URL.
+- Pas de lifecycle policy.
+- Pas de CDN Cloud CDN.
+- Pas de listing objet dans le port initial.
+- Pas de resumable upload expose au client final.
+
+## Validation
+
+```bash
+uv run python -c "from arclith import Arclith; Arclith('config').file_storage()"
+uv run python scripts/storage_smoke.py
+```
+
+Ne jamais utiliser un bucket de production pour le smoke test.

--- a/docs/capabilities/storage/multitenant.md
+++ b/docs/capabilities/storage/multitenant.md
@@ -1,0 +1,84 @@
+# Multitenant Storage
+
+`multitenant: true` permet a un adapter storage de completer sa configuration
+depuis le `TenantContext` courant.
+
+## Principe
+
+La config versionnee contient les defaults non sensibles. Le resolver tenant
+fournit les coordonnees propres au tenant: bucket, container, prefixe ou
+credentials cloud.
+
+```text
+auth -> tenant id -> TenantResolver -> TenantContext
+                                      -> adapter storage
+                                      -> cible tenant
+```
+
+Chaque adapter lit uniquement sa tranche de contexte: `s3`, `azure-blob` ou
+`gcs`.
+
+## Exemple De Contexte
+
+```python
+from arclith.adapters.context import set_tenant_context
+from arclith.domain.models.tenant import AdapterTenantCoords, TenantContext
+
+token = set_tenant_context(
+    TenantContext(
+        adapters={
+            "s3": AdapterTenantCoords(
+                params={
+                    "bucket_name": "tenant-a-files",
+                    "prefix": "uploads",
+                    "region_name": "eu-west-3",
+                }
+            )
+        }
+    )
+)
+try:
+    ...
+finally:
+    token.var.reset(token)
+```
+
+En production, le contexte est normalement pose par le pipeline d'auth ou par un
+resolver tenant, pas directement dans le use case.
+
+## Coordonnees Attendues
+
+| Adapter | Coordonnees tenant |
+|---|---|
+| `s3` | `bucket_name`, `prefix`, `region_name`, `endpoint_url`, `force_path_style`, `profile_name`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` |
+| `azure-blob` | `account_url`, `blob_service_url`, `container_name`, `container`, `prefix`, `connection_string`, `conn_str`, `account_key`, `storage_account_key`, `sas_token`, `use_default_credential`, `default_credential`, `managed_identity` |
+| `gcs` | `bucket_name`, `prefix`, `project_id`, `project`, `credentials_path`, `service_account_file`, `credentials_json`, `service_account_json`, `credentials_json_b64`, `service_account_json_b64` |
+
+Les alias existent pour faciliter l'integration avec un Vault deja structure.
+
+## Strategies D'isolation
+
+| Strategie | Quand l'utiliser |
+|---|---|
+| bucket/container par tenant | forte isolation IAM/RBAC, lifecycle et quotas par tenant |
+| prefixe par tenant | mutualisation simple, a condition de policies tres bornees |
+| credentials par tenant | comptes ou roles differents selon client |
+| volume ou deploiement filesystem par tenant | dev ou on-prem avec isolation par runtime |
+
+La strategie doit etre coherente avec les contraintes de suppression, audit,
+facturation et restauration.
+
+## Points D'attention
+
+- Ne pas melanger les fichiers de plusieurs tenants dans un prefixe partage sans
+  policy explicite.
+- Ne pas construire la cible tenant depuis une donnee utilisateur non verifiee.
+- Stocker les credentials tenant dans Vault ou un secret manager, jamais dans
+  Git.
+- Tester chaque tenant avec une cle de smoke isolee, par exemple
+  `smoke/<tenant-id>/health.txt`.
+
+## Suite
+
+Lire [Securite](security.md), puis la page du provider utilise:
+[S3](s3.md), [Azure Blob](azure-blob.md) ou [GCS](gcs.md).

--- a/docs/capabilities/storage/multitenant.md
+++ b/docs/capabilities/storage/multitenant.md
@@ -50,7 +50,7 @@ resolver tenant, pas directement dans le use case.
 
 | Adapter | Coordonnees tenant |
 |---|---|
-| `s3` | `bucket_name`, `prefix`, `region_name`, `endpoint_url`, `force_path_style`, `profile_name`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` |
+| `s3` | `bucket_name`, `prefix`, `region_name` (`region`), `endpoint_url`, `force_path_style`, `profile_name`, `aws_access_key_id` (`access_key_id`), `aws_secret_access_key` (`secret_access_key`), `aws_session_token` (`session_token`) |
 | `azure-blob` | `account_url`, `blob_service_url`, `container_name`, `container`, `prefix`, `connection_string`, `conn_str`, `account_key`, `storage_account_key`, `sas_token`, `use_default_credential`, `default_credential`, `managed_identity` |
 | `gcs` | `bucket_name`, `prefix`, `project_id`, `project`, `credentials_path`, `service_account_file`, `credentials_json`, `service_account_json`, `credentials_json_b64`, `service_account_json_b64` |
 

--- a/docs/capabilities/storage/quickstart.md
+++ b/docs/capabilities/storage/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart Filesystem
+
+Ce quickstart stocke les fichiers dans un dossier conteneur `/data/files`. En
+Docker, ce chemin est monte sur un volume persistant.
+
+## Ajouter L'adapter
+
+```bash
+arclith-cli add-adapter \
+  --capability storage \
+  --adapter filesystem \
+  --param root_path=/data/files \
+  --param prefix=uploads \
+  --param create_root=true \
+  --param multitenant=false \
+  --yes
+```
+
+Le CLI cree `config/adapters/outbound/storage.yaml`.
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: filesystem
+root_path: "/data/files"
+prefix: "uploads"
+create_root: true
+multitenant: false
+```
+
+`load_config_dir("config")` mappe ce fichier vers `adapters.storage` puis valide
+les champs avec Pydantic.
+
+## Smoke Test Local
+
+Creer `scripts/storage_smoke.py` dans le service consommateur:
+
+```python
+import asyncio
+from collections.abc import AsyncIterator
+
+from arclith import Arclith
+
+
+async def chunks(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+async def main() -> None:
+    storage = Arclith("config").file_storage()
+
+    stored = await storage.put(
+        "smoke/hello.txt",
+        chunks(b"hello arclith\n"),
+        content_type="text/plain",
+        metadata={"source": "quickstart"},
+    )
+    assert stored.key == "smoke/hello.txt"
+    assert stored.size == len(b"hello arclith\n")
+
+    stream = await storage.get("smoke/hello.txt")
+    payload = b"".join([chunk async for chunk in stream.body])
+    assert payload == b"hello arclith\n"
+    assert await storage.exists("smoke/hello.txt")
+
+    await storage.delete("smoke/hello.txt")
+    assert not await storage.exists("smoke/hello.txt")
+
+
+asyncio.run(main())
+```
+
+Lancer le test en local si `/data/files` existe sur la machine:
+
+```bash
+sudo mkdir -p /data/files
+sudo chown "$(id -u):$(id -g)" /data/files
+uv run python scripts/storage_smoke.py
+```
+
+## Docker Compose Avec Volume
+
+```yaml
+# docker-compose.storage.yml
+services:
+  storage-smoke:
+    build: .
+    working_dir: /app
+    command: uv run python scripts/storage_smoke.py
+    volumes:
+      - ./config:/app/config:ro
+      - ./scripts:/app/scripts:ro
+      - file-storage:/data/files
+
+volumes:
+  file-storage:
+```
+
+Validation:
+
+```bash
+docker compose -f docker-compose.storage.yml run --rm storage-smoke
+docker compose -f docker-compose.storage.yml down
+```
+
+Le volume Docker conserve les objets entre deux lancements. Pour inspecter
+facilement les fichiers depuis l'hote, remplacer le volume nomme par un bind
+mount local:
+
+```yaml
+services:
+  storage-smoke:
+    volumes:
+      - ./var/files:/data/files
+```
+
+## Suite
+
+Lire [Filesystem](filesystem.md), puis [Configuration](configuration.md).

--- a/docs/capabilities/storage/s3.md
+++ b/docs/capabilities/storage/s3.md
@@ -1,0 +1,140 @@
+# AWS S3 Storage
+
+`s3` stocke les objets dans AWS S3 ou dans un backend compatible S3 comme MinIO.
+
+## Installer
+
+```bash
+uv add "arclith[s3]"
+```
+
+## Configuration
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: s3
+bucket_name: "arclith-files"
+prefix: "uploads"
+region_name: "eu-west-3"
+endpoint_url: null
+force_path_style: false
+multitenant: false
+```
+
+| Champ | Role |
+|---|---|
+| `bucket_name` | bucket cible en single-tenant |
+| `prefix` | prefixe applique devant les objets |
+| `region_name` | region AWS passee a `boto3.Session` |
+| `endpoint_url` | endpoint custom, utile pour MinIO |
+| `force_path_style` | force le path-style S3 pour les compatibles S3 |
+| `multitenant` | autorise les coordonnees S3 dans `TenantContext` |
+
+## Credentials Et Secrets
+
+En single-tenant, l'adapter ne declare pas de champs `aws_access_key_id` dans
+`StorageSettings`. Il laisse `boto3` utiliser sa chaine standard: role IAM du
+runtime, profile AWS, variables standard du SDK ou credentials injectes par la
+plateforme.
+
+En production, preferer un role IAM ou workload identity. Si les credentials
+varient par tenant, les fournir via `TenantContext` avec ces cles:
+
+```text
+bucket_name
+prefix
+region_name
+endpoint_url
+force_path_style
+profile_name
+aws_access_key_id
+aws_secret_access_key
+aws_session_token
+```
+
+Ces valeurs tenant doivent venir de Vault ou d'un secret manager. Elles ne
+doivent pas etre commitees dans `storage.yaml`.
+
+## MinIO Local
+
+```yaml
+# docker-compose.minio.yml
+services:
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio-data:/data
+
+volumes:
+  minio-data:
+```
+
+Configuration Arclith locale:
+
+```yaml
+# config/adapters/outbound/storage.yaml
+adapter: s3
+bucket_name: "arclith-files"
+prefix: "uploads"
+region_name: "eu-west-3"
+endpoint_url: "http://127.0.0.1:9000"
+force_path_style: true
+multitenant: false
+```
+
+Demarrer MinIO, creer le bucket `arclith-files`, puis lancer le smoke test du
+[quickstart](quickstart.md) avec des credentials de developpement injectes dans
+l'environnement local.
+
+## IAM Minimal
+
+Pour le contrat actuel, borner les droits aux objets du prefixe utilise:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::arclith-files/uploads/*"
+    }
+  ]
+}
+```
+
+`FileStoragePort` ne liste pas les objets. Ajouter `s3:ListBucket` uniquement si
+un use case applicatif introduit explicitement du listing, avec une condition de
+prefixe.
+
+AWS documente que les operations objet S3 comme `GetObject`, `PutObject` et
+`DeleteObject` ciblent les ARN objets, y compris avec un prefixe. Voir
+[How Amazon S3 works with IAM](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security_iam_service-with-iam.html).
+
+## Limites Connues
+
+- Pas de creation automatique de bucket.
+- Pas de policy lifecycle ou retention.
+- Pas d'URL signee dans le port initial.
+- Pas de listing objet.
+- Pas d'upload multipart expose au client final.
+
+## Validation
+
+```bash
+uv run python -c "from arclith import Arclith; Arclith('config').file_storage()"
+uv run python scripts/storage_smoke.py
+```
+
+Ne jamais lancer un smoke test destructif sur un bucket de production.

--- a/docs/capabilities/storage/security.md
+++ b/docs/capabilities/storage/security.md
@@ -1,0 +1,93 @@
+# Securite Storage
+
+La capability storage fournit des garde-fous de base. Elle ne remplace pas les
+controles metier, les politiques cloud ou les services de securite du runtime.
+
+## Path Traversal
+
+Toutes les cles passent par `normalize_storage_key()` avant d'atteindre un
+backend. Une cle ne peut pas etre absolue, contenir `..`, contenir `//`, finir
+par `/` ou utiliser le separateur Windows `\`.
+
+Regle d'application: ne jamais reutiliser directement un nom de fichier fourni
+par l'utilisateur comme cle de stockage.
+
+```python
+from uuid6 import uuid7
+
+
+def build_document_key(tenant_id: str, original_filename: str) -> str:
+    extension = original_filename.rsplit(".", maxsplit=1)[-1].lower()
+    return f"{tenant_id}/documents/{uuid7()}.{extension}"
+```
+
+Le nom original reste une metadata metier dans le repository, pas une partie
+obligatoire de la cle objet.
+
+## Content-Type
+
+`content_type` est une indication de stockage, pas une preuve. Le service
+consommateur doit verifier le type attendu selon son besoin: extension, magic
+bytes, parseur metier ou service d'analyse.
+
+Ne pas accepter un contenu executable uniquement parce que le client annonce
+`text/plain` ou `image/png`.
+
+## Taille Maximale
+
+`FileStoragePort` ne decide pas d'une taille maximale globale. Le use case doit
+refuser trop tot les fichiers qui depassent la politique du produit.
+
+```python
+MAX_BYTES = 10 * 1024 * 1024
+
+
+def ensure_allowed_size(size: int) -> None:
+    if size > MAX_BYTES:
+        raise ValueError("file too large")
+```
+
+Pour les uploads HTTP, appliquer aussi une limite au niveau reverse proxy,
+serveur ASGI ou middleware.
+
+## Permissions Backend
+
+Les credentials doivent etre bornes au strict necessaire:
+
+- ecriture objet;
+- lecture objet;
+- lecture metadata;
+- suppression objet si le use case le permet.
+
+Ne pas donner de droits d'administration bucket/container a l'application. Les
+operations de creation de bucket, lifecycle, retention, CORS et CDN restent de
+la responsabilite de l'infrastructure.
+
+## Isolation Tenant
+
+En multitenant, choisir explicitement le niveau d'isolation:
+
+| Strategie | Isolation | Cout operationnel |
+|---|---|---|
+| bucket ou container par tenant | forte | plus de ressources a gerer |
+| prefixe par tenant | moyenne | policies plus fines et plus fragiles |
+| volume filesystem par tenant | forte si volume dedie | montage et permissions a maintenir |
+
+Le use case ne doit pas accepter un `tenant_id` arbitraire dans la cle. La cle
+derive du contexte d'authentification ou du `TenantContext`.
+
+## Hors Scope Initial
+
+Ces controles sont volontairement hors du port initial:
+
+- antivirus;
+- quotas;
+- lifecycle policies;
+- CDN;
+- URLs signees;
+- upload multipart expose au client final;
+- classification DLP;
+- chiffrement applicatif bout en bout.
+
+Ils peuvent etre ajoutes autour du use case ou dans un service specialise, sans
+changer le contrat minimal de `FileStoragePort`.

--- a/docs/capabilities/storage/use-case.md
+++ b/docs/capabilities/storage/use-case.md
@@ -1,0 +1,139 @@
+# Use Case Complet
+
+Cet exemple montre la frontiere attendue: le use case manipule le port storage
+et le repository metier. Il ne depend d'aucun SDK provider.
+
+## Entite De Metadata
+
+```python
+from uuid import UUID
+
+from arclith import Entity
+
+
+class Document(Entity):
+    owner_id: UUID
+    storage_key: str
+    original_filename: str
+    content_type: str | None
+    size: int | None
+    checksum: str | None
+```
+
+Le nom original, le proprietaire et les droits restent dans l'entite. Le backend
+storage ne sert pas de catalogue metier.
+
+## Upload
+
+```python
+from collections.abc import AsyncIterator
+from uuid import UUID
+
+from uuid6 import uuid7
+
+from arclith import FileStoragePort, Repository
+
+
+class UploadDocument:
+    def __init__(
+        self,
+        storage: FileStoragePort,
+        repository: Repository[Document],
+    ) -> None:
+        self._storage = storage
+        self._repository = repository
+
+    async def execute(
+        self,
+        *,
+        owner_id: UUID,
+        original_filename: str,
+        content: AsyncIterator[bytes],
+        content_type: str | None,
+    ) -> Document:
+        extension = original_filename.rsplit(".", maxsplit=1)[-1].lower()
+        key = f"{owner_id}/documents/{uuid7()}.{extension}"
+
+        stored = await self._storage.put(
+            key,
+            content,
+            content_type=content_type,
+            metadata={"owner_id": str(owner_id)},
+        )
+
+        document = Document(
+            owner_id=owner_id,
+            storage_key=stored.key,
+            original_filename=original_filename,
+            content_type=stored.content_type,
+            size=stored.size,
+            checksum=stored.checksum,
+        )
+        return await self._repository.create(document)
+```
+
+## Download
+
+```python
+from uuid import UUID
+
+from arclith import FileStoragePort, Repository, StoredObjectStream
+
+
+class DownloadDocument:
+    def __init__(
+        self,
+        storage: FileStoragePort,
+        repository: Repository[Document],
+    ) -> None:
+        self._storage = storage
+        self._repository = repository
+
+    async def execute(self, document_id: UUID) -> tuple[Document, StoredObjectStream]:
+        document = await self._repository.read(document_id)
+        if document is None:
+            raise LookupError("document metadata not found")
+
+        stream = await self._storage.get(document.storage_key)
+        return document, stream
+```
+
+Le handler HTTP transforme ensuite `stream.body` en reponse streaming. Cette
+conversion appartient au transport, pas au use case.
+
+## Delete
+
+```python
+from uuid import UUID
+
+from arclith import FileStoragePort, Repository
+
+
+class DeleteDocument:
+    def __init__(
+        self,
+        storage: FileStoragePort,
+        repository: Repository[Document],
+    ) -> None:
+        self._storage = storage
+        self._repository = repository
+
+    async def execute(self, document_id: UUID) -> None:
+        document = await self._repository.read(document_id)
+        if document is None:
+            return
+
+        await self._storage.delete(document.storage_key)
+        await self._repository.delete(document_id)
+```
+
+Selon le produit, l'ordre peut etre inverse ou compense par une file de retry.
+Le point important est de garder le choix transactionnel dans l'application, pas
+dans l'adapter.
+
+## Tests Unitaires
+
+Injecter un fake `FileStoragePort` suffit pour tester les regles du use case. Les
+smoke tests provider restent separes et verifies avec les pages
+[Filesystem](filesystem.md), [S3](s3.md), [Azure Blob](azure-blob.md) ou
+[GCS](gcs.md).

--- a/docs/capabilities/storage/use-case.md
+++ b/docs/capabilities/storage/use-case.md
@@ -1,7 +1,7 @@
 # Use Case Complet
 
-Cet exemple montre la frontiere attendue: le use case manipule le port storage
-et le repository metier. Il ne depend d'aucun SDK provider.
+Cet exemple montre la frontière attendue : le use case manipule le port storage
+et le repository métier. Il ne dépend d'aucun SDK provider.
 
 ## Entite De Metadata
 

--- a/docs/map.md
+++ b/docs/map.md
@@ -33,6 +33,7 @@ Cette page aide à choisir la bonne entrée dans la documentation Arclith.
 | probes et runtime | [Runtime et probes](production/runtime.md) |
 | Docker | [Docker](runtime-docker.md) |
 | Kubernetes | [Kubernetes](runtime-docker/kubernetes.md) |
+| fichiers et blobs | [Storage](capabilities/storage.md) |
 
 ## Je Veux Comprendre Une Capability
 
@@ -45,6 +46,11 @@ fiche dédiée:
 - [Command Bus](capabilities/command-bus.md)
 - [Repository](capabilities/repository.md)
 - [Storage](capabilities/storage.md)
+  ([quickstart](capabilities/storage/quickstart.md),
+  [configuration](capabilities/storage/configuration.md),
+  [S3](capabilities/storage/s3.md),
+  [Azure Blob](capabilities/storage/azure-blob.md),
+  [GCS](capabilities/storage/gcs.md))
 - [Auth](capabilities/auth.md)
 - [Tenant](capabilities/tenant.md)
 - [License](capabilities/license.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,18 @@ nav:
       - Probe: capabilities/probe.md
       - Runtime: capabilities/runtime.md
       - Repository: capabilities/repository.md
-      - Storage: capabilities/storage.md
+      - Storage:
+          - Vue d'ensemble: capabilities/storage.md
+          - Quickstart filesystem: capabilities/storage/quickstart.md
+          - Architecture: capabilities/storage/architecture.md
+          - Configuration: capabilities/storage/configuration.md
+          - Sécurité: capabilities/storage/security.md
+          - Multitenant: capabilities/storage/multitenant.md
+          - Use case complet: capabilities/storage/use-case.md
+          - Filesystem: capabilities/storage/filesystem.md
+          - AWS S3: capabilities/storage/s3.md
+          - Azure Blob: capabilities/storage/azure-blob.md
+          - Google Cloud Storage: capabilities/storage/gcs.md
       - Cache: capabilities/cache.md
       - Logger: capabilities/logger.md
       - Secrets: capabilities/secrets.md


### PR DESCRIPTION
## Summary
- split the FileStorage documentation into focused pages: overview, quickstart, architecture, configuration, security, multitenant, use case and provider pages
- document filesystem Docker volume usage and a local smoke test flow
- document S3, Azure Blob and GCS configuration, secrets/credential handling, minimal permissions, validation and known limits
- update MkDocs navigation, the documentation map and the capabilities catalogue

Closes #142

## Validation
- `make docs`
- `git diff --check`
- commit hook: `ruff check arclith`, `mypy arclith`, `bandit -r arclith -ll`
- pre-push hook: `ruff check arclith`, `bandit -r arclith -ll`, `mypy arclith`, `pytest --cov --cov-report=term-missing --cov-report=html` (509 passed, 1 skipped, coverage 91.64%)