### PR TITLE
docs: add local AI validation guide

### DIFF
--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -4,8 +4,8 @@ Ce guide part de zéro et aboutit à un service local qui expose:
 
 - une entité métier `Ingredient`;
 - une API FastAPI générée par `arclith-cli`;
-- un agent LangGraph testé dans LangGraph Studio;
-- des traces LangSmith;
+- un agent LangGraph testé via l'API locale, avec Studio si internet est disponible;
+- des traces LangSmith optionnelles;
 - un LLM local LM Studio via endpoint OpenAI-compatible.
 
 La règle d'architecture reste la même du début à la fin:
@@ -20,6 +20,8 @@ Demande naturelle
 ```
 
 Le LLM traduit l'intention. Il ne doit pas écrire directement dans la persistance.
+Pour les commandes à jour de validation offline LM Studio + LangGraph, voir
+[Validation IA locale](learning/local-ai-validation.md).
 
 ## 1. Prérequis
 
@@ -28,7 +30,7 @@ Le LLM traduit l'intention. Il ne doit pas écrire directement dans la persistan
 - `git`
 - LM Studio avec le Local Server démarré sur `http://127.0.0.1:1234/v1`
 - un modèle chargé dans LM Studio
-- une clé LangSmith si le tracing doit remonter dans LangSmith
+- une clé LangSmith seulement si le tracing doit remonter dans LangSmith
 
 Installer la CLI depuis le repository:
 
@@ -290,15 +292,40 @@ agent = arclith.langgraph(AgentState, register_agent, name="pantry_agent")
 Pour une autre entité, remplacer `pantry_agent`, `Ingredient`, `build_ingredient_service` et les
 prompts par les noms générés par `arclith-cli new`.
 
-## 6. Lancer LangGraph Studio
+## 6. Lancer LangGraph
 
 Dans un terminal dedie:
 
 ```bash
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run --frozen langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
-Dans LangGraph Studio, appeler le graphe `pantry_agent` avec un état:
+En offline, tester directement l'API locale:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "pantry_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "ajoute Sucre roux"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+L'API locale est documentée ici:
+
+```text
+http://127.0.0.1:2024/docs
+```
+
+Si internet est disponible, LangGraph Studio peut aussi appeler le graphe `pantry_agent` avec un
+état:
 
 ```json
 {
@@ -371,6 +398,7 @@ Le quickstart est valide seulement si:
 - le nœud agent appelle le service applicatif généré;
 - l'interpréteur d'intention applicatif traduit la demande en `IngredientIntent`;
 - LM Studio répond sur `/v1/models`;
+- LangGraph répond via l'API locale `:2024`;
 - LangSmith reçoit les traces quand `LANGSMITH_TRACING=true`.
 
 ## 9. Règles à conserver en projet réel
@@ -379,4 +407,5 @@ Le quickstart est valide seulement si:
 - Faire produire au LLM un objet structuré, puis laisser les use cases appliquer le métier.
 - Garder un interpréteur déterministe ou des tests sans LLM pour les gates CI.
 - Garder `.env` et les credentials hors Git.
-- Utiliser LangGraph Studio et LangSmith pour tester les conversations et inspecter les traces.
+- Utiliser l'API locale LangGraph pour les tests offline.
+- Utiliser LangGraph Studio et LangSmith pour inspecter les conversations quand ils sont disponibles.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -20,7 +20,7 @@ Demande naturelle
 ```
 
 Le LLM traduit l'intention. Il ne doit pas écrire directement dans la persistance.
-Pour les commandes à jour de validation offline LM Studio + LangGraph, voir
+Pour les commandes à jour de validation hors ligne LM Studio + LangGraph, voir
 [Validation IA locale](learning/local-ai-validation.md).
 
 ## 1. Prérequis
@@ -302,7 +302,7 @@ export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run --frozen langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
-En offline, tester directement l'API locale:
+Hors ligne, tester directement l'API locale:
 
 ```bash
 curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
@@ -407,5 +407,5 @@ Le quickstart est valide seulement si:
 - Faire produire au LLM un objet structuré, puis laisser les use cases appliquer le métier.
 - Garder un interpréteur déterministe ou des tests sans LLM pour les gates CI.
 - Garder `.env` et les credentials hors Git.
-- Utiliser l'API locale LangGraph pour les tests offline.
+- Utiliser l'API locale LangGraph pour les tests hors ligne.
 - Utiliser LangGraph Studio et LangSmith pour inspecter les conversations quand ils sont disponibles.

--- a/docs/capabilities/agent.md
+++ b/docs/capabilities/agent.md
@@ -11,7 +11,7 @@ un état de graphe, puis appelle les ports inbound ou use cases Arclith.
 
 | Adapter | Usage |
 |---|---|
-| `langgraph` | entrypoint LangGraph Studio |
+| `langgraph` | Agent Server local ou déployé, consommable par API |
 
 ## Commande
 
@@ -103,6 +103,17 @@ arclith-cli add-adapter --capability observability --adapter langsmith --yes
 LM Studio est pratique pour le local. LangSmith est optionnel mais utile pour
 inspecter les runs, messages et erreurs.
 
+Pour un développement hors ligne:
+
+```bash
+unset LANGSMITH_API_KEY LANGCHAIN_API_KEY
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
+```
+
+LangGraph Studio charge une UI hébergée. Sans internet, interagir avec l'Agent Server via son API
+locale ou via `langgraph_sdk`.
+
 ## Règles
 
 - Un node appelle un use case ou un port inbound.
@@ -123,6 +134,63 @@ Pour un lancement sans navigateur :
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
+API locale:
+
+```text
+http://127.0.0.1:2024
+http://127.0.0.1:2024/docs
+```
+
+Run rapide:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Reponds en une phrase."}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Inspection durable:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Reponds en une phrase."}]},"stream_mode":"values"}'
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+```
+
+Remplacer `agent` par le nom du graphe dans `langgraph.json`.
+
+## Serveur Central Ou Par Service
+
+En développement, un même `langgraph dev` peut exposer plusieurs graphes:
+
+```json
+{
+  "graphs": {
+    "todo_agent": "./src/app/adapters/inbound/langgraph/todo.py:agent",
+    "support_agent": "./src/app/adapters/inbound/langgraph/support.py:agent"
+  }
+}
+```
+
+En production, découper par bounded context. Un agent proche du service appelle ses propres ports et
+use cases. Un agent central peut orchestrer plusieurs services, mais il appelle leurs APIs, events ou
+tools MCP. Il ne lit pas directement leurs repositories ou bases.
+
 ## Suite
 
-Lire [llm](llm.md), [observability](observability.md), puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).
+Lire [llm](llm.md), [observability](observability.md), [Validation IA locale](../learning/local-ai-validation.md),
+puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).

--- a/docs/capabilities/agent.md
+++ b/docs/capabilities/agent.md
@@ -150,7 +150,7 @@ curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
     "assistant_id": "agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Reponds en une phrase."}
+        {"role": "human", "content": "Réponds en une phrase."}
       ]
     },
     "stream_mode": "values"
@@ -166,7 +166,7 @@ THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
 
 curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
   -H "Content-Type: application/json" \
-  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Reponds en une phrase."}]},"stream_mode":"values"}'
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Réponds en une phrase."}]},"stream_mode":"values"}'
 
 curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
 ```

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -126,7 +126,7 @@ curl -fsS http://127.0.0.1:1234/v1/chat/completions \
   -d '{
     "model": "<model-id-lm-studio>",
     "messages": [
-      {"role": "user", "content": "Reponds uniquement: ok"}
+      {"role": "user", "content": "Réponds uniquement: ok"}
     ],
     "stream": false
   }' | python -m json.tool
@@ -145,7 +145,7 @@ llm = ChatOpenAI(
     temperature=0,
 )
 
-print(llm.invoke("Reponds uniquement: ok").content)
+print(llm.invoke("Réponds uniquement: ok").content)
 PY
 ```
 
@@ -197,7 +197,7 @@ Vérifier au minimum:
 | provider OpenAI-compatible sans `base_url` | erreur de configuration |
 | secret absent pour OpenAI ou Anthropic | erreur explicite |
 | fake LLM en test unitaire | aucun appel réseau |
-| agent offline | `LANGSMITH_TRACING=false` et réponse via l'API LangGraph locale |
+| agent hors ligne | `LANGSMITH_TRACING=false` et réponse via l'API LangGraph locale |
 | agent avec observabilité active | traces visibles dans LangSmith |
 
 ## Suite

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -66,6 +66,14 @@ api_key: "lm-studio"
 base_url: "http://127.0.0.1:1234/v1"
 ```
 
+Le `model_name` doit être l'identifiant exact retourné par LM Studio:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/models | python -m json.tool
+```
+
+Ne pas inventer un alias comme `local-model` si LM Studio ne le déclare pas.
+
 OpenAI garde la clé dans `.env` via un mapping de secret:
 
 ```yaml
@@ -108,6 +116,42 @@ result = await use_case.execute(command)
 
 Éviter le chemin inverse où le prompt appelle directement le repository.
 
+## Test Local Minimal
+
+Avant de brancher l'agent, prouver que le modèle local répond:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "<model-id-lm-studio>",
+    "messages": [
+      {"role": "user", "content": "Reponds uniquement: ok"}
+    ],
+    "stream": false
+  }' | python -m json.tool
+```
+
+Puis prouver que le client Python utilisé par Arclith sait parler à cet endpoint:
+
+```bash
+uv run --with langchain-openai python - <<'PY'
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="<model-id-lm-studio>",
+    base_url="http://127.0.0.1:1234/v1",
+    api_key="lm-studio",
+    temperature=0,
+)
+
+print(llm.invoke("Reponds uniquement: ok").content)
+PY
+```
+
+Depuis Docker, remplacer souvent `127.0.0.1` par `host.docker.internal`, car `localhost` désigne le
+conteneur.
+
 ## Règles
 
 Le LLM interprète ou assiste. Il n'écrit pas directement dans la persistance.
@@ -132,6 +176,14 @@ LM Studio:
 curl -fsS http://127.0.0.1:1234/v1/models
 ```
 
+Chat Completions local:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<model-id-lm-studio>","messages":[{"role":"user","content":"ok ?"}],"stream":false}'
+```
+
 Tests:
 
 ```bash
@@ -145,6 +197,7 @@ Vérifier au minimum:
 | provider OpenAI-compatible sans `base_url` | erreur de configuration |
 | secret absent pour OpenAI ou Anthropic | erreur explicite |
 | fake LLM en test unitaire | aucun appel réseau |
+| agent offline | `LANGSMITH_TRACING=false` et réponse via l'API LangGraph locale |
 | agent avec observabilité active | traces visibles dans LangSmith |
 
 ## Suite
@@ -153,4 +206,5 @@ Lire aussi:
 
 - [Capability Agent](agent.md)
 - [Capability Observability](observability.md)
+- [Validation IA locale](../learning/local-ai-validation.md)
 - [Tutoriel agent](../tutorials/todo-list/06-agent-config.md)

--- a/docs/capabilities/mcp.md
+++ b/docs/capabilities/mcp.md
@@ -119,6 +119,11 @@ asyncio.run(main())
 PY
 ```
 
+LM Studio Chat peut aussi servir de client MCP local si le serveur est déclaré dans `mcp.json`.
+Cela permet de tester les tools avec un modèle local. Cette intégration concerne le serveur MCP,
+pas directement l'Agent Server LangGraph `:2024`.
+
 ## Suite
 
-Lire [auth](auth.md), [probe](probe.md), puis [Deep Dive MCP](../deep-dives/mcp.md).
+Lire [auth](auth.md), [probe](probe.md), [Deep Dive MCP](../deep-dives/mcp.md), puis
+[tester le MCP dans LM Studio](../tutorials/todo-list/05-mcp-lm-studio.md).

--- a/docs/capabilities/observability.md
+++ b/docs/capabilities/observability.md
@@ -53,6 +53,15 @@ endpoint: "https://api.smith.langchain.com"
 api_key_env: LANGSMITH_API_KEY
 ```
 
+LangSmith est optionnel pour exécuter un agent localement. Pour un poste offline:
+
+```bash
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
+```
+
+Le run se valide alors via l'API locale LangGraph `http://127.0.0.1:2024`, pas via Studio.
+
 ## Règles
 
 - OpenTelemetry sert au runtime, API, métriques et corrélation.
@@ -69,4 +78,5 @@ OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local uv run pytest
 
 ## Suite
 
-Lire [Observabilité production](../production/observability.md), [logger](logger.md) et [agent](agent.md).
+Lire [Observabilité production](../production/observability.md), [logger](logger.md),
+[agent](agent.md) et [Validation IA locale](../learning/local-ai-validation.md).

--- a/docs/capabilities/observability.md
+++ b/docs/capabilities/observability.md
@@ -53,7 +53,7 @@ endpoint: "https://api.smith.langchain.com"
 api_key_env: LANGSMITH_API_KEY
 ```
 
-LangSmith est optionnel pour exécuter un agent localement. Pour un poste offline:
+LangSmith est optionnel pour exécuter un agent localement. Pour un poste hors ligne:
 
 ```bash
 export LANGSMITH_TRACING=false

--- a/docs/deep-dives/agent.md
+++ b/docs/deep-dives/agent.md
@@ -19,6 +19,22 @@ message utilisateur
 
 Le LLM aide à interpréter. Il ne remplace pas les règles métier.
 
+## Runtime Et Frontière Microservice
+
+`langgraph dev` ou l'Agent Server déployé expose une API de runs et threads. Ce runtime peut être
+placé de deux façons:
+
+| Placement | Quand l'utiliser | Règle |
+| --- | --- | --- |
+| agent dans le service | l'agent manipule un seul domaine | il appelle les ports et use cases du service |
+| agent central | l'assistant orchestre plusieurs domaines | il appelle les APIs, events ou tools MCP des services |
+
+Un agent central ne doit pas importer les repositories des autres services et ne doit pas lire leurs
+bases directement. Sinon, il recrée un couplage de monolithe derrière une façade agentique.
+
+En développement, un même `langgraph.json` peut déclarer plusieurs graphes. En production, le
+découpage suit l'ownership, les secrets, les permissions et les besoins de scaling.
+
 ## État Du Graphe
 
 L'état doit être typé et limité aux informations utiles au parcours.
@@ -83,6 +99,15 @@ Activer LangSmith pour inspecter:
 | erreurs node | diagnostiquer un blocage |
 | sorties use case | vérifier l'action réelle |
 
+LangSmith est optionnel pour exécuter localement. En offline, désactiver le tracing et utiliser
+l'API locale de l'Agent Server:
+
+```bash
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
+uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
 ## Validation
 
 ```bash
@@ -92,6 +117,18 @@ uv run langgraph dev --no-browser --allow-blocking --port 2024
 Tester aussi les nodes sans serveur LangGraph quand c'est possible. Les tests
 unitaires doivent pouvoir utiliser un fake LLM.
 
+Pour inspecter un run sans Studio:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"ping"}]},"stream_mode":"values"}'
+```
+
+Pour relire l'état final, créer un thread explicite puis consulter
+`/threads/{thread_id}/state`. La procédure complète est dans
+[Validation IA locale](../learning/local-ai-validation.md).
+
 ## Erreurs Fréquentes
 
 | Erreur | Correction |
@@ -100,6 +137,7 @@ unitaires doivent pouvoir utiliser un fake LLM.
 | état non typé | définir un `TypedDict` explicite |
 | node trop large | découper interprétation, validation et action |
 | test dépendant du réseau | injecter un fake LLM |
+| Studio inaccessible hors ligne | utiliser l'API locale `:2024` |
 | trace absente | vérifier la config LangSmith et `.env` |
 
 ## Pages Liées

--- a/docs/deep-dives/agent.md
+++ b/docs/deep-dives/agent.md
@@ -99,7 +99,7 @@ Activer LangSmith pour inspecter:
 | erreurs node | diagnostiquer un blocage |
 | sorties use case | vérifier l'action réelle |
 
-LangSmith est optionnel pour exécuter localement. En offline, désactiver le tracing et utiliser
+LangSmith est optionnel pour exécuter localement. Hors ligne, désactiver le tracing et utiliser
 l'API locale de l'Agent Server:
 
 ```bash

--- a/docs/learning/local-ai-validation.md
+++ b/docs/learning/local-ai-validation.md
@@ -1,0 +1,262 @@
+# Validation IA Locale Et Hors Ligne
+
+Objectif: prouver rapidement qu'un LLM local, un adapter LLM Arclith et un agent LangGraph
+fonctionnent, même sans LangSmith ni accès internet.
+
+## Modèle Mental
+
+Trois composants sont séparés:
+
+```text
+client local, curl, UI ou test
+  -> Agent Server LangGraph :2024
+  -> adapter LLM Arclith / ChatOpenAI
+  -> LM Studio :1234/v1
+```
+
+LM Studio sert le modèle. LangGraph orchestre le graphe. Arclith garde le métier dans les ports et
+use cases.
+
+Ne pas confondre:
+
+| Besoin | Surface |
+| --- | --- |
+| tester que le modèle local répond | LM Studio `:1234/v1` |
+| tester que le graphe agent répond | LangGraph `:2024` |
+| inspecter un thread durable | API LangGraph `/threads/...` |
+| tracer dans LangSmith | optionnel, nécessite réseau et clé |
+| utiliser LM Studio Chat comme interface | possible via MCP, pas via `:2024` directement |
+
+## Préparer Le Mode Offline
+
+Pour un test strictement local:
+
+```bash
+unset LANGSMITH_API_KEY LANGCHAIN_API_KEY
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
+```
+
+Si le projet charge `.env`, conserver les mêmes valeurs dans `.env.local` ou `.env`:
+
+```dotenv
+LANGSMITH_TRACING=false
+LANGGRAPH_CLI_NO_ANALYTICS=1
+```
+
+LangGraph Studio charge une interface hébergée depuis `smith.langchain.com`. En offline, utiliser
+l'API locale, le SDK Python ou une petite UI locale.
+
+## Tester LM Studio
+
+Démarrer le serveur local LM Studio sur `http://127.0.0.1:1234/v1`, puis vérifier les modèles:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/models | python -m json.tool
+```
+
+Recopier le `id` exact du modèle chargé. Un alias inventé comme `local-model` peut être refusé par
+LM Studio.
+
+Tester une complétion minimale:
+
+```bash
+curl -fsS http://127.0.0.1:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistralai/ministral-3-3b",
+    "messages": [
+      {"role": "user", "content": "Reponds uniquement: ok"}
+    ],
+    "stream": false
+  }' | python -m json.tool
+```
+
+Remplacer `mistralai/ministral-3-3b` par l'identifiant retourné par `/v1/models`.
+
+## Tester L'Adapter LLM Arclith
+
+Installer et configurer l'adapter:
+
+```bash
+uv add "arclith[langgraph]"
+
+arclith-cli add-adapter \
+  --capability llm \
+  --adapter lmstudio \
+  --param model_name="<model-id-lm-studio>" \
+  --yes
+```
+
+Vérifier la configuration:
+
+```yaml
+# config/adapters/outbound/lm.yaml
+provider: openai
+model_name: "<model-id-lm-studio>"
+api_key: "lm-studio"
+base_url: "http://127.0.0.1:1234/v1"
+```
+
+Tester le client OpenAI-compatible depuis Python:
+
+```bash
+uv run --with langchain-openai python - <<'PY'
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="<model-id-lm-studio>",
+    base_url="http://127.0.0.1:1234/v1",
+    api_key="lm-studio",
+    temperature=0,
+)
+
+response = llm.invoke("Reponds uniquement: ok")
+print(response.content)
+PY
+```
+
+Ce test prouve que le modèle local, l'endpoint OpenAI-compatible et la dépendance Python sont
+cohérents. Les tests unitaires métier doivent rester sur un fake de port LLM.
+
+## Tester LangGraph Sans Studio
+
+Lancer l'Agent Server local:
+
+```bash
+uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
+Le serveur expose une API locale:
+
+```text
+http://127.0.0.1:2024
+http://127.0.0.1:2024/docs
+```
+
+Tester un run stateless:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "todo_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Le `assistant_id` doit correspondre au nom déclaré dans `langgraph.json`.
+
+## Inspecter Un Thread Durable
+
+Pour pouvoir relire l'état final, créer un thread explicite:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+echo "$THREAD_ID"
+```
+
+Lancer le run dans ce thread:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "todo_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Relire l'état et les runs:
+
+```bash
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/runs" | python -m json.tool
+```
+
+Utiliser `stream_mode: "values"` ou `"updates"` pour apprendre le graphe. `messages-tuple` est utile
+pour le streaming fin des messages, mais il est moins lisible au début.
+
+## Tester Avec Le SDK Python
+
+```bash
+uv run --with langgraph-sdk python - <<'PY'
+from langgraph_sdk import get_sync_client
+
+client = get_sync_client(url="http://127.0.0.1:2024")
+
+state = client.runs.wait(
+    None,
+    "todo_agent",
+    input={
+        "messages": [
+            {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+        ]
+    },
+)
+
+print(state)
+PY
+```
+
+Ce chemin est le plus pratique pour écrire un smoke test local automatisé.
+
+## LM Studio Chat Et LangGraph
+
+LM Studio Chat ne se branche pas directement sur `http://127.0.0.1:2024`, car l'Agent Server
+LangGraph n'expose pas une API Chat Completions. Deux chemins sont possibles:
+
+```text
+recommande:
+client -> LangGraph :2024 -> adapter LLM -> LM Studio :1234/v1
+
+possible:
+LM Studio Chat -> serveur MCP local -> LangGraph :2024
+```
+
+Le pont MCP est utile pour tester une ergonomie chat locale, mais LangGraph devient alors un tool
+appelé par LM Studio. Ce n'est pas le même modèle que LangGraph orchestrateur principal.
+
+## Architecture Microservice
+
+En développement, un seul `langgraph dev` peut exposer plusieurs graphes depuis `langgraph.json`.
+
+En production, découper selon le bounded context:
+
+- agent proche du service si l'agent manipule un domaine précis;
+- agent central si l'assistant orchestre plusieurs domaines;
+- jamais d'accès direct depuis l'agent central aux repositories ou bases des autres services.
+
+Un agent central appelle les APIs, events ou tools MCP des microservices. Les use cases restent
+propriétaires de leur métier.
+
+## Checklist
+
+- `/v1/models` retourne le `model id` local.
+- `/v1/chat/completions` répond avec ce `model id`.
+- `config/adapters/outbound/lm.yaml` utilise le même `model_name`.
+- `LANGSMITH_TRACING=false` est actif pour un test offline.
+- `langgraph dev --no-browser --allow-blocking --port 2024` démarre.
+- un run `values` répond via `/runs/stream`.
+- un thread explicite peut être relu via `/threads/{thread_id}/state`.
+- les tests unitaires importants utilisent un fake LLM.
+
+## Sources
+
+- LM Studio local server: <https://lmstudio.ai/docs/developer/core/server>
+- LM Studio OpenAI-compatible: <https://lmstudio.ai/docs/developer/openai-compat>
+- LM Studio MCP: <https://lmstudio.ai/docs/app/mcp>
+- LangGraph local server: <https://docs.langchain.com/oss/python/langgraph/local-server>

--- a/docs/learning/local-ai-validation.md
+++ b/docs/learning/local-ai-validation.md
@@ -27,7 +27,7 @@ Ne pas confondre:
 | tracer dans LangSmith | optionnel, nécessite réseau et clé |
 | utiliser LM Studio Chat comme interface | possible via MCP, pas via `:2024` directement |
 
-## Préparer Le Mode Offline
+## Préparer Le Mode Hors Ligne
 
 Pour un test strictement local:
 
@@ -44,7 +44,7 @@ LANGSMITH_TRACING=false
 LANGGRAPH_CLI_NO_ANALYTICS=1
 ```
 
-LangGraph Studio charge une interface hébergée depuis `smith.langchain.com`. En offline, utiliser
+LangGraph Studio charge une interface hébergée depuis `smith.langchain.com`. Hors ligne, utiliser
 l'API locale, le SDK Python ou une petite UI locale.
 
 ## Tester LM Studio
@@ -66,7 +66,7 @@ curl -fsS http://127.0.0.1:1234/v1/chat/completions \
   -d '{
     "model": "mistralai/ministral-3-3b",
     "messages": [
-      {"role": "user", "content": "Reponds uniquement: ok"}
+      {"role": "user", "content": "Réponds uniquement: ok"}
     ],
     "stream": false
   }' | python -m json.tool
@@ -111,7 +111,7 @@ llm = ChatOpenAI(
     temperature=0,
 )
 
-response = llm.invoke("Reponds uniquement: ok")
+response = llm.invoke("Réponds uniquement: ok")
 print(response.content)
 PY
 ```
@@ -143,7 +143,7 @@ curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
     "assistant_id": "todo_agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+        {"role": "human", "content": "Quelles sont mes tâches en cours ?"}
       ]
     },
     "stream_mode": "values"
@@ -173,7 +173,7 @@ curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
     "assistant_id": "todo_agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+        {"role": "human", "content": "Quelles sont mes tâches en cours ?"}
       ]
     },
     "stream_mode": "values"
@@ -203,7 +203,7 @@ state = client.runs.wait(
     "todo_agent",
     input={
         "messages": [
-            {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+            {"role": "human", "content": "Quelles sont mes tâches en cours ?"}
         ]
     },
 )
@@ -248,7 +248,7 @@ propriétaires de leur métier.
 - `/v1/models` retourne le `model id` local.
 - `/v1/chat/completions` répond avec ce `model id`.
 - `config/adapters/outbound/lm.yaml` utilise le même `model_name`.
-- `LANGSMITH_TRACING=false` est actif pour un test offline.
+- `LANGSMITH_TRACING=false` est actif pour un test hors ligne.
 - `langgraph dev --no-browser --allow-blocking --port 2024` démarre.
 - un run `values` répond via `/runs/stream`.
 - un thread explicite peut être relu via `/threads/{thread_id}/state`.

--- a/docs/learning/setup.md
+++ b/docs/learning/setup.md
@@ -47,6 +47,9 @@ curl -fsS http://127.0.0.1:1234/v1/models
 Si la commande échoue, ouvrir LM Studio, charger un modèle, puis activer le
 serveur local OpenAI-compatible.
 
+Pour prouver le chemin complet LM Studio, adapter LLM et LangGraph sans LangSmith, suivre
+[Validation IA locale et hors ligne](local-ai-validation.md).
+
 ## Validation
 
 ```bash
@@ -70,4 +73,5 @@ pas lancé ou n'écoute pas sur `127.0.0.1:1234`.
 
 ## Suite
 
-Lire [Comprendre le modèle](foundations.md).
+Lire [Comprendre le modèle](foundations.md), ou [Validation IA locale et hors ligne](local-ai-validation.md)
+si le parcours agent est prévu.

--- a/docs/learning/training-path.md
+++ b/docs/learning/training-path.md
@@ -12,7 +12,8 @@ Apprendre Arclith par niveaux de lecture, du POC au projet complet.
 2. lire les foundations pour préparer l'environnement et comprendre le modèle;
 3. suivre une formation ciblée pour apprendre un geste précis;
 4. lire la capability correspondante pour connaître le contrat complet;
-5. réaliser un projet end to end pour assembler les briques.
+5. valider les briques IA locales si le projet contient un agent;
+6. réaliser un projet end to end pour assembler les briques.
 
 Chaque bloc produit un résultat vérifiable. Ne pas avancer si la validation de
 la page courante échoue.
@@ -24,8 +25,9 @@ la page courante échoue.
 | 1 | [Quickstarts essentiels](quickstarts.md) | POC API, MCP, bus ou agent validé |
 | 2 | [Préparer son poste](setup.md) | CLI, Python et Docker prêts |
 | 3 | [Comprendre le modèle](foundations.md) | vocabulaire commun |
-| 4 | [Projet Todo](../tutorials/todo-list/index.md) | service complet |
-| 5 | [Validation finale](validation.md) | critères de passage validés |
+| 4 | [Validation IA locale](local-ai-validation.md) | LM Studio et LangGraph testés sans LangSmith |
+| 5 | [Projet Todo](../tutorials/todo-list/index.md) | service complet |
+| 6 | [Validation finale](validation.md) | critères de passage validés |
 
 Le format des supports vidéo et captures est décrit dans
 [Captures et vidéos](media.md).

--- a/docs/learning/validation.md
+++ b/docs/learning/validation.md
@@ -56,7 +56,7 @@ La revue doit vérifier:
 - validation d'entrée explicite;
 - erreurs HTTP cohérentes;
 - tests reproductibles;
-- mode offline explicite quand LangSmith n'est pas disponible;
+- mode hors ligne explicite quand LangSmith n'est pas disponible;
 - documentation de chaque capability activée.
 
 ## Média

--- a/docs/learning/validation.md
+++ b/docs/learning/validation.md
@@ -16,6 +16,7 @@ opérer un service simple.
 | API | exposer un use case via FastAPI |
 | MCP | exposer le même use case via un tool |
 | Agent | brancher un graphe qui appelle le use case |
+| IA locale | prouver LM Studio et LangGraph sans LangSmith |
 | Tests | tester le domaine sans serveur externe |
 | Production | expliquer auth, cache, secrets, observabilité et probes |
 | Docker | builder et lancer un runtime local |
@@ -30,17 +31,21 @@ Créer un service minimal avec:
 4. une API locale;
 5. un tool MCP;
 6. un repository `memory`;
-7. une validation Docker locale.
+7. un test LM Studio ou fake LLM documenté;
+8. une validation LangGraph locale par API;
+9. une validation Docker locale.
 
 ## Validation Technique
 
 ```bash
 uv run pytest
 curl -fsS http://127.0.0.1:8000/health
+curl -fsS http://127.0.0.1:1234/v1/models
 docker build -t arclith-training:local .
 ```
 
 Adapter le port HTTP si le projet généré utilise une autre valeur.
+Le test LM Studio peut être remplacé par un fake LLM si le poste est volontairement sans modèle local.
 
 ## Revue
 
@@ -51,6 +56,7 @@ La revue doit vérifier:
 - validation d'entrée explicite;
 - erreurs HTTP cohérentes;
 - tests reproductibles;
+- mode offline explicite quand LangSmith n'est pas disponible;
 - documentation de chaque capability activée.
 
 ## Média
@@ -61,4 +67,5 @@ La revue doit vérifier:
 
 ## Suite
 
-Lire les [deep dives](../deep-dives/api.md) selon le besoin du projet.
+Lire les [deep dives](../deep-dives/api.md) selon le besoin du projet, et
+[Validation IA locale](local-ai-validation.md) pour les projets agent.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -264,18 +264,33 @@ Exemple de ports applicatifs cibles:
 - `TracePort`: envoie les traces LangSmith ou autre;
 - `EventBusPort`: publie des événements si besoin.
 
-### LangSmith comme banc de test
+### LangGraph local comme banc de test
 
 Arclith ne génère pas d'UI dédiée pour tester un agent. Le chemin standard est un adapter
-`agent/langgraph` testé dans LangGraph Studio, avec les traces branchées sur LangSmith:
+`agent/langgraph` testé via l'Agent Server local. LangGraph Studio et LangSmith sont utiles pour
+inspecter les conversations quand internet et la clé sont disponibles, mais ils ne sont pas requis
+pour valider un run local:
 
 ```bash
 uv add "arclith[langgraph]"
 arclith-cli add-adapter --capability llm --adapter lmstudio --param "model_name=<model-id-lm-studio>" --yes
 arclith-cli add-adapter --capability agent --adapter langgraph
 arclith-cli add-adapter --capability observability --adapter langsmith
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+Tester sans Studio:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"ping"}]},"stream_mode":"values"}'
+```
+
+Pour les commandes complètes LM Studio, threads et inspection de state, lire
+[Validation IA locale](learning/local-ai-validation.md).
 
 L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet n'a plus qu'à modifier ce fichier

--- a/docs/quickstarts/agent.md
+++ b/docs/quickstarts/agent.md
@@ -53,7 +53,7 @@ curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
     "assistant_id": "agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Reponds uniquement: ok"}
+        {"role": "human", "content": "Réponds uniquement: ok"}
       ]
     },
     "stream_mode": "values"
@@ -69,7 +69,7 @@ THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
 
 curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
   -H "Content-Type: application/json" \
-  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Reponds uniquement: ok"}]},"stream_mode":"values"}'
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Réponds uniquement: ok"}]},"stream_mode":"values"}'
 
 curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
 ```
@@ -80,7 +80,7 @@ L'Agent Server local répond sur `http://127.0.0.1:2024`. La documentation API l
 sur `http://127.0.0.1:2024/docs`.
 
 LangGraph Studio détecte aussi le graphe généré depuis `langgraph.json`, mais son UI hébergée
-nécessite un accès internet. En offline, la validation se fait par API ou SDK.
+nécessite un accès internet. Hors ligne, la validation se fait par API ou SDK.
 
 Le graphe généré est volontairement minimal. Le projet remplace ensuite l'état, les nœuds et les
 transitions pour appeler ses use cases.

--- a/docs/quickstarts/agent.md
+++ b/docs/quickstarts/agent.md
@@ -39,12 +39,48 @@ uvx --from arclith-cli arclith-cli add-adapter \
 ## Validation
 
 ```bash
-uv run langgraph dev
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
+uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
+Dans un second terminal:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Reponds uniquement: ok"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Pour inspecter l'état après le run, utiliser un thread:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"agent","input":{"messages":[{"role":"human","content":"Reponds uniquement: ok"}]},"stream_mode":"values"}'
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
 ```
 
 ## Résultat
 
-LangGraph Studio détecte le graphe généré depuis `langgraph.json`.
+L'Agent Server local répond sur `http://127.0.0.1:2024`. La documentation API locale est disponible
+sur `http://127.0.0.1:2024/docs`.
+
+LangGraph Studio détecte aussi le graphe généré depuis `langgraph.json`, mais son UI hébergée
+nécessite un accès internet. En offline, la validation se fait par API ou SDK.
 
 Le graphe généré est volontairement minimal. Le projet remplace ensuite l'état, les nœuds et les
 transitions pour appeler ses use cases.
@@ -52,9 +88,10 @@ transitions pour appeler ses use cases.
 ## Média
 
 !!! note "Média à produire"
-    Capture : LangGraph Studio avec le graphe chargé.
-    Vidéo : ajout agent, lancement Studio, premier run.
+    Capture : terminal avec `langgraph dev` et réponse API.
+    Vidéo : ajout agent, lancement local, premier run API, puis Studio si internet disponible.
 
 ## Suite
 
-Lire [agent/langgraph](../capabilities/agent.md), puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).
+Lire [agent/langgraph](../capabilities/agent.md), [Validation IA locale](../learning/local-ai-validation.md),
+puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -41,7 +41,7 @@ rapide en tutoriel complet.
         <img src="../assets/academy/training.png" alt="" decoding="async" loading="lazy" />
         <span class="academy-card__kicker">Agent</span>
         <strong>Préparer LangGraph</strong>
-        <p>Ajouter l'adapter agent, générer <code>langgraph.json</code> et ouvrir Studio sur un graphe minimal.</p>
+        <p>Ajouter l'adapter agent, générer <code>langgraph.json</code> et tester l'Agent Server local.</p>
       </a>
     </div>
   </section>
@@ -61,6 +61,7 @@ rapide en tutoriel complet.
       <a href="mcp/">2. MCP HTTP</a>
       <a href="bus/">3. Bus RabbitMQ</a>
       <a href="agent/">4. Agent LangGraph</a>
+      <a href="../learning/local-ai-validation/">Validation IA locale</a>
       <a href="../tutorials/todo-list/">Projet Todo complet</a>
     </div>
   </section>

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -71,7 +71,7 @@ http://127.0.0.1:2024
 http://127.0.0.1:2024/docs
 ```
 
-LangSmith Studio est optionnel et nécessite un accès réseau. En offline, déclencher un run par API:
+LangSmith Studio est optionnel et nécessite un accès réseau. Hors ligne, déclencher un run par API:
 
 ```bash
 curl -N -X POST "http://127.0.0.1:2024/runs/stream" \

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -43,6 +43,8 @@ docker build -t my-service:local .
 ```bash
 docker run --rm \
   --env-file .env.local \
+  -e LANGSMITH_TRACING=false \
+  -e LANGGRAPH_CLI_NO_ANALYTICS=1 \
   -e LANGGRAPH_HOST=0.0.0.0 \
   -e LANGGRAPH_PORT=2024 \
   -p 2024:2024 \
@@ -62,15 +64,45 @@ docker run --rm \
 
 ## Vérifier
 
-Ouvrir LangSmith Studio ou le client agent sur:
+Ouvrir le client agent sur:
 
 ```text
 http://127.0.0.1:2024
+http://127.0.0.1:2024/docs
+```
+
+LangSmith Studio est optionnel et nécessite un accès réseau. En offline, déclencher un run par API:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "my_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "ping"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
 ```
 
 Pour une validation complète, déclencher un run avec un `thread_id` durable et vérifier que le graphe
-appelle bien les ports/use cases du projet. Le conteneur qui expose l'agent ne doit pas écrire en
-base directement depuis le LLM.
+appelle bien les ports/use cases du projet:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"my_agent","input":{"messages":[{"role":"human","content":"ping"}]},"stream_mode":"values"}'
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+```
+
+Le conteneur qui expose l'agent ne doit pas écrire en base directement depuis le LLM.
 
 ## Secrets
 
@@ -102,8 +134,10 @@ docker run --rm --env-file .env.local my-service:local agent
 - LLM comme adapter outbound, jamais comme accès direct à la persistance.
 - Variables LLM injectées au runtime uniquement.
 - `host.docker.internal` utilisé quand le modèle tourne sur le poste hôte.
+- API locale `:2024` testée même sans LangSmith.
 - Traces LangSmith/OpenTelemetry activées par configuration, pas par code métier.
 - En production, remplacer `langgraph dev` par la commande serveur validée du projet via
   `ARCLITH_AGENT_COMMAND` si nécessaire.
 
-Page suivante: [autres modes locaux](local-other-modes.md).
+Page suivante: [autres modes locaux](local-other-modes.md). Voir aussi
+[Validation IA locale](../learning/local-ai-validation.md).

--- a/docs/tutorials/todo-list/00-lm-studio.md
+++ b/docs/tutorials/todo-list/00-lm-studio.md
@@ -68,6 +68,28 @@ curl -fsS http://127.0.0.1:1234/v1/chat/completions \
   }' | python -m json.tool
 ```
 
+Tester ensuite le même endpoint avec le client Python utilisé côté agent:
+
+```bash
+uv run --with langchain-openai python - <<'PY'
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="mistralai/ministral-3-3b",
+    base_url="http://127.0.0.1:1234/v1",
+    api_key="lm-studio",
+    temperature=0,
+)
+
+response = llm.invoke("Reponds uniquement: ok")
+print(response.content)
+PY
+```
+
+Remplacer `mistralai/ministral-3-3b` par l'`id` exact retourné par `/v1/models`. Ce deuxième test
+prouve que le serveur LM Studio et l'intégration OpenAI-compatible utilisée par LangChain sont
+cohérents.
+
 ## Informations à garder
 
 | Élément | Valeur locale du tutoriel |
@@ -103,5 +125,8 @@ arclith-cli add-adapter \
 | `invalid model identifier` | model id incorrect | recopier l'`id` de `/v1/models` |
 | erreur `response_format` | version Arclith incompatible | utiliser `arclith>=0.15.0` |
 | appel depuis Docker impossible | `localhost` pointe dans le container | utiliser `host.docker.internal:1234` |
+
+Pour un guide plus complet sur le mode offline, lire
+[Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 Étape suivante: [initialiser le projet](01-init-project.md).

--- a/docs/tutorials/todo-list/00-lm-studio.md
+++ b/docs/tutorials/todo-list/00-lm-studio.md
@@ -81,7 +81,7 @@ llm = ChatOpenAI(
     temperature=0,
 )
 
-response = llm.invoke("Reponds uniquement: ok")
+response = llm.invoke("Réponds uniquement: ok")
 print(response.content)
 PY
 ```
@@ -126,7 +126,7 @@ arclith-cli add-adapter \
 | erreur `response_format` | version Arclith incompatible | utiliser `arclith>=0.15.0` |
 | appel depuis Docker impossible | `localhost` pointe dans le container | utiliser `host.docker.internal:1234` |
 
-Pour un guide plus complet sur le mode offline, lire
+Pour un guide plus complet sur le mode hors ligne, lire
 [Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 Étape suivante: [initialiser le projet](01-init-project.md).

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -146,6 +146,15 @@ Le graphe est déclaré dans `langgraph.json`:
 todo_agent -> src/todo_list_service/adapters/inbound/langgraph/agent.py:agent
 ```
 
+Si Studio n'est pas accessible, ouvrir l'API locale:
+
+```text
+http://127.0.0.1:2024/docs
+```
+
+Les commandes `curl` de validation offline sont regroupées dans
+[Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
+
 ## Découpage principal
 
 ```text

--- a/docs/tutorials/todo-list/01-init-project.md
+++ b/docs/tutorials/todo-list/01-init-project.md
@@ -152,7 +152,7 @@ Si Studio n'est pas accessible, ouvrir l'API locale:
 http://127.0.0.1:2024/docs
 ```
 
-Les commandes `curl` de validation offline sont regroupées dans
+Les commandes `curl` de validation hors ligne sont regroupées dans
 [Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 ## Découpage principal

--- a/docs/tutorials/todo-list/05-mcp-lm-studio.md
+++ b/docs/tutorials/todo-list/05-mcp-lm-studio.md
@@ -41,4 +41,19 @@ serveur `http://127.0.0.1:8121/mcp`, et que les logs du service Arclith montrent
 
 ![Flux LM Studio vers MCP Arclith](assets/05-lmstudio-mcp.svg)
 
+## Et LangGraph ?
+
+LM Studio Chat consomme ici un serveur MCP. Il ne se branche pas directement sur l'Agent Server
+LangGraph `http://127.0.0.1:2024`, car cette API expose des `threads` et des `runs`, pas une API MCP
+ou Chat Completions.
+
+Le chemin recommandé pour l'agent reste:
+
+```text
+client local -> LangGraph :2024 -> adapter LLM -> LM Studio :1234/v1
+```
+
+Un pont MCP peut appeler LangGraph, mais il doit être développé comme serveur MCP dédié. Dans ce cas,
+LM Studio orchestre le chat et LangGraph devient un tool appelé par le modèle.
+
 Étape suivante: [ajouter un agent](06-agent.md).

--- a/docs/tutorials/todo-list/06-agent-config.md
+++ b/docs/tutorials/todo-list/06-agent-config.md
@@ -48,6 +48,14 @@ base_url: "http://127.0.0.1:1234/v1"
 
 LangSmith est optionnel pour exécuter localement, mais utile pour inspecter les runs.
 
+Si vous travaillez hors ligne, désactiver explicitement le tracing et passer directement à la
+configuration LangGraph:
+
+```dotenv
+LANGSMITH_TRACING=false
+LANGGRAPH_CLI_NO_ANALYTICS=1
+```
+
 ```bash
 arclith-cli add-adapter --capability observability
 ```
@@ -85,6 +93,9 @@ La clé reste dans `.env`, jamais dans Git. LangSmith sert à observer l'agent:
 - LM Studio fournit le modèle local;
 - LangSmith affiche les runs, les messages, les appels LLM et les erreurs.
 
+Sans internet, LangGraph continue de tourner localement. L'inspection se fait alors avec
+`http://127.0.0.1:2024/docs`, `/runs/stream` et `/threads/{thread_id}/state`.
+
 ![Flux LangGraph et LangSmith](assets/06-langsmith-flow.svg)
 
 ## LangGraph config
@@ -109,5 +120,8 @@ Modifier `langgraph.json`:
   "env": ".env"
 }
 ```
+
+Pour prouver cette configuration avant de continuer, utiliser
+[Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 Étape suivante: [écrire les intent-interpreters](06-agent-intent-interpreters.md).

--- a/docs/tutorials/todo-list/06-agent-intent-interpreters.md
+++ b/docs/tutorials/todo-list/06-agent-intent-interpreters.md
@@ -35,8 +35,8 @@ class TodoActionInterpreter:
             output_type=TodoActionDecision,
             instructions=(
                 "Tu classes l'intention d'un utilisateur qui parle a un agent de gestion de todos. "
-                "Retourne create_todo quand il veut creer, ajouter ou enregistrer une tache. "
-                "Retourne list_todos quand il veut afficher, lister ou consulter les taches existantes. "
+                "Retourne create_todo quand il veut creer, ajouter ou enregistrer une tâche. "
+                "Retourne list_todos quand il veut afficher, lister ou consulter les tâches existantes. "
                 "Retourne cancel_todo_creation quand il annule une creation de todo en cours. "
                 "Retourne unknown quand l'intention n'est pas une action todo prise en charge."
             ),

--- a/docs/tutorials/todo-list/06-agent-tests-studio.md
+++ b/docs/tutorials/todo-list/06-agent-tests-studio.md
@@ -1,7 +1,7 @@
 # 6.7 Tester l'agent
 
 Intention: verrouiller le comportement agent sans dépendre d'un LLM réel pour les cas déterministes,
-puis tester le graphe dans LangGraph Studio.
+puis tester le graphe avec l'API locale LangGraph. Studio reste utile quand internet est disponible.
 
 ## Tests unitaires
 
@@ -289,19 +289,66 @@ Ces tests couvrent les comportements importants:
 - `Qu'est ce que je dois faire aujourd'hui ?` liste les todos au lieu de créer une tâche;
 - les prompts ambigus passent par `TodoActionInterpreter`.
 
-## LangGraph Studio
+## LangGraph API Locale
 
-Lancer LangGraph Studio:
+Lancer l'Agent Server local:
 
 ```bash
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
-Le terminal affiche une URL de ce type:
+Le terminal affiche une API locale et, si internet est disponible, une URL Studio:
 
 ```text
+http://127.0.0.1:2024
+http://127.0.0.1:2024/docs
 https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024
 ```
+
+En offline, utiliser l'API locale. Tester un run stateless:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "todo_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Je dois acheter des bananes demain"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Créer ensuite un thread durable pour relire l'état:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "todo_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/runs" | python -m json.tool
+```
+
+## LangGraph Studio
+
+Si Studio est accessible, utiliser les mêmes payloads depuis l'interface.
 
 Créer une todo simple:
 
@@ -375,5 +422,8 @@ Résultat attendu:
 ```text
 Creation de todo annulee.
 ```
+
+Pour plus de commandes offline, lire
+[Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 Étape suivante: [annexes locales](07-local-services.md).

--- a/docs/tutorials/todo-list/06-agent-tests-studio.md
+++ b/docs/tutorials/todo-list/06-agent-tests-studio.md
@@ -220,7 +220,7 @@ def test_detect_high_confidence_action_does_not_match_substrings() -> None:
 
 
 def test_detect_high_confidence_action_keeps_vague_todo_prompt_for_llm() -> None:
-    result = detect_high_confidence_action("mes taches importantes", {})
+    result = detect_high_confidence_action("mes tâches importantes", {})
 
     assert result == TodoAction.UNKNOWN
 
@@ -307,7 +307,7 @@ http://127.0.0.1:2024/docs
 https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024
 ```
 
-En offline, utiliser l'API locale. Tester un run stateless:
+Hors ligne, utiliser l'API locale. Tester un run stateless:
 
 ```bash
 curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
@@ -336,7 +336,7 @@ curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
     "assistant_id": "todo_agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+        {"role": "human", "content": "Quelles sont mes tâches en cours ?"}
       ]
     },
     "stream_mode": "values"
@@ -423,7 +423,7 @@ Résultat attendu:
 Creation de todo annulee.
 ```
 
-Pour plus de commandes offline, lire
+Pour plus de commandes hors ligne, lire
 [Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 Étape suivante: [annexes locales](07-local-services.md).

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -244,11 +244,49 @@ MODE=mcp_http uv run python main.py
 LangGraph:
 
 ```bash
+export LANGSMITH_TRACING=false
+export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
 À partir de là, une todo créée par Swagger, par LM Studio via MCP ou par LangGraph doit être visible
 par les autres canaux.
+
+## Valider LangGraph En Offline
+
+Studio est utile pour apprendre le graphe, mais l'UI hébergée n'est pas nécessaire. En offline,
+tester l'Agent Server local par API:
+
+```bash
+curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "todo_agent",
+    "input": {
+      "messages": [
+        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+      ]
+    },
+    "stream_mode": "values"
+  }'
+```
+
+Pour prouver la persistance de conversation, créer un thread:
+
+```bash
+THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}' | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id":"todo_agent","input":{"messages":[{"role":"human","content":"Quelles sont mes taches en cours ?"}]},"stream_mode":"values"}'
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+```
+
+Les données métier doivent venir de MongoDB via `TodoRepositoryPort`, pas de la mémoire interne du
+processus LangGraph.
 
 ## Visualiser MongoDB avec Compass
 
@@ -331,6 +369,8 @@ Les deux sont complémentaires:
 | corréler plusieurs microservices | OpenTelemetry |
 
 Pour ce tutoriel, LangSmith aide à apprendre l'agent. OpenTelemetry prépare la suite production.
+Pour travailler sans internet, garder LangSmith désactivé et suivre
+[Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
 
 ## Tout valider
 

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -252,9 +252,9 @@ uv run langgraph dev --no-browser --allow-blocking --port 2024
 À partir de là, une todo créée par Swagger, par LM Studio via MCP ou par LangGraph doit être visible
 par les autres canaux.
 
-## Valider LangGraph En Offline
+## Valider LangGraph Hors Ligne
 
-Studio est utile pour apprendre le graphe, mais l'UI hébergée n'est pas nécessaire. En offline,
+Studio est utile pour apprendre le graphe, mais l'UI hébergée n'est pas nécessaire. Hors ligne,
 tester l'Agent Server local par API:
 
 ```bash
@@ -264,7 +264,7 @@ curl -N -X POST "http://127.0.0.1:2024/runs/stream" \
     "assistant_id": "todo_agent",
     "input": {
       "messages": [
-        {"role": "human", "content": "Quelles sont mes taches en cours ?"}
+        {"role": "human", "content": "Quelles sont mes tâches en cours ?"}
       ]
     },
     "stream_mode": "values"
@@ -280,7 +280,7 @@ THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
 
 curl -N -X POST "http://127.0.0.1:2024/threads/$THREAD_ID/runs/stream" \
   -H "Content-Type: application/json" \
-  -d '{"assistant_id":"todo_agent","input":{"messages":[{"role":"human","content":"Quelles sont mes taches en cours ?"}]},"stream_mode":"values"}'
+  -d '{"assistant_id":"todo_agent","input":{"messages":[{"role":"human","content":"Quelles sont mes tâches en cours ?"}]},"stream_mode":"values"}'
 
 curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
 ```

--- a/docs/tutorials/todo-list/index.md
+++ b/docs/tutorials/todo-list/index.md
@@ -109,6 +109,9 @@ Les étapes API, MCP et agent sont découpées en sous-étapes:
 - LM Studio pour l'agent et le test MCP depuis LM Studio;
 - une clé LangSmith si vous voulez tracer l'agent dans LangSmith.
 
+LangSmith n'est pas requis pour travailler hors ligne. Le chemin complet LM Studio + LangGraph local
+est détaillé dans [Validation IA locale et hors ligne](../../learning/local-ai-validation.md).
+
 Installer la CLI publiée:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Quickstarts essentiels: learning/quickstarts.md
       - Format d'une page: learning/page-format.md
       - Captures et vidéos: learning/media.md
+      - Validation IA locale: learning/local-ai-validation.md
       - Validation finale: learning/validation.md
   - Capabilities:
       - Catalogue: capabilities.md


### PR DESCRIPTION
## Summary
- add a central local/offline AI validation guide for LM Studio and LangGraph
- link the guide from setup, quickstarts, capabilities, deep dives, Docker runtime, and Todo tutorial pages
- clarify offline LangGraph API usage, durable thread inspection, LM Studio Chat via MCP, and service-boundary guidance

## Validation
- make docs
- git diff --check
- commit hook: ruff, mypy, bandit
- push hook: ruff, bandit, mypy, pytest with coverage (509 passed, 1 skipped, 91.64%)