### PR TITLE
Refactor quickstarts academy overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,17 +9,14 @@ hide:
     <div class="academy-hero__copy">
       <img class="academy-logo" src="assets/brand/arclith-logo-white.svg" alt="Arclith" />
       <p class="academy-eyebrow">Arclith Academy</p>
-      <h1>Du POC au projet complet, avec des frontières claires.</h1>
+      <h1>Le framework pour l'architecture hexagonale</h1>
       <p class="academy-lead">
-        Apprends Arclith dans le bon ordre: quickstart pour voir tourner,
-        foundations pour installer et comprendre, formation pour pratiquer,
-        capabilities pour approfondir, puis projets end to end.
+        Le code métier ne devrait pas dépendre d'un moteur de base de données
+        ou d'un moteur d'API. L'architecture hexagonale découple le code métier
+        des détails techniques. Arclith est un framework Python qui facilite
+        cette architecture pour créer des applications robustes, testables et
+        maintenables.
       </p>
-      <nav class="academy-actions" aria-label="Actions principales">
-        <a class="md-button md-button--primary" href="quickstarts/">Démarrer</a>
-        <a class="md-button" href="learning/training-path/">Se former</a>
-        <a class="md-button" href="capabilities/">Approfondir</a>
-      </nav>
     </div>
     <div class="academy-hero__media">
       <video
@@ -44,11 +41,7 @@ hide:
   <section class="academy-section" aria-labelledby="academy-categories-title">
     <div class="academy-section__header">
       <p class="academy-eyebrow">Parcours</p>
-      <h2 id="academy-categories-title">Choisir le bon niveau de lecture</h2>
-      <p>
-        Chaque section correspond à une intention: tester vite, comprendre,
-        apprendre un geste, approfondir un contrat ou réaliser un projet complet.
-      </p>
+      <h2 id="academy-categories-title">5 thèmes pour tout apprendre</h2>
     </div>
 
     <div class="academy-grid academy-grid--categories">
@@ -86,24 +79,6 @@ hide:
         <strong>Construire de A à Z</strong>
         <p>Réalisation end to end d'un projet concret avec domaine, API, MCP, agent et persistance.</p>
       </a>
-    </div>
-  </section>
-
-  <section class="academy-section" aria-labelledby="academy-featured-title">
-    <div class="academy-section__header">
-      <p class="academy-eyebrow">Chemin recommandé</p>
-      <h2 id="academy-featured-title">La prochaine étape utile</h2>
-    </div>
-
-    <div class="academy-featured">
-      <a href="quickstarts/">Quickstart</a>
-      <a href="learning/setup/">Préparer son poste</a>
-      <a href="foundations/what-is-arclith/">Comprendre Arclith</a>
-      <a href="learning/training-path/">Parcours de formation</a>
-      <a href="capabilities/structure/">Structure d'une capability</a>
-      <a href="capabilities/storage/">Storage</a>
-      <a href="production/baseline/">Baseline production</a>
-      <a href="tutorials/todo-list/">Projet Todo complet</a>
     </div>
   </section>
 </div>

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -1,17 +1,72 @@
 # Quickstarts
 
 Ces pages servent à vérifier les flux les plus fréquents en quelques minutes.
+Chaque quickstart valide un canal d'entrée Arclith, sans transformer ce test
+rapide en tutoriel complet.
 
-## Choisir
+<div class="quickstarts-overview">
+  <section class="academy-section" aria-labelledby="quickstarts-choose-title">
+    <div class="academy-section__header">
+      <p class="academy-eyebrow">Choisir</p>
+      <h2 id="quickstarts-choose-title">Un flux, un objectif de validation</h2>
+      <p>
+        Commence par l'API pour voir le service tourner, puis ajoute les
+        surfaces dont ton projet a besoin : MCP, bus RabbitMQ ou agent LangGraph.
+      </p>
+    </div>
 
-| Besoin | Page |
-|---|---|
-| Démarrer un service HTTP | [API](api.md) |
-| Exposer des tools MCP | [MCP](mcp.md) |
-| Ajouter un worker RabbitMQ | [Bus](bus.md) |
-| Préparer un agent LangGraph | [Agent](agent.md) |
+    <div class="academy-grid academy-grid--categories">
+      <a class="academy-card" href="api/">
+        <img src="../assets/academy/quickstarts.png" alt="" decoding="async" loading="lazy" />
+        <span class="academy-card__kicker">API</span>
+        <strong>Démarrer un service HTTP</strong>
+        <p>Initialiser un projet, lancer le mode API, vérifier la probe <code>/health</code> et ouvrir Swagger.</p>
+      </a>
 
-## Projet De Départ
+      <a class="academy-card" href="mcp/">
+        <img src="../assets/academy/reference.png" alt="" decoding="async" loading="lazy" />
+        <span class="academy-card__kicker">MCP</span>
+        <strong>Exposer des tools</strong>
+        <p>Lancer le transport MCP HTTP, contrôler <code>/info</code> et repérer l'URL FastMCP du serveur.</p>
+      </a>
+
+      <a class="academy-card" href="bus/">
+        <img src="../assets/academy/production.png" alt="" decoding="async" loading="lazy" />
+        <span class="academy-card__kicker">Bus</span>
+        <strong>Ajouter RabbitMQ</strong>
+        <p>Installer l'adapter command bus, charger la configuration et préparer le futur worker.</p>
+      </a>
+
+      <a class="academy-card" href="agent/">
+        <img src="../assets/academy/training.png" alt="" decoding="async" loading="lazy" />
+        <span class="academy-card__kicker">Agent</span>
+        <strong>Préparer LangGraph</strong>
+        <p>Ajouter l'adapter agent, générer <code>langgraph.json</code> et ouvrir Studio sur un graphe minimal.</p>
+      </a>
+    </div>
+  </section>
+
+  <section class="academy-section" aria-labelledby="quickstarts-path-title">
+    <div class="academy-section__header">
+      <p class="academy-eyebrow">Ordre recommandé</p>
+      <h2 id="quickstarts-path-title">Avancer du runtime vers l'orchestration</h2>
+      <p>
+        L'ordre ci-dessous garde une progression simple : service local, surface
+        outillée, traitement asynchrone, puis agent.
+      </p>
+    </div>
+
+    <div class="academy-featured">
+      <a href="api/">1. API locale</a>
+      <a href="mcp/">2. MCP HTTP</a>
+      <a href="bus/">3. Bus RabbitMQ</a>
+      <a href="agent/">4. Agent LangGraph</a>
+      <a href="../tutorials/todo-list/">Projet Todo complet</a>
+    </div>
+  </section>
+</div>
+
+## Projet de départ
 
 Si tu n'as pas encore de projet Arclith :
 
@@ -25,7 +80,8 @@ Les quickstarts partent ensuite de ce dossier.
 
 ## Règle
 
-Un quickstart valide seulement le bootstrap.
+Un quickstart valide seulement le bootstrap : l'application démarre, la
+configuration est chargée et la surface technique répond.
 
 Pour écrire du métier réel, suivre le [parcours Todo](../tutorials/todo-list/index.md).
 


### PR DESCRIPTION
## Summary
- keep the existing academy homepage refresh in the commit
- refactor the quickstarts overview with academy-style tiles for API, MCP, Bus, and Agent
- add a recommended quickstart path and clearer bootstrap guidance

## Validation
- make docs
- git diff --check
- Playwright preview of /quickstarts/
- local HTTP checks for /quickstarts/, /quickstarts/api/, /quickstarts/mcp/, /quickstarts/bus/, /quickstarts/agent/, and /tutorials/todo-list/
- pre-push hooks: ruff, bandit, mypy, pytest coverage: 509 passed, 1 skipped, 91.64%