### PR TITLE
feat: add structured LLM streaming progress

### DIFF
--- a/arclith/adapters/outbound/pydantic_ai/llm.py
+++ b/arclith/adapters/outbound/pydantic_ai/llm.py
@@ -1,6 +1,15 @@
+from collections.abc import AsyncIterator
+from typing import Any
 from typing import TypeVar
 
-from arclith.domain.ports.outbound.llm import LLMPort
+from arclith.domain.ports.outbound.llm import (
+    LLMPort,
+    LLMProgressEvent,
+    LLMStreamEvent,
+    LLMStructuredChunk,
+    LLMStructuredFinal,
+    LLMStructuredStreamOptions,
+)
 from arclith.infrastructure.config import LMSettings
 from arclith.infrastructure.lm import build_pydantic_ai_model
 
@@ -18,12 +27,64 @@ class PydanticAILLMAdapter(LLMPort):
         output_type: type[T],
         instructions: str,
     ) -> T:
+        agent = self._build_agent(output_type=output_type, instructions=instructions)
+        result = await agent.run(prompt)
+        return result.output
+
+    async def stream_structured(
+        self,
+        prompt: str,
+        *,
+        output_type: type[T],
+        instructions: str,
+        stream_options: LLMStructuredStreamOptions | None = None,
+    ) -> AsyncIterator[LLMStreamEvent[T]]:
+        options = stream_options or LLMStructuredStreamOptions()
+        agent = self._build_agent(output_type=output_type, instructions=instructions)
+
+        if options.include_progress:
+            yield LLMProgressEvent(
+                stage="llm.started",
+                message="Structured completion started.",
+            )
+
+        if not options.include_snapshots:
+            result = await agent.run(prompt)
+            yield LLMStructuredFinal(output=result.output)
+            return
+
+        sequence = 0
+        async with agent.run_stream(prompt) as result:
+            if options.include_progress:
+                yield LLMProgressEvent(
+                    stage="llm.streaming",
+                    message="Structured output stream opened.",
+                )
+
+            async for output in result.stream_output(debounce_by=options.debounce_by):
+                sequence += 1
+                yield LLMStructuredChunk(output=output, sequence=sequence)
+
+            final_output = result.get_output()
+
+        if options.include_progress:
+            yield LLMProgressEvent(
+                stage="llm.completed",
+                message="Structured completion finished.",
+                metadata={"snapshots": sequence},
+            )
+        yield LLMStructuredFinal(output=final_output, metadata={"snapshots": sequence})
+
+    def _build_agent(
+        self,
+        *,
+        output_type: type[T],
+        instructions: str,
+    ) -> Any:
         from pydantic_ai import Agent
 
-        agent = Agent(
+        return Agent(
             build_pydantic_ai_model(self._settings),
             output_type=output_type,
             instructions=instructions,
         )
-        result = await agent.run(prompt)
-        return result.output

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -15,7 +15,7 @@ from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
-from arclith.infrastructure.config import AppConfig, load_config_dir, load_config_file
+from arclith.infrastructure.config import AppConfig, LangGraphStreamMode, load_config_dir, load_config_file
 from arclith.infrastructure.file_storage_factory import FileStorageRegistry
 from arclith.infrastructure.repository_factory import RepositoryRegistry
 
@@ -44,6 +44,16 @@ _LEVEL_MAP: dict[str, LogLevel] = {
     "ERROR": LogLevel.ERROR,
     "CRITICAL": LogLevel.CRITICAL,
 }
+
+
+def _normalize_langgraph_stream_mode(
+    stream_mode: LangGraphStreamMode | Sequence[LangGraphStreamMode],
+) -> LangGraphStreamMode | list[LangGraphStreamMode]:
+    if isinstance(stream_mode, str):
+        return stream_mode
+    return list(stream_mode)
+
+
 class _UvicornLogInterceptHandler(logging.Handler):
     def __init__(self, logger: Logger) -> None:
         super().__init__()
@@ -433,6 +443,7 @@ class Arclith:
         interrupt_before: Any = None,
         interrupt_after: Any = None,
         debug: bool = False,
+        stream_mode: LangGraphStreamMode | Sequence[LangGraphStreamMode] | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
     ) -> Any:
         from langgraph.graph import StateGraph
@@ -444,7 +455,7 @@ class Arclith:
             output_schema=output_schema,
         )
         register_graph(builder, self)
-        return builder.compile(
+        compiled = builder.compile(
             checkpointer=checkpointer,
             cache=cache,
             store=store,
@@ -454,6 +465,12 @@ class Arclith:
             name=name,
             transformers=transformers,
         )
+        resolved_stream_mode = stream_mode
+        if resolved_stream_mode is None and self.config.langgraph is not None:
+            resolved_stream_mode = self.config.langgraph.stream_mode
+        if resolved_stream_mode is not None:
+            setattr(compiled, "stream_mode", _normalize_langgraph_stream_mode(resolved_stream_mode))
+        return compiled
 
     def run_api(self, app: "FastAPI | str") -> None:
         import uvicorn

--- a/arclith/domain/ports/outbound/llm.py
+++ b/arclith/domain/ports/outbound/llm.py
@@ -1,7 +1,98 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import asdict, dataclass, field, is_dataclass
+from types import MappingProxyType
+from typing import Any, Literal, TypeVar
 
 T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class LLMStructuredStreamOptions:
+    """Options for structured LLM streaming."""
+
+    include_progress: bool = True
+    include_snapshots: bool = True
+    debounce_by: float | None = 0.1
+
+    def __post_init__(self) -> None:
+        if self.debounce_by is not None and self.debounce_by < 0:
+            raise ValueError("debounce_by must be >= 0 or None")
+
+
+@dataclass(frozen=True)
+class LLMProgressEvent:
+    """Provider-neutral progress event emitted during a structured LLM run."""
+
+    stage: str
+    message: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    kind: Literal["progress"] = "progress"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+@dataclass(frozen=True)
+class LLMStructuredChunk[T]:
+    """Accumulated, partially validated structured output snapshot."""
+
+    output: T
+    sequence: int
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    kind: Literal["structured_chunk"] = "structured_chunk"
+
+    def __post_init__(self) -> None:
+        if self.sequence <= 0:
+            raise ValueError("sequence must be > 0")
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+@dataclass(frozen=True)
+class LLMStructuredFinal[T]:
+    """Final structured output for a completed LLM run."""
+
+    output: T
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    kind: Literal["structured_final"] = "structured_final"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+
+type LLMStreamEvent[T] = LLMProgressEvent | LLMStructuredChunk[T] | LLMStructuredFinal[T]
+
+
+def llm_stream_event_to_payload(event: LLMStreamEvent[Any]) -> dict[str, Any]:
+    """Convert an LLM stream event into a JSON-friendly payload."""
+    if isinstance(event, LLMProgressEvent):
+        return {
+            "kind": event.kind,
+            "stage": event.stage,
+            "message": event.message,
+            "metadata": dict(event.metadata),
+        }
+    if isinstance(event, LLMStructuredChunk):
+        return {
+            "kind": event.kind,
+            "sequence": event.sequence,
+            "output": _serialize_output(event.output),
+            "metadata": dict(event.metadata),
+        }
+    return {
+        "kind": event.kind,
+        "output": _serialize_output(event.output),
+        "metadata": dict(event.metadata),
+    }
+
+
+def _serialize_output(output: Any) -> Any:
+    model_dump = getattr(output, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    if is_dataclass(output) and not isinstance(output, type):
+        return asdict(output)
+    return output
 
 
 class LLMPort(ABC):
@@ -15,3 +106,26 @@ class LLMPort(ABC):
     ) -> T:
         """Transform a natural-language prompt into a typed structured object."""
         ...
+
+    async def stream_structured(
+        self,
+        prompt: str,
+        *,
+        output_type: type[T],
+        instructions: str,
+        stream_options: LLMStructuredStreamOptions | None = None,
+    ) -> AsyncIterator[LLMStreamEvent[T]]:
+        """Stream progress and structured output while preserving the final object contract."""
+        options = stream_options or LLMStructuredStreamOptions()
+        if options.include_progress:
+            yield LLMProgressEvent(
+                stage="llm.started",
+                message="Structured completion started.",
+            )
+
+        output = await self.complete_structured(
+            prompt,
+            output_type=output_type,
+            instructions=instructions,
+        )
+        yield LLMStructuredFinal(output=output)

--- a/arclith/domain/ports/outbound/llm.py
+++ b/arclith/domain/ports/outbound/llm.py
@@ -1,10 +1,15 @@
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import date, datetime, time
+from enum import Enum
+from pathlib import PurePath
 from types import MappingProxyType
 from typing import Any, Literal, TypeVar
+from uuid import UUID
 
 T = TypeVar("T")
+_UNHANDLED = object()
 
 
 @dataclass(frozen=True)
@@ -70,29 +75,86 @@ def llm_stream_event_to_payload(event: LLMStreamEvent[Any]) -> dict[str, Any]:
             "kind": event.kind,
             "stage": event.stage,
             "message": event.message,
-            "metadata": dict(event.metadata),
+            "metadata": _serialize_output(event.metadata),
         }
     if isinstance(event, LLMStructuredChunk):
         return {
             "kind": event.kind,
             "sequence": event.sequence,
             "output": _serialize_output(event.output),
-            "metadata": dict(event.metadata),
+            "metadata": _serialize_output(event.metadata),
         }
     return {
         "kind": event.kind,
         "output": _serialize_output(event.output),
-        "metadata": dict(event.metadata),
+        "metadata": _serialize_output(event.metadata),
     }
 
 
 def _serialize_output(output: Any) -> Any:
+    if output is None or isinstance(output, str | int | float | bool):
+        return output
+
+    for serializer in _OUTPUT_SERIALIZERS:
+        serialized = serializer(output)
+        if serialized is not _UNHANDLED:
+            return serialized
+
+    return str(output)
+
+
+def _serialize_model_dump(output: Any) -> Any:
     model_dump = getattr(output, "model_dump", None)
     if callable(model_dump):
         return model_dump(mode="json")
+    return _UNHANDLED
+
+
+def _serialize_dataclass(output: Any) -> Any:
     if is_dataclass(output) and not isinstance(output, type):
-        return asdict(output)
-    return output
+        return _serialize_output(asdict(output))
+    return _UNHANDLED
+
+
+def _serialize_enum(output: Any) -> Any:
+    if isinstance(output, Enum):
+        return _serialize_output(output.value)
+    return _UNHANDLED
+
+
+def _serialize_temporal(output: Any) -> Any:
+    if isinstance(output, datetime | date | time):
+        return output.isoformat()
+    return _UNHANDLED
+
+
+def _serialize_stringlike(output: Any) -> Any:
+    if isinstance(output, UUID | PurePath):
+        return str(output)
+    return _UNHANDLED
+
+
+def _serialize_mapping(output: Any) -> Any:
+    if isinstance(output, Mapping):
+        return {str(key): _serialize_output(value) for key, value in output.items()}
+    return _UNHANDLED
+
+
+def _serialize_sequence(output: Any) -> Any:
+    if isinstance(output, list | tuple | set | frozenset):
+        return [_serialize_output(item) for item in output]
+    return _UNHANDLED
+
+
+_OUTPUT_SERIALIZERS = (
+    _serialize_model_dump,
+    _serialize_dataclass,
+    _serialize_enum,
+    _serialize_temporal,
+    _serialize_stringlike,
+    _serialize_mapping,
+    _serialize_sequence,
+)
 
 
 class LLMPort(ABC):

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from arclith.domain.ports.outbound.file_storage import FileStorageInvalidKey, normalize_storage_key
 
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
+LangGraphStreamMode = Literal["values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"]
 
 
 class MongoDBSettings(BaseModel):
@@ -124,6 +125,7 @@ class LangGraphSettings(BaseModel):
     graph: str = "agent"
     entrypoint: str
     env: str = ".env"
+    stream_mode: LangGraphStreamMode | list[LangGraphStreamMode] = "updates"
 
 
 StorageAdapter = Literal["filesystem", "s3", "azure-blob", "gcs"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -141,7 +141,7 @@ arclith-cli add-adapter --adapter mariadb --entity Recipe --param database=my_re
 arclith-cli add-adapter --capability api --adapter fastapi --param port=8080 --yes
 arclith-cli add-adapter --capability mcp --adapter fastmcp --param port=8081 --yes
 arclith-cli add-adapter --capability llm --adapter lmstudio --param model_name=qwen/qwen3.5-9b --yes
-arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=recipe_agent --yes
+arclith-cli add-adapter --capability agent --adapter langgraph --param graph_name=recipe_agent --param stream_mode=updates,custom --yes
 arclith-cli add-adapter --capability observability --adapter langsmith
 arclith-cli add-adapter --capability observability --adapter opentelemetry --param service_name=my_recipe_service --yes
 arclith-cli add-adapter --capability runtime --adapter docker-image --yes
@@ -166,7 +166,7 @@ arclith-cli add-adapter --capability repository --adapter memory --entity Recipe
    - `lmstudio` → `model_name`, `base_url`, `api_key`
    - `openai` → `model_name`, `base_url`, `OPENAI_API_KEY`
    - `anthropic` → `model_name`, `ANTHROPIC_API_KEY`
-   - `langgraph` → `graph_name`
+   - `langgraph` → `graph_name`, `stream_mode`
    - `langsmith` → `tracing`, `project`, `endpoint`, `LANGSMITH_API_KEY`
    - `opentelemetry` → `service_name`, `endpoint`, `traces_endpoint`, `metrics_endpoint`, `protocol`, `traces`, `metrics`, `instrument_fastapi`
    - `command-bus/rabbitmq` → `url`, `exchange`, `exchange_type`, `queue`, `routing_key`, `prefetch`, `consumer_name`, `concurrency`, `publisher_confirms`, `durable`, `retry_enabled`, `retry_requeue`, `dead_letter_exchange`, `dead_letter_routing_key`
@@ -240,7 +240,9 @@ l'environnement, un fichier local de secrets ou Vault selon le resolver choisi.
 L'adapter `agent/langgraph` génère `langgraph.json`, `config/adapters/inbound/langgraph.yaml` et
 `src/<package>/adapters/inbound/langgraph/agent.py`. Le projet ne modifie ensuite que ce fichier pour
 son agent. Comme `fastapi` et `fastmcp`, LangGraph est configuré par son nom produit dans
-`AppConfig.langgraph`, sans `adapters.agent`. L'adapter `observability/langsmith` génère
+`AppConfig.langgraph`, sans `adapters.agent`. `stream_mode` vaut `updates` par défaut et accepte une
+liste CSV comme `updates,custom` pour exposer les sorties de nodes et les événements
+`get_stream_writer()`. L'adapter `observability/langsmith` génère
 `config/adapters/outbound/langsmith.yaml`, l'ajoute à `observability.enabled`, met
 à jour `.env` et ajoute `.env` au `.gitignore` si besoin. LangSmith Studio devient l'endroit standard
 pour tester les agents. Une `LANGSMITH_API_KEY` déjà présente est conservée si aucune nouvelle valeur

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -686,9 +686,17 @@ def _file_template_vars(
         "package_path": package_path,
         "langgraph_entrypoint": langgraph_entrypoint,
         "graph_name": graph_name,
+        "stream_mode_yaml": _langgraph_stream_mode_yaml(str(params.get("stream_mode") or "updates")),
         "secret_template_yaml": _secret_template_yaml(str(params.get("field_path") or "")),
         "secret_chain_yaml": _secret_chain_yaml(str(params.get("resolvers") or "")),
     }
+
+
+def _langgraph_stream_mode_yaml(stream_mode: str) -> str:
+    values = _split_csv_values(stream_mode)
+    if len(values) == 1:
+        return f'"{values[0]}"'
+    return yaml.safe_dump(values, default_flow_style=True, sort_keys=False).strip()
 
 
 def _secret_template_yaml(field_path: str) -> str:

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -1483,6 +1483,7 @@ name: "{graph_name}"
 graph: "{graph_name}"
 entrypoint: "{langgraph_entrypoint}"
 env: ".env"
+stream_mode: {stream_mode_yaml}
 """,
             file_templates=(
                 FileTemplateSpec(
@@ -1507,6 +1508,7 @@ env: ".env"
 from typing import Any, TypedDict
 
 from arclith import Arclith
+from langgraph.config import get_stream_writer
 from langgraph.graph import END, START
 
 
@@ -1520,6 +1522,8 @@ arclith = Arclith("config")
 # Template minimal volontaire: remplacer AgentState, run_agent et les edges par
 # l'état, les noeuds et les transitions propres au projet.
 async def run_agent(state: AgentState) -> AgentState:
+    writer = get_stream_writer()
+    writer({{"kind": "progress", "stage": "agent.started", "message": "Agent node started."}})
     return state
 
 
@@ -1539,6 +1543,14 @@ agent = arclith.langgraph(AgentState, register_agent, name="{graph_name}")
                     kind="string",
                     prompt="Nom du graphe LangGraph",
                     default="agent",
+                ),
+                ParameterSpec(
+                    name="stream_mode",
+                    kind="string",
+                    prompt="Mode(s) de streaming LangGraph",
+                    default="updates",
+                    choices=("values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"),
+                    csv_choices=True,
                 ),
             ),
             entity_scoped=False,

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1282,7 +1282,7 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
         project_dir=project_dir,
         capability_name="agent",
         adapter="langgraph",
-        adapter_params={"graph_name": "todo_agent"},
+        adapter_params={"graph_name": "todo_agent", "stream_mode": "updates,custom"},
         yes=True,
     )
 
@@ -1308,8 +1308,10 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     assert "agent:" not in adapters_yaml
     assert 'name: "todo_agent"' in langgraph_config
     assert 'entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"' in langgraph_config
+    assert "stream_mode: [updates, custom]" in langgraph_config
     generated_agent = agent_file.read_text(encoding="utf-8")
     assert "Template minimal volontaire" in generated_agent
+    assert "get_stream_writer" in generated_agent
     assert "agent = arclith.langgraph(AgentState, register_agent, name=\"todo_agent\")" in generated_agent
     assert not (package_root / "adapters" / "outbound" / "langgraph").exists()
 
@@ -1344,6 +1346,10 @@ async def test_add_langgraph_agent_adapter_generates_compilable_minimal_agent(
     try:
         spec.loader.exec_module(module)
         assert await module.agent.ainvoke({"messages": []}) == {"messages": []}
+        events = [event async for event in module.agent.astream({"messages": []}, stream_mode="custom")]
+        assert events == [
+            {"kind": "progress", "stage": "agent.started", "message": "Agent node started."}
+        ]
     finally:
         sys.modules.pop(spec.name, None)
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -393,7 +393,7 @@ def test_agent_capability_catalog_declares_langgraph() -> None:
         "{package_path}/adapters/inbound/langgraph/__init__.py",
         "{package_path}/adapters/inbound/langgraph/agent.py",
     ]
-    assert [parameter.name for parameter in langgraph.parameters] == ["graph_name"]
+    assert [parameter.name for parameter in langgraph.parameters] == ["graph_name", "stream_mode"]
 
 
 def test_repository_adapter_specs_include_config_and_parameters() -> None:

--- a/docs/capabilities/agent.md
+++ b/docs/capabilities/agent.md
@@ -36,6 +36,7 @@ name: "agent"
 graph: "agent"
 entrypoint: "src/<package>/adapters/inbound/langgraph/agent.py:agent"
 env: ".env"
+stream_mode: "updates"
 ```
 
 ```json
@@ -54,6 +55,7 @@ env: ".env"
 from typing import Any, TypedDict
 
 from arclith import Arclith
+from langgraph.config import get_stream_writer
 from langgraph.graph import END, START
 
 
@@ -65,6 +67,8 @@ arclith = Arclith("config")
 
 
 async def run_agent(state: AgentState) -> AgentState:
+    writer = get_stream_writer()
+    writer({"kind": "progress", "stage": "agent.started", "message": "Agent node started."})
     return state
 
 
@@ -79,6 +83,60 @@ agent = arclith.langgraph(AgentState, register_agent, name="agent")
 
 Le template généré est volontairement minimal. Le projet remplace ensuite
 `AgentState`, les nodes et les edges par son propre parcours.
+
+## Streaming Et Progression
+
+`config/adapters/inbound/langgraph.yaml` peut fixer le mode de streaming par
+défaut du graphe compilé:
+
+```yaml
+stream_mode:
+  - updates
+  - custom
+```
+
+Le CLI accepte la même configuration via:
+
+```bash
+arclith-cli add-adapter \
+  --capability agent \
+  --adapter langgraph \
+  --param stream_mode=updates,custom \
+  --yes
+```
+
+Les modes utiles sont:
+
+| Mode | Usage |
+|---|---|
+| `updates` | suivre les sorties de nodes |
+| `values` | recevoir l'état complet après chaque étape |
+| `messages` | streamer les tokens LLM quand le node utilise un modèle compatible |
+| `custom` | recevoir les événements envoyés avec `get_stream_writer()` |
+
+Dans un node qui consomme `LLMPort.stream_structured()`, publier les événements
+Arclith en `custom`:
+
+```python
+from arclith.domain.ports.outbound.llm import llm_stream_event_to_payload
+from langgraph.config import get_stream_writer
+
+
+async def classify_intent(state: AgentState) -> AgentState:
+    writer = get_stream_writer()
+    final_intent = None
+
+    async for event in llm.stream_structured(
+        state["messages"][-1]["content"],
+        output_type=Intent,
+        instructions="Extraire l'intention utilisateur.",
+    ):
+        writer(llm_stream_event_to_payload(event))
+        if event.kind == "structured_final":
+            final_intent = event.output
+
+    return {**state, "intent": final_intent}
+```
 
 ## Appeler Le Métier
 

--- a/docs/capabilities/llm.md
+++ b/docs/capabilities/llm.md
@@ -116,6 +116,40 @@ result = await use_case.execute(command)
 
 Éviter le chemin inverse où le prompt appelle directement le repository.
 
+## Streaming Structuré
+
+`LLMPort.stream_structured()` expose un flux exploitable sans exposer PydanticAI
+dans le domaine. Le flux émet des événements `progress`, des snapshots
+`structured_chunk`, puis un `structured_final`.
+
+```python
+from arclith.domain.ports.outbound.llm import (
+    LLMStructuredFinal,
+    LLMStructuredStreamOptions,
+    llm_stream_event_to_payload,
+)
+
+async for event in llm.stream_structured(
+    user_message,
+    output_type=Intent,
+    instructions="Extraire l'intention utilisateur.",
+    stream_options=LLMStructuredStreamOptions(
+        include_progress=True,
+        include_snapshots=True,
+        debounce_by=0.05,
+    ),
+):
+    payload = llm_stream_event_to_payload(event)
+    publish_progress(payload)
+
+    if isinstance(event, LLMStructuredFinal):
+        intent = event.output
+```
+
+PydanticAI émet des snapshots cumulés, pas des deltas. Le dernier événement
+`structured_final` reste la sortie métier à utiliser pour décider et appeler les
+use cases.
+
 ## Test Local Minimal
 
 Avant de brancher l'agent, prouver que le modèle local répond:

--- a/docs/learning/local-ai-validation.md
+++ b/docs/learning/local-ai-validation.md
@@ -187,7 +187,7 @@ curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
 curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/runs" | python -m json.tool
 ```
 
-Utiliser `stream_mode: "values"` ou `"updates"` pour apprendre le graphe. `messages-tuple` est utile
+Utiliser `stream_mode: "values"` ou `"updates"` pour apprendre le graphe. `messages` est utile
 pour le streaming fin des messages, mais il est moins lisible au début.
 
 ## Tester Avec Le SDK Python

--- a/tests/units/adapters/outbound/test_pydantic_ai_llm.py
+++ b/tests/units/adapters/outbound/test_pydantic_ai_llm.py
@@ -4,7 +4,12 @@ import pydantic_ai
 
 from arclith.adapters.outbound.pydantic_ai import llm as llm_module
 from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
-from arclith.domain.ports.outbound.llm import LLMPort
+from arclith.domain.ports.outbound.llm import (
+    LLMPort,
+    LLMStructuredChunk,
+    LLMStructuredFinal,
+    LLMStructuredStreamOptions,
+)
 from arclith.infrastructure.config import LMSettings
 
 
@@ -46,3 +51,122 @@ async def test_pydantic_ai_llm_adapter_returns_structured_output(monkeypatch) ->
     result = await adapter.complete_structured("prompt", output_type=Result, instructions="instructions")
 
     assert isinstance(result, Result)
+
+
+async def test_pydantic_ai_llm_adapter_streams_structured_output(monkeypatch) -> None:
+    class Result:
+        def __init__(self, value: str = "") -> None:
+            self.value = value
+
+    seen: dict[str, object] = {}
+
+    class FakeStreamResult:
+        def __init__(self, output_type) -> None:
+            self._output_type = output_type
+            self._final = output_type("final")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def stream_output(self, *, debounce_by: float | None = 0.1):
+            seen["debounce_by"] = debounce_by
+            yield self._output_type("partial")
+
+        def get_output(self):
+            return self._final
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, instructions) -> None:
+            self._output_type = output_type
+            seen["instructions"] = instructions
+
+        def run_stream(self, prompt: str):
+            seen["prompt"] = prompt
+            return FakeStreamResult(self._output_type)
+
+    monkeypatch.setattr(llm_module, "build_pydantic_ai_model", lambda settings: object())
+    monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
+    adapter = PydanticAILLMAdapter(
+        LMSettings(
+            provider="openai",
+            model_name="local-model",
+            api_key="lm-studio",
+            base_url="http://127.0.0.1:1234/v1",
+        )
+    )
+
+    events = [
+        event
+        async for event in adapter.stream_structured(
+            "prompt",
+            output_type=Result,
+            instructions="instructions",
+            stream_options=LLMStructuredStreamOptions(debounce_by=None),
+        )
+    ]
+
+    assert seen == {
+        "instructions": "instructions",
+        "prompt": "prompt",
+        "debounce_by": None,
+    }
+    assert [event.kind for event in events] == [
+        "progress",
+        "progress",
+        "structured_chunk",
+        "progress",
+        "structured_final",
+    ]
+    assert isinstance(events[2], LLMStructuredChunk)
+    assert events[2].sequence == 1
+    assert events[2].output.value == "partial"
+    assert isinstance(events[-1], LLMStructuredFinal)
+    assert events[-1].output.value == "final"
+    assert events[-1].metadata["snapshots"] == 1
+
+
+async def test_pydantic_ai_llm_adapter_can_disable_stream_snapshots(monkeypatch) -> None:
+    class Result:
+        pass
+
+    seen: dict[str, bool] = {"run_stream": False}
+
+    class FakeAgent:
+        def __init__(self, model, *, output_type, instructions) -> None:
+            self._output_type = output_type
+
+        async def run(self, prompt: str):
+            return SimpleNamespace(output=self._output_type())
+
+        def run_stream(self, prompt: str):
+            seen["run_stream"] = True
+            raise AssertionError("run_stream should not be called when snapshots are disabled")
+
+    monkeypatch.setattr(llm_module, "build_pydantic_ai_model", lambda settings: object())
+    monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
+    adapter = PydanticAILLMAdapter(
+        LMSettings(
+            provider="openai",
+            model_name="local-model",
+            api_key="lm-studio",
+            base_url="http://127.0.0.1:1234/v1",
+        )
+    )
+
+    events = [
+        event
+        async for event in adapter.stream_structured(
+            "prompt",
+            output_type=Result,
+            instructions="instructions",
+            stream_options=LLMStructuredStreamOptions(include_progress=False, include_snapshots=False),
+        )
+    ]
+
+    assert seen["run_stream"] is False
+    assert len(events) == 1
+    assert isinstance(events[0], LLMStructuredFinal)
+    assert isinstance(events[0].output, Result)

--- a/tests/units/domain/ports/test_llm.py
+++ b/tests/units/domain/ports/test_llm.py
@@ -1,4 +1,15 @@
-from arclith.domain.ports.outbound.llm import LLMPort
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+
+from arclith.domain.ports.outbound.llm import (
+    LLMPort,
+    LLMProgressEvent,
+    LLMStructuredFinal,
+    LLMStructuredStreamOptions,
+    llm_stream_event_to_payload,
+)
 
 
 class StaticLLM(LLMPort):
@@ -21,3 +32,65 @@ async def test_llm_port_supports_typed_structured_completion() -> None:
     result = await llm.complete_structured("prompt", output_type=Result, instructions="instructions")
 
     assert isinstance(result, Result)
+
+
+async def test_llm_port_streams_progress_and_final_object_by_default() -> None:
+    class Result:
+        pass
+
+    llm = StaticLLM()
+
+    events = [
+        event
+        async for event in llm.stream_structured("prompt", output_type=Result, instructions="instructions")
+    ]
+
+    assert isinstance(events[0], LLMProgressEvent)
+    assert events[0].stage == "llm.started"
+    assert isinstance(events[1], LLMStructuredFinal)
+    assert isinstance(events[1].output, Result)
+
+
+async def test_llm_port_stream_options_can_disable_progress() -> None:
+    class Result:
+        pass
+
+    llm = StaticLLM()
+
+    events = [
+        event
+        async for event in llm.stream_structured(
+            "prompt",
+            output_type=Result,
+            instructions="instructions",
+            stream_options=LLMStructuredStreamOptions(include_progress=False),
+        )
+    ]
+
+    assert len(events) == 1
+    assert isinstance(events[0], LLMStructuredFinal)
+
+
+def test_llm_stream_event_payload_serializes_structured_outputs() -> None:
+    class PydanticResult(BaseModel):
+        title: str
+
+    @dataclass(frozen=True)
+    class DataclassResult:
+        title: str
+
+    assert llm_stream_event_to_payload(LLMStructuredFinal(output=PydanticResult(title="pydantic"))) == {
+        "kind": "structured_final",
+        "output": {"title": "pydantic"},
+        "metadata": {},
+    }
+    assert llm_stream_event_to_payload(LLMStructuredFinal(output=DataclassResult(title="dataclass"))) == {
+        "kind": "structured_final",
+        "output": {"title": "dataclass"},
+        "metadata": {},
+    }
+
+
+def test_llm_stream_options_reject_negative_debounce() -> None:
+    with pytest.raises(ValueError, match="debounce_by must be >= 0 or None"):
+        LLMStructuredStreamOptions(debounce_by=-0.1)

--- a/tests/units/domain/ports/test_llm.py
+++ b/tests/units/domain/ports/test_llm.py
@@ -1,4 +1,9 @@
 from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+import json
+from pathlib import PurePosixPath
+from uuid import UUID
 
 import pytest
 from pydantic import BaseModel
@@ -89,6 +94,41 @@ def test_llm_stream_event_payload_serializes_structured_outputs() -> None:
         "output": {"title": "dataclass"},
         "metadata": {},
     }
+
+
+def test_llm_stream_event_payload_is_json_encodable_for_nested_values() -> None:
+    class Status(Enum):
+        DONE = "done"
+
+    class Opaque:
+        def __str__(self) -> str:
+            return "opaque"
+
+    payload = llm_stream_event_to_payload(
+        LLMStructuredFinal(
+            output={
+                "status": Status.DONE,
+                "due_date": date(2026, 8, 23),
+                "path": PurePosixPath("docs/readme.md"),
+                "ids": {UUID("12345678-1234-5678-1234-567812345678")},
+                "opaque": Opaque(),
+            },
+            metadata={"seen_at": date(2026, 8, 23)},
+        )
+    )
+
+    assert payload == {
+        "kind": "structured_final",
+        "output": {
+            "status": "done",
+            "due_date": "2026-08-23",
+            "path": "docs/readme.md",
+            "ids": ["12345678-1234-5678-1234-567812345678"],
+            "opaque": "opaque",
+        },
+        "metadata": {"seen_at": "2026-08-23"},
+    }
+    json.dumps(payload)
 
 
 def test_llm_stream_options_reject_negative_debounce() -> None:

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -486,6 +486,7 @@ def test_load_config_dir_langgraph_scoped():
             "graph": "todo_agent",
             "entrypoint": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent",
             "env": ".env",
+            "stream_mode": ["updates", "custom"],
         },
     })
     config = load_config_dir(path)
@@ -494,6 +495,7 @@ def test_load_config_dir_langgraph_scoped():
     assert config.langgraph.graph == "todo_agent"
     assert config.langgraph.entrypoint == "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
     assert config.langgraph.env == ".env"
+    assert config.langgraph.stream_mode == ["updates", "custom"]
 
 
 def test_langsmith_observability_requires_scoped_config():
@@ -527,6 +529,15 @@ def test_langgraph_settings_defaults():
     assert settings.name == "agent"
     assert settings.graph == "agent"
     assert settings.env == ".env"
+    assert settings.stream_mode == "updates"
+
+
+def test_langgraph_settings_rejects_unknown_stream_mode():
+    with pytest.raises(ValidationError):
+        LangGraphSettings(
+            entrypoint="./src/demo_service/adapters/inbound/langgraph/agent.py:agent",
+            stream_mode="unknown",
+        )
 
 
 def test_langsmith_settings_defaults():

--- a/tests/units/test_arclith_langgraph.py
+++ b/tests/units/test_arclith_langgraph.py
@@ -33,3 +33,57 @@ def test_langgraph_builds_compiled_graph(tmp_path):
 
     assert registered["arclith"] is arclith
     assert agent.invoke({"value": "ok"}) == {"value": "ok!"}
+
+
+def test_langgraph_applies_stream_mode_from_config(tmp_path):
+    config_dir = tmp_path / "config"
+    langgraph_config = config_dir / "adapters" / "inbound" / "langgraph.yaml"
+    langgraph_config.parent.mkdir(parents=True)
+    langgraph_config.write_text(
+        """
+entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+stream_mode:
+  - updates
+  - custom
+""",
+        encoding="utf-8",
+    )
+    arclith = Arclith(config_dir)
+
+    def register_agent(builder: Any, current_arclith: Arclith) -> None:
+        def echo(state: AgentState) -> AgentState:
+            return state
+
+        builder.add_node("echo", echo)
+        builder.add_edge(START, "echo")
+        builder.add_edge("echo", END)
+
+    agent = arclith.langgraph(AgentState, register_agent, name="test_agent")
+
+    assert agent.stream_mode == ["updates", "custom"]
+
+
+def test_langgraph_stream_mode_argument_overrides_config(tmp_path):
+    config_dir = tmp_path / "config"
+    langgraph_config = config_dir / "adapters" / "inbound" / "langgraph.yaml"
+    langgraph_config.parent.mkdir(parents=True)
+    langgraph_config.write_text(
+        """
+entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+stream_mode: "updates"
+""",
+        encoding="utf-8",
+    )
+    arclith = Arclith(config_dir)
+
+    def register_agent(builder: Any, current_arclith: Arclith) -> None:
+        def echo(state: AgentState) -> AgentState:
+            return state
+
+        builder.add_node("echo", echo)
+        builder.add_edge(START, "echo")
+        builder.add_edge("echo", END)
+
+    agent = arclith.langgraph(AgentState, register_agent, name="test_agent", stream_mode="values")
+
+    assert agent.stream_mode == "values"


### PR DESCRIPTION
## Summary
- add provider-neutral LLM streaming events and structured stream options to LLMPort
- implement PydanticAI run_stream support with progress, snapshots, and final structured output
- make LangGraph stream_mode configurable through config, Arclith.langgraph(), and the CLI scaffold
- document LLM streaming and LangGraph custom progress events

## Validation
- make quality
- (cd cli && uv run --frozen python -m pytest -q)
- uv run --frozen --group docs mkdocs build --strict