### PR TITLE
feat: add repository/postgresql adapter

### DIFF
--- a/arclith/adapters/outbound/postgresql/config.py
+++ b/arclith/adapters/outbound/postgresql/config.py
@@ -1,0 +1,98 @@
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import quote_plus
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class PostgreSQLConfig:
+    url: str | None = None
+    host: str = "127.0.0.1"
+    port: int = 5432
+    database: str | None = None
+    user: str = "app"
+    password: str | None = None
+    schema: str = "public"
+    driver: str = "asyncpg"
+    table_prefix: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_port(self.port)
+        _validate_identifier("schema", self.schema, allow_empty=False)
+        _validate_identifier("table_prefix", self.table_prefix, allow_empty=True)
+        _validate_driver(self.driver)
+
+    def connection_url(self) -> str:
+        if self.url:
+            return self.url
+        if not self.database:
+            raise ValueError(
+                "PostgreSQL database is required when url is not configured"
+            )
+
+        auth = quote_plus(self.user)
+        if self.password:
+            auth = f"{auth}:{quote_plus(self.password)}"
+        database = quote_plus(self.database)
+        return f"postgresql+{self.driver}://{auth}@{self.host}:{self.port}/{database}"
+
+    def with_tenant_params(self, params: Mapping[str, str]) -> "PostgreSQLConfig":
+        return PostgreSQLConfig(
+            url=_first_value(params, "url", "uri", default=self.url),
+            host=_string_value(params, "host", default=self.host),
+            port=_port_value(params, self.port),
+            database=_first_value(params, "database", "db_name", default=self.database),
+            user=_string_value(params, "user", "username", default=self.user),
+            password=_first_value(params, "password", default=self.password),
+            schema=_string_value(params, "schema", default=self.schema),
+            driver=_string_value(params, "driver", default=self.driver),
+            table_prefix=_string_value(
+                params, "table_prefix", default=self.table_prefix
+            ),
+        )
+
+
+def _first_value(
+    params: Mapping[str, str], *names: str, default: str | None
+) -> str | None:
+    for name in names:
+        raw_value = params.get(name)
+        value = raw_value.strip() if raw_value is not None else None
+        if value:
+            return value
+    return default
+
+
+def _string_value(params: Mapping[str, str], *names: str, default: str) -> str:
+    value = _first_value(params, *names, default=default)
+    return value or default
+
+
+def _port_value(params: Mapping[str, str], default: int) -> int:
+    raw_value = params.get("port")
+    value = raw_value.strip() if raw_value is not None else ""
+    if not value:
+        return default
+    if not value.isdigit():
+        raise ValueError("PostgreSQL port must be an integer")
+    return _validate_port(int(value))
+
+
+def _validate_port(port: int) -> int:
+    if port <= 0 or port > 65535:
+        raise ValueError("PostgreSQL port must be between 1 and 65535")
+    return port
+
+
+def _validate_identifier(name: str, value: str, *, allow_empty: bool) -> None:
+    if allow_empty and not value:
+        return
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"PostgreSQL {name} must be a safe SQL identifier")
+
+
+def _validate_driver(driver: str) -> None:
+    if not re.fullmatch(r"^[A-Za-z0-9_]+$", driver):
+        raise ValueError("PostgreSQL driver must be a safe SQLAlchemy driver token")

--- a/arclith/adapters/outbound/postgresql/repository.py
+++ b/arclith/adapters/outbound/postgresql/repository.py
@@ -33,6 +33,7 @@ class _SQLAlchemyAPI:
     table: Any
     delete: Any
     count: Any
+    create_schema: Any
     insert: Any
     select: Any
     update: Any
@@ -57,6 +58,7 @@ def _sqlalchemy_api() -> _SQLAlchemyAPI:
         )
         from sqlalchemy.dialects.postgresql import JSONB
         from sqlalchemy.ext.asyncio import create_async_engine
+        from sqlalchemy.schema import CreateSchema
     except ModuleNotFoundError as exc:
         raise RuntimeError(_EXTRA_MESSAGE) from exc
 
@@ -70,6 +72,7 @@ def _sqlalchemy_api() -> _SQLAlchemyAPI:
         table=Table,
         delete=delete,
         count=func.count,
+        create_schema=CreateSchema,
         insert=insert,
         select=select,
         update=update,
@@ -156,6 +159,12 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
             if ready_key in self._ready_tables:
                 return
             async with engine.begin() as connection:
+                if metadata.schema != "public":
+                    await connection.execute(
+                        _sqlalchemy_api().create_schema(
+                            metadata.schema, if_not_exists=True
+                        )
+                    )
                 await connection.run_sync(metadata.create_all)
             self._ready_tables.add(ready_key)
 

--- a/arclith/adapters/outbound/postgresql/repository.py
+++ b/arclith/adapters/outbound/postgresql/repository.py
@@ -1,0 +1,274 @@
+from asyncio import Lock
+from dataclasses import dataclass
+from functools import cache
+import importlib.util
+import json
+import re
+from typing import Any, Generic, TypeVar
+
+from uuid6 import UUID, uuid7
+
+from arclith.adapters.context import get_adapter_tenant_context
+from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+from arclith.domain.models.entity import Entity
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.domain.ports.outbound.repository import Repository
+
+T = TypeVar("T", bound=Entity)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_EXTRA_MESSAGE = (
+    "PostgreSQL repository requires the optional extra: arclith[postgresql]"
+)
+
+
+@dataclass(frozen=True)
+class _SQLAlchemyAPI:
+    column: Any
+    datetime: Any
+    integer: Any
+    jsonb: Any
+    metadata: Any
+    string: Any
+    table: Any
+    delete: Any
+    count: Any
+    insert: Any
+    select: Any
+    update: Any
+    create_async_engine: Any
+
+
+@cache
+def _sqlalchemy_api() -> _SQLAlchemyAPI:
+    try:
+        from sqlalchemy import (
+            Column,
+            DateTime,
+            Integer,
+            MetaData,
+            String,
+            Table,
+            delete,
+            func,
+            insert,
+            select,
+            update,
+        )
+        from sqlalchemy.dialects.postgresql import JSONB
+        from sqlalchemy.ext.asyncio import create_async_engine
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(_EXTRA_MESSAGE) from exc
+
+    return _SQLAlchemyAPI(
+        column=Column,
+        datetime=DateTime,
+        integer=Integer,
+        jsonb=JSONB,
+        metadata=MetaData,
+        string=String,
+        table=Table,
+        delete=delete,
+        count=func.count,
+        insert=insert,
+        select=select,
+        update=update,
+        create_async_engine=create_async_engine,
+    )
+
+
+def _require_asyncpg() -> None:
+    if importlib.util.find_spec("asyncpg") is None:
+        raise RuntimeError(_EXTRA_MESSAGE)
+
+
+class PostgreSQLRepository(Repository[T], Generic[T]):
+    """Generic PostgreSQL repository storing each entity as one JSONB document."""
+
+    def __init__(
+        self, config: PostgreSQLConfig, entity_class: type[T], logger: Logger
+    ) -> None:
+        self._config = config
+        self._entity_class = entity_class
+        self._logger = logger
+        self._tables: dict[str, tuple[Any, Any]] = {}
+        self._engines: dict[str, Any] = {}
+        self._ready_tables: set[str] = set()
+        self._schema_locks: dict[str, Lock] = {}
+
+    def _active_config(self) -> PostgreSQLConfig:
+        coords = get_adapter_tenant_context("postgresql")
+        if coords is None:
+            return self._config
+        return self._config.with_tenant_params(coords.params)
+
+    def _table_key(self, config: PostgreSQLConfig) -> str:
+        return f"{config.schema}.{config.table_prefix}{self._entity_class.__name__.lower()}"
+
+    def _table_for(self, config: PostgreSQLConfig) -> tuple[Any, Any]:
+        table_key = self._table_key(config)
+        if table_key not in self._tables:
+            self._tables[table_key] = self._build_table(config)
+        return self._tables[table_key]
+
+    def _build_table(self, config: PostgreSQLConfig) -> tuple[Any, Any]:
+        table_name = f"{config.table_prefix}{self._entity_class.__name__.lower()}"
+        if not _IDENTIFIER_RE.fullmatch(table_name):
+            raise ValueError(f"Invalid PostgreSQL table name: {table_name}")
+
+        api = _sqlalchemy_api()
+        metadata = api.metadata(schema=config.schema)
+        table = api.table(
+            table_name,
+            metadata,
+            api.column("uuid", api.string(36), primary_key=True),
+            api.column("data", api.jsonb, nullable=False),
+            api.column("created_at", api.datetime(timezone=True), nullable=False),
+            api.column("updated_at", api.datetime(timezone=True), nullable=False),
+            api.column("deleted_at", api.datetime(timezone=True), nullable=True),
+            api.column("version", api.integer, nullable=False),
+        )
+        return metadata, table
+
+    def _engine_for(self, url: str, table_name: str, driver: str) -> Any:
+        if url not in self._engines:
+            if driver == "asyncpg":
+                _require_asyncpg()
+            self._engines[url] = _sqlalchemy_api().create_async_engine(
+                url, pool_pre_ping=True
+            )
+            self._logger.debug("PostgreSQL engine created", table=table_name)
+        return self._engines[url]
+
+    def _schema_lock_for(self, url: str) -> Lock:
+        if url not in self._schema_locks:
+            self._schema_locks[url] = Lock()
+        return self._schema_locks[url]
+
+    async def _ensure_schema(
+        self, engine: Any, url: str, metadata: Any, table_key: str
+    ) -> None:
+        ready_key = f"{url}|{table_key}"
+        if ready_key in self._ready_tables:
+            return
+
+        async with self._schema_lock_for(url):
+            if ready_key in self._ready_tables:
+                return
+            async with engine.begin() as connection:
+                await connection.run_sync(metadata.create_all)
+            self._ready_tables.add(ready_key)
+
+    async def _engine_and_table(self) -> tuple[Any, Any]:
+        config = self._active_config()
+        url = config.connection_url()
+        metadata, table = self._table_for(config)
+        engine = self._engine_for(url, table.name, config.driver)
+        await self._ensure_schema(engine, url, metadata, self._table_key(config))
+        return engine, table
+
+    def _entity_values(self, entity: T) -> dict[str, Any]:
+        return {
+            "uuid": str(entity.uuid),
+            "data": entity.model_dump(mode="json"),
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def _row_to_entity(self, row: Any) -> T:
+        payload = row["data"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            raise ValueError("PostgreSQL repository row payload must be a JSON object")
+        return self._entity_class(**payload)
+
+    async def create(self, entity: T) -> T:
+        engine, table = await self._engine_and_table()
+        async with engine.begin() as connection:
+            await connection.execute(
+                _sqlalchemy_api().insert(table).values(**self._entity_values(entity))
+            )
+        return entity
+
+    async def read(self, uuid: UUID) -> T | None:
+        engine, table = await self._engine_and_table()
+        statement = (
+            _sqlalchemy_api().select(table.c.data).where(table.c.uuid == str(uuid))
+        )
+        async with engine.connect() as connection:
+            row = (await connection.execute(statement)).mappings().first()
+        return self._row_to_entity(row) if row is not None else None
+
+    async def update(self, entity: T) -> T:
+        engine, table = await self._engine_and_table()
+        values = self._entity_values(entity)
+        values.pop("uuid")
+        statement = (
+            _sqlalchemy_api()
+            .update(table)
+            .where(table.c.uuid == str(entity.uuid))
+            .values(**values)
+        )
+        async with engine.begin() as connection:
+            await connection.execute(statement)
+        return entity
+
+    async def delete(self, uuid: UUID) -> None:
+        engine, table = await self._engine_and_table()
+        statement = _sqlalchemy_api().delete(table).where(table.c.uuid == str(uuid))
+        async with engine.begin() as connection:
+            await connection.execute(statement)
+
+    async def find_all(self) -> list[T]:
+        engine, table = await self._engine_and_table()
+        statement = (
+            _sqlalchemy_api()
+            .select(table.c.data)
+            .where(table.c.deleted_at.is_(None))
+            .order_by(table.c.created_at, table.c.uuid)
+        )
+        async with engine.connect() as connection:
+            rows = (await connection.execute(statement)).mappings().all()
+        return [self._row_to_entity(row) for row in rows]
+
+    async def find_page(
+        self, offset: int = 0, limit: int | None = None
+    ) -> tuple[list[T], int]:
+        engine, table = await self._engine_and_table()
+        statement = (
+            _sqlalchemy_api()
+            .select(table.c.data, _sqlalchemy_api().count().over().label("__total"))
+            .where(table.c.deleted_at.is_(None))
+            .order_by(table.c.created_at, table.c.uuid)
+            .offset(offset)
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+
+        async with engine.connect() as connection:
+            rows = (await connection.execute(statement)).mappings().all()
+
+        total = int(rows[0]["__total"]) if rows else 0
+        return [self._row_to_entity(row) for row in rows], total
+
+    async def find_deleted(self) -> list[T]:
+        engine, table = await self._engine_and_table()
+        statement = (
+            _sqlalchemy_api()
+            .select(table.c.data)
+            .where(table.c.deleted_at.is_not(None))
+            .order_by(table.c.deleted_at, table.c.uuid)
+        )
+        async with engine.connect() as connection:
+            rows = (await connection.execute(statement)).mappings().all()
+        return [self._row_to_entity(row) for row in rows]
+
+    async def duplicate(self, uuid: UUID) -> T:
+        entity = await self.read(uuid)
+        if entity is None or entity.is_deleted:
+            raise KeyError(f"Entity with uuid {uuid} not found")
+        clone = entity.model_copy(update={"uuid": uuid7()})
+        return await self.create(clone)

--- a/arclith/domain/models/tenant.py
+++ b/arclith/domain/models/tenant.py
@@ -11,6 +11,7 @@ class AdapterTenantCoords:
     Exemples :
     - MongoDB  : {"uri": "mongodb://...", "db_name": "tenant_foo"}
     - MariaDB  : {"uri": "mysql://...", "db_name": "tenant_schema"}
+    - PostgreSQL : {"uri": "postgresql://...", "db_name": "tenant_db", "schema": "tenant_schema"}
     - S3       : {"endpoint_url": "https://...", "bucket_name": "tenant-foo", "region": "eu-west-1"}
     - Redis    : {"uri": "redis://...", "key_prefix": "tenant_foo"}
 
@@ -35,7 +36,7 @@ class AdapterTenantCoords:
 class TenantContext:
     """Contexte tenant multi-adaptateur.
 
-    Clé = nom de l'adaptateur (``"mongodb"``, ``"s3"``, ``"mariadb"``...).
+    Clé = nom de l'adaptateur (``"mongodb"``, ``"s3"``, ``"mariadb"``, ``"postgresql"``...).
     Chaque adaptateur lit uniquement sa propre tranche via ``get(adapter_name)``.
 
     Exemple : MongoDB multitenant + S3 single-tenant → seul ``"mongodb"`` est présent.

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from arclith.domain.ports.outbound.file_storage import FileStorageInvalidKey, normalize_storage_key
+from arclith.domain.ports.outbound.file_storage import (
+    FileStorageInvalidKey,
+    normalize_storage_key,
+)
 
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
-LangGraphStreamMode = Literal["values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"]
+_SQL_IDENTIFIER_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
+LangGraphStreamMode = Literal[
+    "values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"
+]
 
 
 class MongoDBSettings(BaseModel):
@@ -65,6 +72,64 @@ class MariaDBSettings(BaseModel):
         return self
 
 
+class PostgreSQLSettings(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+    url: str | None = None
+    host: str = "127.0.0.1"
+    port: int = 5432
+    database: str | None = None
+    user: str = "app"
+    password: str | None = None
+    schema_name: str = Field(default="public", alias="schema")
+    driver: str = "asyncpg"
+    table_prefix: str = ""
+    multitenant: bool = False
+
+    @field_validator("port")
+    @classmethod
+    def must_be_valid_port(cls, v: int) -> int:
+        if v <= 0 or v > 65535:
+            raise ValueError("port doit etre compris entre 1 et 65535")
+        return v
+
+    @field_validator("schema_name")
+    @classmethod
+    def must_be_safe_schema(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("schema PostgreSQL ne doit pas etre vide")
+        if not re.fullmatch(_SQL_IDENTIFIER_RE, value):
+            raise ValueError("schema PostgreSQL doit etre un identifiant SQL sur")
+        return value
+
+    @field_validator("table_prefix")
+    @classmethod
+    def must_be_safe_table_prefix(cls, v: str) -> str:
+        value = v.strip()
+        if value and not re.fullmatch(_SQL_IDENTIFIER_RE, value):
+            raise ValueError(
+                "table_prefix PostgreSQL doit etre vide ou un identifiant SQL sur"
+            )
+        return value
+
+    @field_validator("driver")
+    @classmethod
+    def must_be_safe_driver(cls, v: str) -> str:
+        value = v.strip()
+        if not re.fullmatch(r"^[A-Za-z0-9_]+$", value):
+            raise ValueError("driver PostgreSQL doit etre un token SQLAlchemy sur")
+        return value
+
+    @model_validator(mode="after")
+    def validate_connection_target(self) -> "PostgreSQLSettings":
+        if self.multitenant:
+            return self
+        if not self.url and not self.database:
+            raise ValueError("database est requis quand url n'est pas configure")
+        return self
+
+
 class LMSettings(BaseModel):
     provider: Literal["anthropic", "openai"] = "anthropic"
     model_name: str = "claude-sonnet-4-5"
@@ -111,7 +176,9 @@ class ObservabilitySettings(BaseModel):
 
     @field_validator("enabled")
     @classmethod
-    def must_not_contain_duplicates(cls, v: list[ObservabilityAdapter]) -> list[ObservabilityAdapter]:
+    def must_not_contain_duplicates(
+        cls, v: list[ObservabilityAdapter]
+    ) -> list[ObservabilityAdapter]:
         if len(v) != len(set(v)):
             raise ValueError("observability.enabled ne doit pas contenir de doublons")
         return v
@@ -190,6 +257,7 @@ _REPOSITORY_CONFIG_SECTIONS: dict[str, str] = {
     "mongodb": "mongodb",
     "duckdb": "duckdb",
     "mariadb": "mariadb",
+    "postgresql": "postgresql",
 }
 _LOGGER_ADAPTERS = {"console"}
 _OBSERVABILITY_CONFIG_SECTIONS: dict[ObservabilityAdapter, str] = {
@@ -216,6 +284,7 @@ class AdaptersSettings(BaseModel):
     mongodb: MongoDBSettings | None = None
     duckdb: DuckDBSettings | None = None
     mariadb: MariaDBSettings | None = None
+    postgresql: PostgreSQLSettings | None = None
     storage: StorageSettings | None = None
     lm: LMSettings | None = None
     langsmith: LangSmithSettings | None = None
@@ -230,6 +299,8 @@ class AdaptersSettings(BaseModel):
                 return self.duckdb.multitenant if self.duckdb else False
             case "mariadb":
                 return self.mariadb.multitenant if self.mariadb else False
+            case "postgresql":
+                return self.postgresql.multitenant if self.postgresql else False
             case _:
                 return False
 
@@ -238,7 +309,9 @@ class AdaptersSettings(BaseModel):
     def must_be_supported_logger_adapter(cls, v: str) -> str:
         if v not in _LOGGER_ADAPTERS:
             supported = ", ".join(sorted(_LOGGER_ADAPTERS))
-            raise ValueError(f"logger={v} non supporte. Adapters logger supportes: {supported}")
+            raise ValueError(
+                f"logger={v} non supporte. Adapters logger supportes: {supported}"
+            )
         return v
 
     @model_validator(mode="after")
@@ -250,7 +323,9 @@ class AdaptersSettings(BaseModel):
             )
 
         for observability_adapter in self.observability.enabled:
-            observability_section = _OBSERVABILITY_CONFIG_SECTIONS[observability_adapter]
+            observability_section = _OBSERVABILITY_CONFIG_SECTIONS[
+                observability_adapter
+            ]
             if getattr(self, observability_section) is None:
                 raise ValueError(
                     f"observability.enabled contient {observability_adapter} mais aucune section "
@@ -280,7 +355,9 @@ class KeycloakSettings(BaseModel):
     url: str
     realm: str
     audience: str | None = None
-    client_id: str | None = None  # Client OAuth2 pour Swagger UI (doit être public/PKCE)
+    client_id: str | None = (
+        None  # Client OAuth2 pour Swagger UI (doit être public/PKCE)
+    )
 
 
 class TenantSettings(BaseModel):
@@ -339,7 +416,9 @@ class RabbitMQCommandBusSettings(BaseModel):
     @classmethod
     def must_be_positive(cls, v: int) -> int:
         if v <= 0:
-            raise ValueError("rabbitmq command-bus prefetch/concurrency doivent etre > 0")
+            raise ValueError(
+                "rabbitmq command-bus prefetch/concurrency doivent etre > 0"
+            )
         return v
 
 
@@ -349,7 +428,9 @@ class CommandBusSettings(BaseModel):
 
     @field_validator("enabled")
     @classmethod
-    def must_not_contain_duplicates(cls, v: list[CommandBusAdapter]) -> list[CommandBusAdapter]:
+    def must_not_contain_duplicates(
+        cls, v: list[CommandBusAdapter]
+    ) -> list[CommandBusAdapter]:
         if len(v) != len(set(v)):
             raise ValueError("command_bus.enabled ne doit pas contenir de doublons")
         return v
@@ -423,24 +504,24 @@ def _resolve_key_path(rel: Path) -> list[str]:
       config/<name>.yaml                   → ["<name>"]
     """
     parts = rel.with_suffix("").parts
-    
+
     # Single level: config/<name>.yaml → ["<name>"]
     if len(parts) == 1:
         return [parts[0]]
-    
+
     # Two levels: config/adapters/adapters.yaml → ["adapters"]
     if len(parts) == 2:
         if parts[0] == "adapters" and parts[1] == "adapters":
             return ["adapters"]
         return []
-    
+
     # Three levels: config/adapters/{outbound|inbound}/<name>.yaml
     if len(parts) == 3 and parts[0] == "adapters":
         if parts[1] == "outbound":
             return ["adapters", parts[2]]
         if parts[1] == "inbound":
             return [_INBOUND_ALIAS.get(parts[2], parts[2])]
-    
+
     return []
 
 
@@ -487,6 +568,7 @@ def _resolve_secrets(data: dict, base_path: Path) -> dict:
 
 # ── Public loaders ────────────────────────────────────────────────────────────
 
+
 def load_config_dir(path: Path) -> AppConfig:
     """Load AppConfig from a config/ directory.
 
@@ -532,4 +614,6 @@ def export_config_yaml(config_dir: Path, output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as f:
         f.write("# generated by arclith-cli export-config — do not edit manually\n")
-        yaml.safe_dump(merged, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        yaml.safe_dump(
+            merged, f, default_flow_style=False, allow_unicode=True, sort_keys=False
+        )

--- a/arclith/infrastructure/repository_factory.py
+++ b/arclith/infrastructure/repository_factory.py
@@ -23,7 +23,9 @@ class RepositoryRegistry(Generic[T, R]):
     def __init__(self) -> None:
         self._factories: dict[str, RepositoryFactory[T, R]] = {}
 
-    def register(self, name: str, factory: RepositoryFactory[T, R]) -> "RepositoryRegistry[T, R]":
+    def register(
+        self, name: str, factory: RepositoryFactory[T, R]
+    ) -> "RepositoryRegistry[T, R]":
         self._factories[name] = factory
         return self
 
@@ -67,17 +69,22 @@ def build_repository(
     registry: RepositoryRegistry[T, R] | None = None,
 ) -> Repository[T] | R:
     if registry is None:
-        return default_repository_registry(entity_class).build(config, entity_class, logger)
+        return default_repository_registry(entity_class).build(
+            config, entity_class, logger
+        )
     return registry.build(config, entity_class, logger)
 
 
-def default_repository_registry(_entity_class: type[T]) -> RepositoryRegistry[T, Repository[T]]:
+def default_repository_registry(
+    _entity_class: type[T],
+) -> RepositoryRegistry[T, Repository[T]]:
     return (
         RepositoryRegistry[T, Repository[T]]()
         .register("memory", _build_memory_repository)
         .register("mongodb", _build_mongodb_repository)
         .register("duckdb", _build_duckdb_repository)
         .register("mariadb", _build_mariadb_repository)
+        .register("postgresql", _build_postgresql_repository)
     )
 
 
@@ -150,6 +157,35 @@ def _build_mariadb_repository(
             password=mariadb.password,
             driver=mariadb.driver,
             table_prefix=mariadb.table_prefix,
+        ),
+        entity_class,
+        logger,
+    )
+
+
+def _build_postgresql_repository(
+    config: AppConfig,
+    entity_class: type[T],
+    logger: Logger,
+) -> Repository[T]:
+    from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+    from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+
+    postgresql = config.adapters.postgresql
+    if postgresql is None:
+        raise ValueError("PostgreSQL settings are required when repository=postgresql")
+
+    return PostgreSQLRepository(
+        PostgreSQLConfig(
+            url=postgresql.url,
+            host=postgresql.host,
+            port=postgresql.port,
+            database=postgresql.database,
+            user=postgresql.user,
+            password=postgresql.password,
+            schema=postgresql.schema_name,
+            driver=postgresql.driver,
+            table_prefix=postgresql.table_prefix,
         ),
         entity_class,
         logger,

--- a/cli/arclith_cli/adapter_templates.py
+++ b/cli/arclith_cli/adapter_templates.py
@@ -66,6 +66,20 @@ class MariaDB{pascal}Repository(MariaDBRepository[{pascal}], {pascal}Repository)
 
     # TODO: add custom query methods here
 """,
+    "postgresql": """\
+from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+from arclith.domain.ports.outbound.logger import Logger
+from {domain_import}.models.{snake} import {pascal}
+from {domain_import}.ports.outbound.{snake}_repository import {pascal}Repository
+
+
+class PostgreSQL{pascal}Repository(PostgreSQLRepository[{pascal}], {pascal}Repository):
+    def __init__(self, config: PostgreSQLConfig, logger: Logger) -> None:
+        super().__init__(config, {pascal}, logger)
+
+    # TODO: add custom query methods here
+""",
 }
 
 # ── repository.py re-export template ─────────────────────────────────────────
@@ -90,6 +104,11 @@ __all__ = ["DuckDB{pascal}Repository"]
 from {adapters_import}.outbound.mariadb.repositories.{snake}_repository import MariaDB{pascal}Repository
 
 __all__ = ["MariaDB{pascal}Repository"]
+""",
+    "postgresql": """\
+from {adapters_import}.outbound.postgresql.repositories.{snake}_repository import PostgreSQL{pascal}Repository
+
+__all__ = ["PostgreSQL{pascal}Repository"]
 """,
 }
 
@@ -153,6 +172,29 @@ def _build_mariadb(cfg: AppConfig, _entity_class: type[{pascal}], log: Logger) -
     )
 
 """,
+    "postgresql": """\
+def _build_postgresql(cfg: AppConfig, _entity_class: type[{pascal}], log: Logger) -> {pascal}Repository:
+    from {adapters_import}.outbound.postgresql.repository import PostgreSQL{pascal}Repository
+    from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+    postgresql = cfg.adapters.postgresql
+    if postgresql is None:
+        raise ValueError("PostgreSQL settings are required when repository=postgresql")
+    return PostgreSQL{pascal}Repository(
+        PostgreSQLConfig(
+            url=postgresql.url,
+            host=postgresql.host,
+            port=postgresql.port,
+            database=postgresql.database,
+            user=postgresql.user,
+            password=postgresql.password,
+            schema=postgresql.schema_name,
+            driver=postgresql.driver,
+            table_prefix=postgresql.table_prefix,
+        ),
+        log,
+    )
+
+""",
 }
 
 _CONTAINER_FOOTER = """\
@@ -169,7 +211,9 @@ def build_{snake}_service(arclith: Arclith) -> tuple[{pascal}Service, Logger]:
 """
 
 
-def render_container(pascal: str, snake: str, installed_adapters: list[str], import_vars: dict[str, str]) -> str:
+def render_container(
+    pascal: str, snake: str, installed_adapters: list[str], import_vars: dict[str, str]
+) -> str:
     """Generate the full container file content for a given entity and its adapters."""
     # memory is always included (arclith built-in, needs no extra files)
     adapters = list(dict.fromkeys(["memory"] + installed_adapters))
@@ -182,9 +226,7 @@ def render_container(pascal: str, snake: str, installed_adapters: list[str], imp
         if a in _CONTAINER_FACTORY
     )
     registrations = "\n".join(
-        f"    .register(\"{a}\", _build_{a})"
-        for a in adapters
-        if a in _CONTAINER_FACTORY
+        f'    .register("{a}", _build_{a})' for a in adapters if a in _CONTAINER_FACTORY
     )
     footer = _CONTAINER_FOOTER.format(**vars, registrations=registrations)
     return header + factories + footer

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -108,10 +108,16 @@ class AdapterSpec:
             "layer": self.layer,
             "description": self.description,
             "config_path": self.config_path,
-            "merge_config_templates": [file_template.to_dict() for file_template in self.merge_config_templates],
+            "merge_config_templates": [
+                file_template.to_dict() for file_template in self.merge_config_templates
+            ],
             "env_path": self.env_path,
-            "file_templates": [file_template.to_dict() for file_template in self.file_templates],
-            "secret_mappings": [secret_mapping.to_dict() for secret_mapping in self.secret_mappings],
+            "file_templates": [
+                file_template.to_dict() for file_template in self.file_templates
+            ],
+            "secret_mappings": [
+                secret_mapping.to_dict() for secret_mapping in self.secret_mappings
+            ],
             "secret_resolver": self.secret_resolver,
             "secret_config_template": bool(self.secret_config_template),
             "gitignore_entries": list(self.gitignore_entries),
@@ -281,6 +287,85 @@ multitenant: false
                     kind="string",
                     prompt="table_prefix",
                     default="",
+                ),
+            ),
+        ),
+        AdapterSpec(
+            name="postgresql",
+            capability="repository",
+            layer="outbound",
+            description="Repository PostgreSQL async optionnel, pilote par SQLAlchemy et asyncpg, avec payload JSONB generique.",
+            config_path="config/adapters/outbound/postgresql.yaml",
+            config_template="""\
+url: null   # à mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complète
+host: {host}
+port: {port}
+database: {database}
+user: {user}
+password: null   # à mapper via config/secrets.yaml ou resolver env/vault
+schema: {schema}
+driver: {driver}
+table_prefix: "{table_prefix}"
+multitenant: {multitenant}
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="adapters.postgresql.url",
+                    secret_key="POSTGRESQL_URL",
+                ),
+                SecretMappingSpec(
+                    field_path="adapters.postgresql.password",
+                    secret_key="POSTGRESQL_PASSWORD",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="host",
+                    kind="string",
+                    prompt="host",
+                    default="127.0.0.1",
+                ),
+                ParameterSpec(
+                    name="port",
+                    kind="string",
+                    prompt="port",
+                    default="5432",
+                ),
+                ParameterSpec(
+                    name="database",
+                    kind="string",
+                    prompt="database",
+                    default_from_project_name=True,
+                ),
+                ParameterSpec(
+                    name="user",
+                    kind="string",
+                    prompt="user",
+                    default="app",
+                ),
+                ParameterSpec(
+                    name="schema",
+                    kind="string",
+                    prompt="schema",
+                    default="public",
+                ),
+                ParameterSpec(
+                    name="driver",
+                    kind="string",
+                    prompt="driver",
+                    default="asyncpg",
+                ),
+                ParameterSpec(
+                    name="table_prefix",
+                    kind="string",
+                    prompt="table_prefix",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="multitenant",
+                    default=False,
                 ),
             ),
         ),
@@ -1549,7 +1634,15 @@ agent = arclith.langgraph(AgentState, register_agent, name="{graph_name}")
                     kind="string",
                     prompt="Mode(s) de streaming LangGraph",
                     default="updates",
-                    choices=("values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"),
+                    choices=(
+                        "values",
+                        "updates",
+                        "custom",
+                        "messages",
+                        "checkpoints",
+                        "tasks",
+                        "debug",
+                    ),
                     csv_choices=True,
                 ),
             ),

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -16,7 +16,9 @@ from arclith_cli.add_adapter import _resolve_parameter, add_adapter_cmd
 from arclith_cli.capabilities import ParameterSpec
 
 
-def _write_model(project_dir: Path, package_name: str, class_name: str, file_name: str) -> None:
+def _write_model(
+    project_dir: Path, package_name: str, class_name: str, file_name: str
+) -> None:
     model_dir = project_dir / "src" / package_name / "domain" / "models"
     model_dir.mkdir(parents=True, exist_ok=True)
     (model_dir / f"{file_name}.py").write_text(
@@ -32,7 +34,9 @@ def _minimal_project(tmp_path: Path) -> Path:
     package_name = "demo_service"
     _write_model(project_dir, package_name, "Widget", "widget")
     (project_dir / "src" / package_name / "adapters" / "outbound").mkdir(parents=True)
-    (project_dir / "src" / package_name / "infrastructure" / "containers").mkdir(parents=True)
+    (project_dir / "src" / package_name / "infrastructure" / "containers").mkdir(
+        parents=True
+    )
     config_dir = project_dir / "config" / "adapters"
     config_dir.mkdir(parents=True)
     (config_dir / "adapters.yaml").write_text(
@@ -53,20 +57,31 @@ def test_add_duckdb_adapter_non_interactive(tmp_path: Path) -> None:
     )
 
     package_root = project_dir / "src" / "demo_service"
-    assert (package_root / "adapters" / "outbound" / "duckdb" / "repositories" / "widget_repository.py").exists()
-    assert (package_root / "adapters" / "outbound" / "duckdb" / "repository.py").exists()
+    assert (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "duckdb"
+        / "repositories"
+        / "widget_repository.py"
+    ).exists()
+    assert (
+        package_root / "adapters" / "outbound" / "duckdb" / "repository.py"
+    ).exists()
     assert 'register("duckdb", _build_duckdb)' in (
         package_root / "infrastructure" / "containers" / "widget_container.py"
     ).read_text(encoding="utf-8")
-    assert "repository: duckdb" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "repository: duckdb" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert "path: data/widgets.parquet" in (
         project_dir / "config" / "adapters" / "outbound" / "duckdb.yaml"
     ).read_text(encoding="utf-8")
 
 
-def test_add_duckdb_adapter_generates_loadable_directory_config_idempotently(tmp_path: Path) -> None:
+def test_add_duckdb_adapter_generates_loadable_directory_config_idempotently(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     for _ in range(2):
@@ -80,11 +95,16 @@ def test_add_duckdb_adapter_generates_loadable_directory_config_idempotently(tmp
     from arclith import Arclith
 
     app = Arclith(project_dir / "config")
-    duckdb_config = (project_dir / "config" / "adapters" / "outbound" / "duckdb.yaml").read_text(
-        encoding="utf-8"
-    )
+    duckdb_config = (
+        project_dir / "config" / "adapters" / "outbound" / "duckdb.yaml"
+    ).read_text(encoding="utf-8")
     container = (
-        project_dir / "src" / "demo_service" / "infrastructure" / "containers" / "widget_container.py"
+        project_dir
+        / "src"
+        / "demo_service"
+        / "infrastructure"
+        / "containers"
+        / "widget_container.py"
     ).read_text(encoding="utf-8")
 
     assert app.config.adapters.repository == "duckdb"
@@ -108,9 +128,9 @@ def test_add_mongodb_adapter_uses_non_interactive_params(tmp_path: Path) -> None
         yes=True,
     )
 
-    mongodb_config = (project_dir / "config" / "adapters" / "outbound" / "mongodb.yaml").read_text(
-        encoding="utf-8"
-    )
+    mongodb_config = (
+        project_dir / "config" / "adapters" / "outbound" / "mongodb.yaml"
+    ).read_text(encoding="utf-8")
     assert "uri: null" in mongodb_config
     assert "multitenant: true" in mongodb_config
     assert "db_name: demo_shared" in mongodb_config
@@ -119,12 +139,14 @@ def test_add_mongodb_adapter_uses_non_interactive_params(tmp_path: Path) -> None
     assert "resolver: env" in secrets
     assert "adapters.mongodb.uri: MONGODB_URI" in secrets
     assert "mongodb://" not in secrets
-    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "repository: memory" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
 
 
-def test_add_mongodb_adapter_generates_loadable_single_tenant_config(tmp_path: Path) -> None:
+def test_add_mongodb_adapter_generates_loadable_single_tenant_config(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     add_adapter_cmd(
@@ -165,15 +187,24 @@ def test_add_mariadb_adapter_uses_catalog_params(tmp_path: Path) -> None:
     )
 
     package_root = project_dir / "src" / "demo_service"
-    repository_file = package_root / "adapters" / "outbound" / "mariadb" / "repositories" / "widget_repository.py"
+    repository_file = (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "mariadb"
+        / "repositories"
+        / "widget_repository.py"
+    )
     assert repository_file.exists()
-    assert "class MariaDBWidgetRepository" in repository_file.read_text(encoding="utf-8")
+    assert "class MariaDBWidgetRepository" in repository_file.read_text(
+        encoding="utf-8"
+    )
     assert 'register("mariadb", _build_mariadb)' in (
         package_root / "infrastructure" / "containers" / "widget_container.py"
     ).read_text(encoding="utf-8")
-    mariadb_config = (project_dir / "config" / "adapters" / "outbound" / "mariadb.yaml").read_text(
-        encoding="utf-8"
-    )
+    mariadb_config = (
+        project_dir / "config" / "adapters" / "outbound" / "mariadb.yaml"
+    ).read_text(encoding="utf-8")
     assert "host: mariadb.local" in mariadb_config
     assert "port: 3307" in mariadb_config
     assert "database: demo_shared" in mariadb_config
@@ -189,8 +220,116 @@ def test_add_mariadb_adapter_uses_catalog_params(tmp_path: Path) -> None:
     assert "secret-password" not in secrets
 
 
+def test_add_postgresql_adapter_uses_catalog_params(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        adapter="postgresql",
+        adapter_params={
+            "host": "postgresql.local",
+            "port": "5433",
+            "database": "demo_shared",
+            "user": "demo_app",
+            "schema": "app",
+            "driver": "asyncpg",
+            "table_prefix": "todo_",
+            "multitenant": "false",
+        },
+        yes=True,
+    )
+
+    package_root = project_dir / "src" / "demo_service"
+    repository_file = (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "postgresql"
+        / "repositories"
+        / "widget_repository.py"
+    )
+    assert repository_file.exists()
+    assert "class PostgreSQLWidgetRepository" in repository_file.read_text(
+        encoding="utf-8"
+    )
+    assert 'register("postgresql", _build_postgresql)' in (
+        package_root / "infrastructure" / "containers" / "widget_container.py"
+    ).read_text(encoding="utf-8")
+    postgresql_config = (
+        project_dir / "config" / "adapters" / "outbound" / "postgresql.yaml"
+    ).read_text(encoding="utf-8")
+    assert "host: postgresql.local" in postgresql_config
+    assert "port: 5433" in postgresql_config
+    assert "database: demo_shared" in postgresql_config
+    assert "user: demo_app" in postgresql_config
+    assert "schema: app" in postgresql_config
+    assert "driver: asyncpg" in postgresql_config
+    assert "url: null" in postgresql_config
+    assert "password: null" in postgresql_config
+    assert 'table_prefix: "todo_"' in postgresql_config
+    assert "multitenant: false" in postgresql_config
+
+    secrets = (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    assert "resolver: env" in secrets
+    assert "adapters.postgresql.url: POSTGRESQL_URL" in secrets
+    assert "adapters.postgresql.password: POSTGRESQL_PASSWORD" in secrets
+    assert "secret-password" not in postgresql_config
+    assert "secret-password" not in secrets
+
+
+def test_add_postgresql_adapter_generates_loadable_single_tenant_config(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        adapter="postgresql",
+        adapter_params={
+            "database": "demo_shared",
+        },
+        yes=True,
+    )
+
+    from arclith import Arclith
+
+    arclith = Arclith(project_dir / "config")
+
+    assert arclith.config.adapters.repository == "postgresql"
+    assert arclith.config.adapters.postgresql is not None
+    assert arclith.config.adapters.postgresql.url is None
+    assert arclith.config.adapters.postgresql.database == "demo_shared"
+    assert arclith.config.adapters.postgresql.schema_name == "public"
+    assert arclith.config.adapters.postgresql.multitenant is False
+
+
 @pytest.mark.parametrize("secret_param", ["password", "url"])
-def test_add_mariadb_adapter_rejects_direct_secret_params(tmp_path: Path, secret_param: str) -> None:
+def test_add_postgresql_adapter_rejects_direct_secret_params(
+    tmp_path: Path, secret_param: str
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            adapter="postgresql",
+            adapter_params={
+                "database": "demo_shared",
+                secret_param: "secret-password",
+            },
+            yes=True,
+        )
+
+    assert not (
+        project_dir / "config" / "adapters" / "outbound" / "postgresql.yaml"
+    ).exists()
+    assert not (project_dir / "config" / "secrets.yaml").exists()
+
+
+@pytest.mark.parametrize("secret_param", ["password", "url"])
+def test_add_mariadb_adapter_rejects_direct_secret_params(
+    tmp_path: Path, secret_param: str
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     with pytest.raises(typer.Exit):
@@ -204,7 +343,9 @@ def test_add_mariadb_adapter_rejects_direct_secret_params(tmp_path: Path, secret
             yes=True,
         )
 
-    assert not (project_dir / "config" / "adapters" / "outbound" / "mariadb.yaml").exists()
+    assert not (
+        project_dir / "config" / "adapters" / "outbound" / "mariadb.yaml"
+    ).exists()
     assert not (project_dir / "config" / "secrets.yaml").exists()
 
 
@@ -213,7 +354,9 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     project_dir = _minimal_project(tmp_path)
-    (project_dir / ".env").write_text("EXISTING=value\nLANGSMITH_PROJECT=old\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "EXISTING=value\nLANGSMITH_PROJECT=old\n", encoding="utf-8"
+    )
 
     add_adapter_cmd(
         project_dir=project_dir,
@@ -229,9 +372,9 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     )
     cli_output = capsys.readouterr()
 
-    config = (project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml").read_text(
-        encoding="utf-8"
-    )
+    config = (
+        project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml"
+    ).read_text(encoding="utf-8")
     assert "tracing: true" in config
     assert 'project: "agent-tests"' in config
     assert 'endpoint: "https://eu.api.smith.langchain.com"' in config
@@ -239,7 +382,9 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     assert "Définir LANGSMITH_API_KEY hors Git" in config
     assert 'langgraph_api_min_version: "0.11.0"' in config
     adapters_config = yaml.safe_load(
-        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+            encoding="utf-8"
+        )
     )
     assert adapters_config["observability"]["enabled"] == ["langsmith"]
 
@@ -261,7 +406,10 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     assert arclith.config.adapters.langsmith is not None
     assert arclith.config.adapters.langsmith.tracing is True
     assert arclith.config.adapters.langsmith.project == "agent-tests"
-    assert arclith.config.adapters.langsmith.endpoint == "https://eu.api.smith.langchain.com"
+    assert (
+        arclith.config.adapters.langsmith.endpoint
+        == "https://eu.api.smith.langchain.com"
+    )
     assert "test-key" not in load_output.out
     assert "test-key" not in load_output.err
     package_root = project_dir / "src" / "demo_service"
@@ -308,9 +456,9 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
     )
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
-    config = (project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml").read_text(
-        encoding="utf-8"
-    )
+    config = (
+        project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml"
+    ).read_text(encoding="utf-8")
     assert "LANGSMITH_API_KEY=" not in env
     assert "LANGSMITH_PROJECT=agent-tests" in env
     assert "api_key_env: LANGSMITH_API_KEY" in config
@@ -350,9 +498,9 @@ def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -
 
     assert second_config == first_config
     assert config == {"host": "127.0.0.1", "port": 8080, "reload": False}
-    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "repository: memory" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "fastapi").exists()
     assert not (package_root / "adapters" / "inbound" / "fastapi").exists()
@@ -399,9 +547,9 @@ def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -
 
     assert second_config == first_config
     assert config == {"host": "127.0.0.1", "port": 9001}
-    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "repository: memory" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "fastmcp").exists()
     assert not (package_root / "adapters" / "inbound" / "fastmcp").exists()
@@ -430,7 +578,9 @@ def test_add_fastmcp_mcp_adapter_generates_inbound_config_only(tmp_path: Path) -
     ]
 
 
-def test_add_probe_server_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
+def test_add_probe_server_adapter_generates_loadable_inbound_config(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     add_adapter_cmd(
@@ -457,9 +607,9 @@ def test_add_probe_server_adapter_generates_loadable_inbound_config(tmp_path: Pa
     assert arclith.config.probe.host == "127.0.0.1"
     assert arclith.config.probe.port == 9100
     assert arclith.config.probe.enabled is False
-    assert "probe:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "probe:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (package_root / "adapters" / "inbound" / "server").exists()
     assert not (package_root / "adapters" / "outbound" / "server").exists()
 
@@ -503,9 +653,9 @@ def test_add_http_idempotency_adapter_merges_http_config(tmp_path: Path) -> None
     assert arclith.config.http.idempotency.enabled is False
     assert arclith.config.http.idempotency.ttl_seconds == 7200
     assert arclith.config.http.idempotency.required is True
-    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "http:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (package_root / "adapters" / "inbound" / "idempotency").exists()
 
 
@@ -543,9 +693,9 @@ def test_add_http_etag_adapter_merges_http_config(tmp_path: Path) -> None:
         "etag": {"enabled": False},
     }
     assert arclith.config.http.etag.enabled is False
-    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "http:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (package_root / "adapters" / "inbound" / "etag").exists()
 
 
@@ -589,13 +739,15 @@ def test_add_http_cache_control_adapter_merges_http_config(tmp_path: Path) -> No
     }
     assert arclith.config.http.cache_control.get_single_max_age == 900
     assert arclith.config.http.cache_control.get_list_max_age == 0
-    assert "http:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "http:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (package_root / "adapters" / "inbound" / "cache-control").exists()
 
 
-def test_add_http_cache_control_adapter_rejects_negative_max_age(tmp_path: Path) -> None:
+def test_add_http_cache_control_adapter_rejects_negative_max_age(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     http_path = project_dir / "config" / "http.yaml"
 
@@ -614,14 +766,13 @@ def test_add_http_cache_control_adapter_rejects_negative_max_age(tmp_path: Path)
     assert not http_path.exists()
 
 
-def test_add_command_bus_rabbitmq_adapter_merges_command_bus_config(tmp_path: Path) -> None:
+def test_add_command_bus_rabbitmq_adapter_merges_command_bus_config(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     command_bus_path = project_dir / "config" / "command_bus.yaml"
     command_bus_path.write_text(
-        "enabled: []\n"
-        "rabbitmq:\n"
-        "  url: amqp://old/\n"
-        "  exchange: old.exchange\n",
+        "enabled: []\nrabbitmq:\n  url: amqp://old/\n  exchange: old.exchange\n",
         encoding="utf-8",
     )
 
@@ -676,13 +827,15 @@ def test_add_command_bus_rabbitmq_adapter_merges_command_bus_config(tmp_path: Pa
     assert arclith.config.command_bus.is_enabled("rabbitmq") is True
     assert arclith.config.command_bus.rabbitmq.prefetch == 7
     assert arclith.config.command_bus.rabbitmq.concurrency == 2
-    assert "command-bus:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "command-bus:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (package_root / "adapters" / "bidirectional" / "rabbitmq").exists()
 
 
-def test_add_command_bus_rabbitmq_adapter_rejects_unbounded_prefetch(tmp_path: Path) -> None:
+def test_add_command_bus_rabbitmq_adapter_rejects_unbounded_prefetch(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     command_bus_path = project_dir / "config" / "command_bus.yaml"
 
@@ -698,7 +851,9 @@ def test_add_command_bus_rabbitmq_adapter_rejects_unbounded_prefetch(tmp_path: P
     assert not command_bus_path.exists()
 
 
-def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: Path) -> None:
+def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     config_path = project_dir / "config" / "adapters" / "inbound" / "keycloak.yaml"
 
@@ -723,9 +878,9 @@ def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: P
         "audience": "rekipe-api",
         "client_id": "swagger-public",
     }
-    assert "auth:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "auth:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "inbound" / "keycloak").exists()
 
@@ -740,14 +895,14 @@ def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(tmp_path: P
     assert arclith.config.keycloak.client_id == "swagger-public"
 
 
-def test_add_vault_tenant_adapter_with_mongodb_multitenant_loads_config(tmp_path: Path) -> None:
+def test_add_vault_tenant_adapter_with_mongodb_multitenant_loads_config(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     cache_path = project_dir / "config" / "adapters" / "inbound" / "cache.yaml"
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(
-        "backend: memory\n"
-        "jwks_ttl: 1200\n"
-        "tenant_uri_ttl: 180\n",
+        "backend: memory\njwks_ttl: 1200\ntenant_uri_ttl: 180\n",
         encoding="utf-8",
     )
 
@@ -777,9 +932,9 @@ def test_add_vault_tenant_adapter_with_mongodb_multitenant_loads_config(tmp_path
     from arclith import Arclith
 
     arclith = Arclith(project_dir / "config")
-    tenant_config = (project_dir / "config" / "adapters" / "inbound" / "tenant.yaml").read_text(
-        encoding="utf-8"
-    )
+    tenant_config = (
+        project_dir / "config" / "adapters" / "inbound" / "tenant.yaml"
+    ).read_text(encoding="utf-8")
     cache_config = yaml.safe_load(cache_path.read_text(encoding="utf-8"))
 
     assert arclith.config.adapters.repository == "mongodb"
@@ -812,9 +967,9 @@ def test_add_role_license_adapter_generates_loadable_config(tmp_path: Path) -> N
     config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
     assert config == {"role": "rekipe:premium"}
-    assert "license:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "license:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "inbound" / "role").exists()
     assert not (package_root / "adapters" / "outbound" / "role").exists()
@@ -849,9 +1004,9 @@ def test_add_lmstudio_llm_adapter_generates_lm_config_only(tmp_path: Path) -> No
     assert 'model_name: "qwen/qwen3.5-9b"' in config
     assert 'api_key: "lm-studio"' in config
     assert 'base_url: "http://127.0.0.1:1234/v1"' in config
-    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "repository: memory" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert not (project_dir / "config" / "secrets.yaml").exists()
 
     package_root = project_dir / "src" / "demo_service"
@@ -974,9 +1129,9 @@ def test_add_storage_adapter_generates_loadable_config_only(
     config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
     assert config == expected_config
-    assert "storage:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "storage:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     if adapter == "azure-blob":
         secrets = yaml.safe_load(
             (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
@@ -1040,9 +1195,9 @@ def test_add_openai_llm_adapter_generates_secret_mapping(
     assert "EXISTING=value" in env
     assert "OPENAI_API_KEY=sk-test" in env
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
-    assert "llm:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "llm:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert "sk-test" not in captured.out
     assert "sk-test" not in captured.err
 
@@ -1124,7 +1279,9 @@ def test_add_anthropic_llm_adapter_generates_idempotent_secret_mapping(
         encoding="utf-8"
     )
     env = (project_dir / ".env").read_text(encoding="utf-8")
-    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    )
 
     assert "provider: anthropic" in config
     assert 'model_name: "claude-dev-model"' in config
@@ -1134,9 +1291,9 @@ def test_add_anthropic_llm_adapter_generates_idempotent_secret_mapping(
     assert secrets["resolver"] == "env"
     assert secrets["mappings"]["adapters.lm.api_key"] == "ANTHROPIC_API_KEY"
     assert list(secrets["mappings"]).count("adapters.lm.api_key") == 1
-    assert "llm:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "llm:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert "existing-local-key" not in captured.out
     assert "existing-local-key" not in captured.err
 
@@ -1151,7 +1308,9 @@ def test_add_anthropic_llm_adapter_generates_idempotent_secret_mapping(
     assert arclith.config.adapters.lm.api_key == "sk-ant-test"
 
 
-def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: Path) -> None:
+def test_add_opentelemetry_observability_adapter_uses_catalog_params(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
 
@@ -1174,9 +1333,9 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
         yes=True,
     )
 
-    config = (project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml").read_text(
-        encoding="utf-8"
-    )
+    config = (
+        project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml"
+    ).read_text(encoding="utf-8")
     assert 'service_name: "demo-api"' in config
     assert 'endpoint: "http://otel-collector:4318"' in config
     assert "traces_endpoint: http://otel-collector:4318/custom/traces" in config
@@ -1188,7 +1347,9 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     assert "instrument_fastapi: true" in config
     assert "metrics_export_interval_millis: 15000" in config
     adapters_config = yaml.safe_load(
-        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+            encoding="utf-8"
+        )
     )
     assert adapters_config["observability"]["enabled"] == ["opentelemetry"]
 
@@ -1201,7 +1362,9 @@ def test_add_opentelemetry_observability_adapter_uses_catalog_params(tmp_path: P
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
 
 
-def test_add_observability_adapters_accumulates_enabled_backends(tmp_path: Path) -> None:
+def test_add_observability_adapters_accumulates_enabled_backends(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     add_adapter_cmd(
@@ -1220,18 +1383,22 @@ def test_add_observability_adapters_accumulates_enabled_backends(tmp_path: Path)
     )
 
     adapters_config = yaml.safe_load(
-        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+            encoding="utf-8"
+        )
     )
     assert adapters_config["observability"]["enabled"] == ["langsmith", "opentelemetry"]
 
-    config = (project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml").read_text(
-        encoding="utf-8"
-    )
+    config = (
+        project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml"
+    ).read_text(encoding="utf-8")
     assert "traces_endpoint: null" in config
     assert "metrics_endpoint: null" in config
 
 
-def test_add_langsmith_preserves_existing_opentelemetry_activation(tmp_path: Path) -> None:
+def test_add_langsmith_preserves_existing_opentelemetry_activation(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
 
@@ -1258,7 +1425,9 @@ def test_add_langsmith_preserves_existing_opentelemetry_activation(tmp_path: Pat
     )
 
     adapters_config = yaml.safe_load(
-        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+            encoding="utf-8"
+        )
     )
     env = (project_dir / ".env").read_text(encoding="utf-8")
     opentelemetry_config = (
@@ -1275,7 +1444,9 @@ def test_add_langsmith_preserves_existing_opentelemetry_activation(tmp_path: Pat
     assert 'service_name: "demo-api"' in opentelemetry_config
 
 
-def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path) -> None:
+def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     add_adapter_cmd(
@@ -1287,14 +1458,18 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     )
 
     package_root = project_dir / "src" / "demo_service"
-    langgraph_json = json.loads((project_dir / "langgraph.json").read_text(encoding="utf-8"))
-    langgraph_config = (project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml").read_text(
-        encoding="utf-8"
+    langgraph_json = json.loads(
+        (project_dir / "langgraph.json").read_text(encoding="utf-8")
     )
+    langgraph_config = (
+        project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml"
+    ).read_text(encoding="utf-8")
     agent_file = package_root / "adapters" / "inbound" / "langgraph" / "agent.py"
 
     assert (project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml").exists()
-    assert (package_root / "adapters" / "inbound" / "langgraph" / "__init__.py").exists()
+    assert (
+        package_root / "adapters" / "inbound" / "langgraph" / "__init__.py"
+    ).exists()
     assert agent_file.exists()
     assert langgraph_json["graphs"] == {
         "todo_agent": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
@@ -1307,12 +1482,18 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(tmp_path: Path
     assert "repository: memory" in adapters_yaml
     assert "agent:" not in adapters_yaml
     assert 'name: "todo_agent"' in langgraph_config
-    assert 'entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"' in langgraph_config
+    assert (
+        'entrypoint: "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"'
+        in langgraph_config
+    )
     assert "stream_mode: [updates, custom]" in langgraph_config
     generated_agent = agent_file.read_text(encoding="utf-8")
     assert "Template minimal volontaire" in generated_agent
     assert "get_stream_writer" in generated_agent
-    assert "agent = arclith.langgraph(AgentState, register_agent, name=\"todo_agent\")" in generated_agent
+    assert (
+        'agent = arclith.langgraph(AgentState, register_agent, name="todo_agent")'
+        in generated_agent
+    )
     assert not (package_root / "adapters" / "outbound" / "langgraph").exists()
 
 
@@ -1332,7 +1513,15 @@ async def test_add_langgraph_agent_adapter_generates_compilable_minimal_agent(
         yes=True,
     )
 
-    agent_file = project_dir / "src" / "demo_service" / "adapters" / "inbound" / "langgraph" / "agent.py"
+    agent_file = (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "adapters"
+        / "inbound"
+        / "langgraph"
+        / "agent.py"
+    )
     monkeypatch.chdir(project_dir)
     monkeypatch.syspath_prepend(str(project_dir / "src"))
     spec = importlib.util.spec_from_file_location(
@@ -1346,9 +1535,18 @@ async def test_add_langgraph_agent_adapter_generates_compilable_minimal_agent(
     try:
         spec.loader.exec_module(module)
         assert await module.agent.ainvoke({"messages": []}) == {"messages": []}
-        events = [event async for event in module.agent.astream({"messages": []}, stream_mode="custom")]
+        events = [
+            event
+            async for event in module.agent.astream(
+                {"messages": []}, stream_mode="custom"
+            )
+        ]
         assert events == [
-            {"kind": "progress", "stage": "agent.started", "message": "Agent node started."}
+            {
+                "kind": "progress",
+                "stage": "agent.started",
+                "message": "Agent node started.",
+            }
         ]
     finally:
         sys.modules.pop(spec.name, None)
@@ -1417,7 +1615,9 @@ def test_add_memory_adapter_rejects_unknown_catalog_param(tmp_path: Path) -> Non
         )
 
 
-def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(tmp_path: Path) -> None:
+def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(
+    tmp_path: Path,
+) -> None:
     project_dir = tmp_path / "memory-service"
 
     result = subprocess.run(
@@ -1432,7 +1632,9 @@ def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(tmp_path: P
         text=True,
         timeout=30,
     )
-    assert result.returncode == 0, f"init failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"init failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
 
     result = subprocess.run(
         ["arclith-cli", "add-entity", "Widget"],
@@ -1441,7 +1643,9 @@ def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(tmp_path: P
         text=True,
         timeout=30,
     )
-    assert result.returncode == 0, f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
 
     result = subprocess.run(
         [
@@ -1460,15 +1664,30 @@ def test_add_memory_adapter_direct_cli_keeps_memory_and_loads_config(tmp_path: P
         text=True,
         timeout=30,
     )
-    assert result.returncode == 0, f"add-adapter failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"add-adapter failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
 
     package_root = project_dir / "src" / "memory_service"
-    assert (package_root / "adapters" / "outbound" / "memory" / "repositories" / "widget_repository.py").exists()
-    assert (package_root / "adapters" / "outbound" / "memory" / "repository.py").exists()
-    assert not (project_dir / "config" / "adapters" / "outbound" / "memory.yaml").exists()
+    assert (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "memory"
+        / "repositories"
+        / "widget_repository.py"
+    ).exists()
+    assert (
+        package_root / "adapters" / "outbound" / "memory" / "repository.py"
+    ).exists()
+    assert not (
+        project_dir / "config" / "adapters" / "outbound" / "memory.yaml"
+    ).exists()
 
     adapters_config = yaml.safe_load(
-        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8")
+        (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
+            encoding="utf-8"
+        )
     )
     assert adapters_config["repository"] == "memory"
 
@@ -1506,12 +1725,21 @@ def test_add_memory_adapter_interactive_wizard_activates_memory(tmp_path: Path) 
         timeout=30,
     )
 
-    assert result.returncode == 0, f"wizard failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
-    package_root = project_dir / "src" / "demo_service"
-    assert (package_root / "adapters" / "outbound" / "memory" / "repositories" / "widget_repository.py").exists()
-    assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
+    assert result.returncode == 0, (
+        f"wizard failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
+    package_root = project_dir / "src" / "demo_service"
+    assert (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "memory"
+        / "repositories"
+        / "widget_repository.py"
+    ).exists()
+    assert "repository: memory" in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
 
 
 def test_add_cache_memory_adapter_generates_loadable_config(tmp_path: Path) -> None:
@@ -1531,9 +1759,9 @@ def test_add_cache_memory_adapter_generates_loadable_config(tmp_path: Path) -> N
     from arclith import Arclith
     from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
 
-    cache_config = (project_dir / "config" / "adapters" / "inbound" / "cache.yaml").read_text(
-        encoding="utf-8"
-    )
+    cache_config = (
+        project_dir / "config" / "adapters" / "inbound" / "cache.yaml"
+    ).read_text(encoding="utf-8")
     app = Arclith(project_dir / "config")
 
     assert cache_config == "backend: memory\njwks_ttl: 1200\ntenant_uri_ttl: 180\n"
@@ -1564,24 +1792,29 @@ def test_add_cache_redis_adapter_generates_secret_mapping(
     )
     captured = capsys.readouterr()
 
-    cache_config = (project_dir / "config" / "adapters" / "inbound" / "cache.yaml").read_text(
-        encoding="utf-8"
+    cache_config = (
+        project_dir / "config" / "adapters" / "inbound" / "cache.yaml"
+    ).read_text(encoding="utf-8")
+    secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
     )
-    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
     env = (project_dir / ".env").read_text(encoding="utf-8")
 
-    assert cache_config == 'backend: redis\nredis_url: ""\njwks_ttl: 900\ntenant_uri_ttl: 120\n'
+    assert (
+        cache_config
+        == 'backend: redis\nredis_url: ""\njwks_ttl: 900\ntenant_uri_ttl: 120\n'
+    )
     assert secrets["resolver"] == "env"
     assert secrets["mappings"]["cache.redis_url"] == "REDIS_URL"
     assert "EXISTING=value" in env
     assert "REDIS_URL=redis://cache:6379/0" in env
-    assert "cache:" not in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "cache:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")
     assert "redis://cache:6379/0" not in cache_config
-    assert "redis://cache:6379/0" not in (project_dir / "config" / "secrets.yaml").read_text(
-        encoding="utf-8"
-    )
+    assert "redis://cache:6379/0" not in (
+        project_dir / "config" / "secrets.yaml"
+    ).read_text(encoding="utf-8")
     assert "redis://cache:6379/0" not in captured.out
     assert "redis://cache:6379/0" not in captured.err
 
@@ -1596,10 +1829,14 @@ def test_add_cache_redis_adapter_generates_secret_mapping(
     assert app.config.cache.tenant_uri_ttl == 120
 
 
-def test_add_console_logger_adapter_generates_explicit_default_selector(tmp_path: Path) -> None:
+def test_add_console_logger_adapter_generates_explicit_default_selector(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
     adapters_path = project_dir / "config" / "adapters" / "adapters.yaml"
-    adapters_path.write_text("repository: memory\nobservability:\n  enabled: []\n", encoding="utf-8")
+    adapters_path.write_text(
+        "repository: memory\nobservability:\n  enabled: []\n", encoding="utf-8"
+    )
 
     add_adapter_cmd(
         project_dir=project_dir,
@@ -1626,18 +1863,13 @@ def test_add_env_secrets_adapter_preserves_existing_mappings_and_uses_explicit_k
 ) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / "config" / "secrets.yaml").write_text(
-        "resolver: yaml\n"
-        "mappings:\n"
-        "  adapters.lm.api_key: OPENAI_API_KEY\n",
+        "resolver: yaml\nmappings:\n  adapters.lm.api_key: OPENAI_API_KEY\n",
         encoding="utf-8",
     )
     outbound_dir = project_dir / "config" / "adapters" / "outbound"
     outbound_dir.mkdir(parents=True, exist_ok=True)
     (outbound_dir / "mongodb.yaml").write_text(
-        "uri: null\n"
-        "db_name: demo\n"
-        "collection_name: null\n"
-        "multitenant: false\n",
+        "uri: null\ndb_name: demo\ncollection_name: null\nmultitenant: false\n",
         encoding="utf-8",
     )
 
@@ -1652,7 +1884,9 @@ def test_add_env_secrets_adapter_preserves_existing_mappings_and_uses_explicit_k
             },
             yes=True,
         )
-    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    )
 
     assert secrets["resolver"] == "env"
     assert secrets["mappings"] == {
@@ -1678,10 +1912,7 @@ def test_add_env_secrets_adapter_allows_derived_env_key(
     outbound_dir = project_dir / "config" / "adapters" / "outbound"
     outbound_dir.mkdir(parents=True, exist_ok=True)
     (outbound_dir / "mongodb.yaml").write_text(
-        "uri: null\n"
-        "db_name: demo\n"
-        "collection_name: null\n"
-        "multitenant: false\n",
+        "uri: null\ndb_name: demo\ncollection_name: null\nmultitenant: false\n",
         encoding="utf-8",
     )
 
@@ -1692,7 +1923,9 @@ def test_add_env_secrets_adapter_allows_derived_env_key(
         adapter_params={"field_path": "adapters.mongodb.uri"},
         yes=True,
     )
-    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    )
 
     assert secrets["resolver"] == "env"
     assert secrets["mappings"]["adapters.mongodb.uri"] == ""
@@ -1727,10 +1960,7 @@ def test_add_yaml_secrets_adapter_generates_template_and_preserves_real_secret_f
     outbound_dir = project_dir / "config" / "adapters" / "outbound"
     outbound_dir.mkdir(parents=True, exist_ok=True)
     (outbound_dir / "mongodb.yaml").write_text(
-        "uri: null\n"
-        "db_name: demo\n"
-        "collection_name: null\n"
-        "multitenant: false\n",
+        "uri: null\ndb_name: demo\ncollection_name: null\nmultitenant: false\n",
         encoding="utf-8",
     )
     real_secret = "adapters:\n  mongodb:\n    uri: mongodb://local:27017\n"
@@ -1747,7 +1977,9 @@ def test_add_yaml_secrets_adapter_generates_template_and_preserves_real_secret_f
             },
             yes=True,
         )
-    config_secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    config_secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    )
     template = (project_dir / "secrets.yaml.template").read_text(encoding="utf-8")
     gitignore = (project_dir / ".gitignore").read_text(encoding="utf-8")
 
@@ -1761,7 +1993,9 @@ def test_add_yaml_secrets_adapter_generates_template_and_preserves_real_secret_f
         "adapters": {"mongodb": {"uri": "replace-me"}}
     }
 
-    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "init"], cwd=project_dir, check=True, capture_output=True, text=True
+    )
     ignored = subprocess.run(
         ["git", "check-ignore", "secrets.yaml"],
         cwd=project_dir,
@@ -1787,10 +2021,7 @@ def test_add_vault_secrets_adapter_generates_safe_config_and_resolves_with_fake_
     outbound_dir = project_dir / "config" / "adapters" / "outbound"
     outbound_dir.mkdir(parents=True, exist_ok=True)
     (outbound_dir / "mongodb.yaml").write_text(
-        "uri: null\n"
-        "db_name: demo\n"
-        "collection_name: null\n"
-        "multitenant: false\n",
+        "uri: null\ndb_name: demo\ncollection_name: null\nmultitenant: false\n",
         encoding="utf-8",
     )
 
@@ -1860,9 +2091,7 @@ def test_add_chain_secrets_adapter_preserves_mappings_and_renders_ordered_fallba
 ) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / "config" / "secrets.yaml").write_text(
-        "resolver: env\n"
-        "mappings:\n"
-        "  adapters.lm.api_key: OPENAI_API_KEY\n",
+        "resolver: env\nmappings:\n  adapters.lm.api_key: OPENAI_API_KEY\n",
         encoding="utf-8",
     )
 
@@ -1881,7 +2110,9 @@ def test_add_chain_secrets_adapter_preserves_mappings_and_renders_ordered_fallba
             },
             yes=True,
         )
-    secrets = yaml.safe_load((project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8"))
+    secrets = yaml.safe_load(
+        (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
+    )
 
     assert secrets["resolver"] == "chain"
     assert secrets["chain"] == ["env", "vault", "yaml"]
@@ -1942,13 +2173,20 @@ def test_add_runtime_docker_image_generates_hardened_templates(tmp_path: Path) -
     assert 'ENTRYPOINT ["./arclith-run"]' in dockerfile
     assert 'CMD ["api"]' in dockerfile
     assert "MODE=api" not in dockerfile
-    assert re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
-    assert re.search(r"(?m)^ENV .*SECRET|^ENV .*TOKEN|^ENV .*PASSWORD", dockerfile) is None
+    assert (
+        re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
+    )
+    assert (
+        re.search(r"(?m)^ENV .*SECRET|^ENV .*TOKEN|^ENV .*PASSWORD", dockerfile) is None
+    )
     assert ".env" in dockerignore
     assert "secrets.yaml" in dockerignore
     assert "*.pem" in dockerignore
     assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
-    assert "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;" in entrypoint
+    assert (
+        "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;"
+        in entrypoint
+    )
     assert "api)" in entrypoint
     assert "mcp|mcp_http)" in entrypoint
     assert "bus|command_bus|command-bus)" in entrypoint
@@ -1980,7 +2218,9 @@ def test_add_runtime_docker_image_rejects_invalid_port(tmp_path: Path) -> None:
         "0.8.14{api_port}",
     ],
 )
-def test_add_runtime_docker_image_rejects_unsafe_uv_version(tmp_path: Path, uv_version: str) -> None:
+def test_add_runtime_docker_image_rejects_unsafe_uv_version(
+    tmp_path: Path, uv_version: str
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     with pytest.raises(typer.Exit):
@@ -1995,7 +2235,9 @@ def test_add_runtime_docker_image_rejects_unsafe_uv_version(tmp_path: Path, uv_v
     assert not (project_dir / "Dockerfile").exists()
 
 
-def test_runtime_entrypoint_drops_explicit_mode_when_env_mode_is_set(tmp_path: Path) -> None:
+def test_runtime_entrypoint_drops_explicit_mode_when_env_mode_is_set(
+    tmp_path: Path,
+) -> None:
     project_dir = _minimal_project(tmp_path)
 
     add_adapter_cmd(
@@ -2025,7 +2267,9 @@ def test_runtime_entrypoint_drops_explicit_mode_when_env_mode_is_set(tmp_path: P
         timeout=30,
     )
 
-    assert result.returncode == 0, f"entrypoint failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"entrypoint failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
     assert json.loads((project_dir / "runtime.json").read_text(encoding="utf-8")) == {
         "mode": "mcp_http",
         "argv": [],
@@ -2033,7 +2277,9 @@ def test_runtime_entrypoint_drops_explicit_mode_when_env_mode_is_set(tmp_path: P
 
 
 def test_boolean_string_default_false_is_false(tmp_path: Path) -> None:
-    parameter = ParameterSpec(name="multitenant", kind="boolean", prompt="multitenant", default="false")
+    parameter = ParameterSpec(
+        name="multitenant", kind="boolean", prompt="multitenant", default="false"
+    )
 
     assert _resolve_parameter(parameter, None, tmp_path, prompt_missing=False) is False
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -14,12 +14,39 @@ def test_repository_capability_catalog_declares_standard_adapters() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key == "repository"
-    assert repository_adapter_names() == ("memory", "mongodb", "duckdb", "mariadb")
+    assert repository_adapter_names() == (
+        "memory",
+        "mongodb",
+        "duckdb",
+        "mariadb",
+        "postgresql",
+    )
     memory = capability.get_adapter("memory")
     assert memory is not None
     assert memory.entity_scoped is True
     assert memory.config_path is None
     assert memory.parameters == ()
+    postgresql = capability.get_adapter("postgresql")
+    assert postgresql is not None
+    assert postgresql.config_path == "config/adapters/outbound/postgresql.yaml"
+    assert [mapping.field_path for mapping in postgresql.secret_mappings] == [
+        "adapters.postgresql.url",
+        "adapters.postgresql.password",
+    ]
+    assert [mapping.secret_key for mapping in postgresql.secret_mappings] == [
+        "POSTGRESQL_URL",
+        "POSTGRESQL_PASSWORD",
+    ]
+    assert [parameter.name for parameter in postgresql.parameters] == [
+        "host",
+        "port",
+        "database",
+        "user",
+        "schema",
+        "driver",
+        "table_prefix",
+        "multitenant",
+    ]
 
 
 def test_cache_capability_catalog_declares_memory_adapter() -> None:
@@ -35,14 +62,23 @@ def test_cache_capability_catalog_declares_memory_adapter() -> None:
     assert memory.capability == "cache"
     assert memory.config_path == "config/adapters/inbound/cache.yaml"
     assert memory.entity_scoped is False
-    assert [parameter.name for parameter in memory.parameters] == ["jwks_ttl", "tenant_uri_ttl"]
+    assert [parameter.name for parameter in memory.parameters] == [
+        "jwks_ttl",
+        "tenant_uri_ttl",
+    ]
     assert redis is not None
     assert redis.capability == "cache"
     assert redis.config_path == "config/adapters/inbound/cache.yaml"
     assert redis.env_path == ".env"
     assert redis.entity_scoped is False
-    assert [parameter.name for parameter in redis.parameters] == ["redis_url", "jwks_ttl", "tenant_uri_ttl"]
-    assert [mapping.field_path for mapping in redis.secret_mappings] == ["cache.redis_url"]
+    assert [parameter.name for parameter in redis.parameters] == [
+        "redis_url",
+        "jwks_ttl",
+        "tenant_uri_ttl",
+    ]
+    assert [mapping.field_path for mapping in redis.secret_mappings] == [
+        "cache.redis_url"
+    ]
     assert [mapping.secret_key for mapping in redis.secret_mappings] == ["REDIS_URL"]
 
 
@@ -75,7 +111,10 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert env.config_path is None
     assert env.secret_resolver == "env"
     assert env.entity_scoped is False
-    assert [parameter.name for parameter in env.parameters] == ["field_path", "secret_key"]
+    assert [parameter.name for parameter in env.parameters] == [
+        "field_path",
+        "secret_key",
+    ]
     assert env.parameters[0].required is True
     assert [mapping.field_path for mapping in env.secret_mappings] == ["{field_path}"]
     assert [mapping.secret_key for mapping in env.secret_mappings] == ["{secret_key}"]
@@ -83,13 +122,24 @@ def test_secrets_capability_catalog_declares_env_adapter() -> None:
     assert yaml.config_path is None
     assert yaml.secret_resolver == "yaml"
     assert yaml.gitignore_entries == ("secrets.yaml",)
-    assert [file_template.path for file_template in yaml.file_templates] == ["secrets.yaml.template"]
-    assert [parameter.name for parameter in yaml.parameters] == ["field_path", "secret_key", "path"]
+    assert [file_template.path for file_template in yaml.file_templates] == [
+        "secrets.yaml.template"
+    ]
+    assert [parameter.name for parameter in yaml.parameters] == [
+        "field_path",
+        "secret_key",
+        "path",
+    ]
     assert vault is not None
     assert vault.config_path is None
     assert vault.secret_resolver == "vault"
     assert vault.entity_scoped is False
-    assert [parameter.name for parameter in vault.parameters] == ["field_path", "secret_key", "addr", "mount"]
+    assert [parameter.name for parameter in vault.parameters] == [
+        "field_path",
+        "secret_key",
+        "addr",
+        "mount",
+    ]
     assert vault.parameters[0].required is True
     assert vault.parameters[1].required is True
     assert chain is not None
@@ -126,7 +176,9 @@ def test_observability_capability_catalog_declares_langsmith() -> None:
         "endpoint",
         "api_key",
     ]
-    langsmith_parameters = {parameter.name: parameter for parameter in langsmith.parameters}
+    langsmith_parameters = {
+        parameter.name: parameter for parameter in langsmith.parameters
+    }
     assert langsmith_parameters["api_key"].secret is True
     assert langsmith_parameters["api_key"].default == ""
 
@@ -142,7 +194,11 @@ def test_api_capability_catalog_declares_fastapi() -> None:
     assert fastapi is not None
     assert fastapi.config_path == "config/adapters/inbound/fastapi.yaml"
     assert fastapi.entity_scoped is False
-    assert [parameter.name for parameter in fastapi.parameters] == ["host", "port", "reload"]
+    assert [parameter.name for parameter in fastapi.parameters] == [
+        "host",
+        "port",
+        "reload",
+    ]
 
 
 def test_mcp_capability_catalog_declares_fastmcp() -> None:
@@ -170,7 +226,11 @@ def test_probe_capability_catalog_declares_server() -> None:
     assert server is not None
     assert server.config_path == "config/adapters/inbound/probe.yaml"
     assert server.entity_scoped is False
-    assert [parameter.name for parameter in server.parameters] == ["host", "port", "enabled"]
+    assert [parameter.name for parameter in server.parameters] == [
+        "host",
+        "port",
+        "enabled",
+    ]
 
 
 def test_http_capability_catalog_declares_idempotency() -> None:
@@ -185,7 +245,9 @@ def test_http_capability_catalog_declares_idempotency() -> None:
     cache_control = capability.get_adapter("cache-control")
     assert idempotency is not None
     assert idempotency.config_path is None
-    assert [template.path for template in idempotency.merge_config_templates] == ["config/http.yaml"]
+    assert [template.path for template in idempotency.merge_config_templates] == [
+        "config/http.yaml"
+    ]
     assert idempotency.entity_scoped is False
     assert [parameter.name for parameter in idempotency.parameters] == [
         "enabled",
@@ -194,12 +256,16 @@ def test_http_capability_catalog_declares_idempotency() -> None:
     ]
     assert etag is not None
     assert etag.config_path is None
-    assert [template.path for template in etag.merge_config_templates] == ["config/http.yaml"]
+    assert [template.path for template in etag.merge_config_templates] == [
+        "config/http.yaml"
+    ]
     assert etag.entity_scoped is False
     assert [parameter.name for parameter in etag.parameters] == ["enabled"]
     assert cache_control is not None
     assert cache_control.config_path is None
-    assert [template.path for template in cache_control.merge_config_templates] == ["config/http.yaml"]
+    assert [template.path for template in cache_control.merge_config_templates] == [
+        "config/http.yaml"
+    ]
     assert cache_control.entity_scoped is False
     assert [parameter.name for parameter in cache_control.parameters] == [
         "get_single_max_age",
@@ -218,7 +284,9 @@ def test_command_bus_capability_catalog_declares_rabbitmq() -> None:
     assert rabbitmq is not None
     assert rabbitmq.layer == "bidirectional"
     assert rabbitmq.config_path is None
-    assert [template.path for template in rabbitmq.merge_config_templates] == ["config/command_bus.yaml"]
+    assert [template.path for template in rabbitmq.merge_config_templates] == [
+        "config/command_bus.yaml"
+    ]
     assert rabbitmq.entity_scoped is False
     assert [parameter.name for parameter in rabbitmq.parameters] == [
         "url",
@@ -243,7 +311,10 @@ def test_runtime_capability_catalog_declares_docker_image() -> None:
 
     assert capability is not None
     assert capability.layer == "runtime"
-    assert capability.description == "Runtime de déploiement standardisé pour images et processus Arclith."
+    assert (
+        capability.description
+        == "Runtime de déploiement standardisé pour images et processus Arclith."
+    )
     assert capability.activation_config_key is None
     assert capability.adapter_names() == ("docker-image",)
     docker_image = capability.get_adapter("docker-image")
@@ -276,7 +347,12 @@ def test_auth_capability_catalog_declares_keycloak() -> None:
     assert keycloak is not None
     assert keycloak.config_path == "config/adapters/inbound/keycloak.yaml"
     assert keycloak.entity_scoped is False
-    assert [parameter.name for parameter in keycloak.parameters] == ["url", "realm", "audience", "client_id"]
+    assert [parameter.name for parameter in keycloak.parameters] == [
+        "url",
+        "realm",
+        "audience",
+        "client_id",
+    ]
 
 
 def test_tenant_capability_catalog_declares_vault() -> None:
@@ -331,7 +407,11 @@ def test_llm_capability_catalog_declares_model_adapters() -> None:
     assert lmstudio is not None
     assert lmstudio.config_path == "config/adapters/outbound/lm.yaml"
     assert lmstudio.entity_scoped is False
-    assert [parameter.name for parameter in lmstudio.parameters] == ["model_name", "base_url", "api_key"]
+    assert [parameter.name for parameter in lmstudio.parameters] == [
+        "model_name",
+        "base_url",
+        "api_key",
+    ]
 
     assert openai is not None
     assert openai.config_path == "config/adapters/outbound/lm.yaml"
@@ -341,17 +421,25 @@ def test_llm_capability_catalog_declares_model_adapters() -> None:
     assert openai_parameters["model_name"].default == "remplacer-par-model-id-openai"
     assert openai_parameters["api_key"].secret is True
     assert openai_parameters["api_key"].default == ""
-    assert [mapping.field_path for mapping in openai.secret_mappings] == ["adapters.lm.api_key"]
+    assert [mapping.field_path for mapping in openai.secret_mappings] == [
+        "adapters.lm.api_key"
+    ]
 
     assert anthropic is not None
     assert anthropic.config_path == "config/adapters/outbound/lm.yaml"
     assert anthropic.env_path == ".env"
     assert anthropic.entity_scoped is False
-    anthropic_parameters = {parameter.name: parameter for parameter in anthropic.parameters}
-    assert anthropic_parameters["model_name"].default == "remplacer-par-model-id-anthropic"
+    anthropic_parameters = {
+        parameter.name: parameter for parameter in anthropic.parameters
+    }
+    assert (
+        anthropic_parameters["model_name"].default == "remplacer-par-model-id-anthropic"
+    )
     assert anthropic_parameters["api_key"].secret is True
     assert anthropic_parameters["api_key"].default == ""
-    assert [mapping.secret_key for mapping in anthropic.secret_mappings] == ["ANTHROPIC_API_KEY"]
+    assert [mapping.secret_key for mapping in anthropic.secret_mappings] == [
+        "ANTHROPIC_API_KEY"
+    ]
 
 
 def test_observability_capability_catalog_declares_opentelemetry() -> None:
@@ -393,7 +481,10 @@ def test_agent_capability_catalog_declares_langgraph() -> None:
         "{package_path}/adapters/inbound/langgraph/__init__.py",
         "{package_path}/adapters/inbound/langgraph/agent.py",
     ]
-    assert [parameter.name for parameter in langgraph.parameters] == ["graph_name", "stream_mode"]
+    assert [parameter.name for parameter in langgraph.parameters] == [
+        "graph_name",
+        "stream_mode",
+    ]
 
 
 def test_repository_adapter_specs_include_config_and_parameters() -> None:
@@ -406,9 +497,17 @@ def test_repository_adapter_specs_include_config_and_parameters() -> None:
 
     assert mongodb is not None
     assert mongodb.config_path == "config/adapters/outbound/mongodb.yaml"
-    assert [parameter.name for parameter in mongodb.parameters] == ["db_name", "collection_name", "multitenant"]
-    assert [mapping.field_path for mapping in mongodb.secret_mappings] == ["adapters.mongodb.uri"]
-    assert [mapping.secret_key for mapping in mongodb.secret_mappings] == ["MONGODB_URI"]
+    assert [parameter.name for parameter in mongodb.parameters] == [
+        "db_name",
+        "collection_name",
+        "multitenant",
+    ]
+    assert [mapping.field_path for mapping in mongodb.secret_mappings] == [
+        "adapters.mongodb.uri"
+    ]
+    assert [mapping.secret_key for mapping in mongodb.secret_mappings] == [
+        "MONGODB_URI"
+    ]
     assert duckdb is not None
     assert duckdb.config_path == "config/adapters/outbound/duckdb.yaml"
     assert [parameter.name for parameter in duckdb.parameters] == ["path"]
@@ -550,7 +649,13 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     payload = json.loads(result.stdout)
     payload_by_name = {capability["name"]: capability for capability in payload}
     repository = payload_by_name["repository"]
-    assert [adapter["name"] for adapter in repository["adapters"]] == ["memory", "mongodb", "duckdb", "mariadb"]
+    assert [adapter["name"] for adapter in repository["adapters"]] == [
+        "memory",
+        "mongodb",
+        "duckdb",
+        "mariadb",
+        "postgresql",
+    ]
     assert repository["adapters"][0]["entity_scoped"] is True
     duckdb = repository["adapters"][2]
     assert duckdb["name"] == "duckdb"
@@ -623,26 +728,36 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "jwks_ttl",
         "tenant_uri_ttl",
     ]
-    assert [mapping["field_path"] for mapping in cache["adapters"][1]["secret_mappings"]] == [
-        "cache.redis_url"
-    ]
+    assert [
+        mapping["field_path"] for mapping in cache["adapters"][1]["secret_mappings"]
+    ] == ["cache.redis_url"]
     logger = payload_by_name["logger"]
     assert logger["activation_config_key"] == "logger"
     assert [adapter["name"] for adapter in logger["adapters"]] == ["console"]
     assert logger["adapters"][0]["entity_scoped"] is False
     assert logger["adapters"][0]["config_path"] is None
     secrets = payload_by_name["secrets"]
-    assert [adapter["name"] for adapter in secrets["adapters"]] == ["env", "yaml", "vault", "chain"]
+    assert [adapter["name"] for adapter in secrets["adapters"]] == [
+        "env",
+        "yaml",
+        "vault",
+        "chain",
+    ]
     env = secrets["adapters"][0]
     yaml_adapter = secrets["adapters"][1]
     vault_adapter = secrets["adapters"][2]
     chain_adapter = secrets["adapters"][3]
     assert env["secret_resolver"] == "env"
-    assert [parameter["name"] for parameter in env["parameters"]] == ["field_path", "secret_key"]
+    assert [parameter["name"] for parameter in env["parameters"]] == [
+        "field_path",
+        "secret_key",
+    ]
     assert env["parameters"][0]["required"] is True
     assert yaml_adapter["secret_resolver"] == "yaml"
     assert yaml_adapter["gitignore_entries"] == ["secrets.yaml"]
-    assert [template["path"] for template in yaml_adapter["file_templates"]] == ["secrets.yaml.template"]
+    assert [template["path"] for template in yaml_adapter["file_templates"]] == [
+        "secrets.yaml.template"
+    ]
     assert vault_adapter["secret_resolver"] == "vault"
     assert [parameter["name"] for parameter in vault_adapter["parameters"]] == [
         "field_path",
@@ -651,11 +766,17 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "mount",
     ]
     assert chain_adapter["secret_resolver"] == "chain"
-    chain_parameters = {parameter["name"]: parameter for parameter in chain_adapter["parameters"]}
+    chain_parameters = {
+        parameter["name"]: parameter for parameter in chain_adapter["parameters"]
+    }
     assert chain_parameters["resolvers"]["choices"] == ["env", "vault", "yaml"]
     assert chain_parameters["resolvers"]["csv_choices"] is True
-    assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == ["fastapi"]
-    assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == ["fastmcp"]
+    assert [adapter["name"] for adapter in payload_by_name["api"]["adapters"]] == [
+        "fastapi"
+    ]
+    assert [adapter["name"] for adapter in payload_by_name["mcp"]["adapters"]] == [
+        "fastmcp"
+    ]
     probe = payload_by_name["probe"]
     assert [adapter["name"] for adapter in probe["adapters"]] == ["server"]
     probe_server = probe["adapters"][0]
@@ -666,22 +787,32 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "enabled",
     ]
     http = payload_by_name["http"]
-    assert [adapter["name"] for adapter in http["adapters"]] == ["idempotency", "etag", "cache-control"]
+    assert [adapter["name"] for adapter in http["adapters"]] == [
+        "idempotency",
+        "etag",
+        "cache-control",
+    ]
     idempotency = http["adapters"][0]
     etag = http["adapters"][1]
     cache_control = http["adapters"][2]
     assert idempotency["config_path"] is None
-    assert [template["path"] for template in idempotency["merge_config_templates"]] == ["config/http.yaml"]
+    assert [template["path"] for template in idempotency["merge_config_templates"]] == [
+        "config/http.yaml"
+    ]
     assert [parameter["name"] for parameter in idempotency["parameters"]] == [
         "enabled",
         "ttl_seconds",
         "required",
     ]
     assert etag["config_path"] is None
-    assert [template["path"] for template in etag["merge_config_templates"]] == ["config/http.yaml"]
+    assert [template["path"] for template in etag["merge_config_templates"]] == [
+        "config/http.yaml"
+    ]
     assert [parameter["name"] for parameter in etag["parameters"]] == ["enabled"]
     assert cache_control["config_path"] is None
-    assert [template["path"] for template in cache_control["merge_config_templates"]] == ["config/http.yaml"]
+    assert [
+        template["path"] for template in cache_control["merge_config_templates"]
+    ] == ["config/http.yaml"]
     assert [parameter["name"] for parameter in cache_control["parameters"]] == [
         "get_single_max_age",
         "get_list_max_age",
@@ -691,7 +822,9 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [adapter["name"] for adapter in command_bus["adapters"]] == ["rabbitmq"]
     rabbitmq = command_bus["adapters"][0]
     assert rabbitmq["config_path"] is None
-    assert [template["path"] for template in rabbitmq["merge_config_templates"]] == ["config/command_bus.yaml"]
+    assert [template["path"] for template in rabbitmq["merge_config_templates"]] == [
+        "config/command_bus.yaml"
+    ]
     assert [parameter["name"] for parameter in rabbitmq["parameters"]] == [
         "url",
         "exchange",
@@ -726,7 +859,9 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     ]
     auth = payload_by_name["auth"]
     assert [adapter["name"] for adapter in auth["adapters"]] == ["keycloak"]
-    keycloak_parameters = {parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]}
+    keycloak_parameters = {
+        parameter["name"]: parameter for parameter in auth["adapters"][0]["parameters"]
+    }
     assert keycloak_parameters["url"]["default"] == "http://localhost:8080"
     assert keycloak_parameters["realm"]["default"] == "rekipe"
     assert keycloak_parameters["audience"]["default"] == "null"
@@ -735,33 +870,54 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     assert [adapter["name"] for adapter in tenant["adapters"]] == ["vault"]
     tenant_vault = tenant["adapters"][0]
     assert tenant_vault["config_path"] == "config/adapters/inbound/tenant.yaml"
-    assert [template["path"] for template in tenant_vault["merge_config_templates"]] == [
-        "config/adapters/inbound/cache.yaml"
-    ]
+    assert [
+        template["path"] for template in tenant_vault["merge_config_templates"]
+    ] == ["config/adapters/inbound/cache.yaml"]
     license_capability = payload_by_name["license"]
     assert [adapter["name"] for adapter in license_capability["adapters"]] == ["role"]
     role_parameters = {
         parameter["name"]: parameter
         for parameter in license_capability["adapters"][0]["parameters"]
     }
-    assert license_capability["adapters"][0]["config_path"] == "config/adapters/inbound/license.yaml"
+    assert (
+        license_capability["adapters"][0]["config_path"]
+        == "config/adapters/inbound/license.yaml"
+    )
     assert role_parameters["role"]["default"] == "rekipe:licensed"
     llm = payload_by_name["llm"]
-    assert [adapter["name"] for adapter in llm["adapters"]] == ["lmstudio", "openai", "anthropic"]
+    assert [adapter["name"] for adapter in llm["adapters"]] == [
+        "lmstudio",
+        "openai",
+        "anthropic",
+    ]
     openai = llm["adapters"][1]
-    openai_parameters = {parameter["name"]: parameter for parameter in openai["parameters"]}
+    openai_parameters = {
+        parameter["name"]: parameter for parameter in openai["parameters"]
+    }
     assert openai_parameters["model_name"]["default"] == "remplacer-par-model-id-openai"
     assert openai_parameters["api_key"]["secret"] is True
     assert openai_parameters["api_key"]["default"] == ""
     anthropic = llm["adapters"][2]
-    anthropic_parameters = {parameter["name"]: parameter for parameter in anthropic["parameters"]}
-    assert anthropic_parameters["model_name"]["default"] == "remplacer-par-model-id-anthropic"
+    anthropic_parameters = {
+        parameter["name"]: parameter for parameter in anthropic["parameters"]
+    }
+    assert (
+        anthropic_parameters["model_name"]["default"]
+        == "remplacer-par-model-id-anthropic"
+    )
     assert anthropic_parameters["api_key"]["secret"] is True
     assert anthropic_parameters["api_key"]["default"] == ""
-    assert [adapter["name"] for adapter in payload_by_name["agent"]["adapters"]] == ["langgraph"]
+    assert [adapter["name"] for adapter in payload_by_name["agent"]["adapters"]] == [
+        "langgraph"
+    ]
     observability = payload_by_name["observability"]
-    assert [adapter["name"] for adapter in observability["adapters"]] == ["langsmith", "opentelemetry"]
+    assert [adapter["name"] for adapter in observability["adapters"]] == [
+        "langsmith",
+        "opentelemetry",
+    ]
     langsmith = observability["adapters"][0]
-    langsmith_parameters = {parameter["name"]: parameter for parameter in langsmith["parameters"]}
+    langsmith_parameters = {
+        parameter["name"]: parameter for parameter in langsmith["parameters"]
+    }
     assert langsmith_parameters["api_key"]["secret"] is True
     assert langsmith_parameters["api_key"]["default"] == ""

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -29,7 +29,7 @@ arclith-cli capabilities --json
 | [license](capabilities/license.md) | inbound | `role` | contrôler un droit d'accès |
 | [probe](capabilities/probe.md) | inbound | `server` | exposer `/health` et `/ready` |
 | [http](capabilities/http.md) | inbound | `idempotency`, `etag`, `cache-control` | durcir les conventions HTTP |
-| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb` | persister les entités |
+| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | persister les entités |
 | [storage](capabilities/storage.md) | outbound | `filesystem`, `s3`, `azure-blob`, `gcs` | stocker fichiers et blobs |
 | [cache](capabilities/cache.md) | outbound | `memory`, `redis` | partager JWKS, tenants et idempotence |
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |

--- a/docs/capabilities/repository.md
+++ b/docs/capabilities/repository.md
@@ -5,8 +5,8 @@ Persistance des entités métier derrière un port repository.
 ## Objectif
 
 Un repository est un adapter outbound. Les use cases dépendent du port
-`Repository[T]`; le choix MongoDB, MariaDB, DuckDB ou mémoire reste dans la
-configuration et l'assemblage applicatif.
+`Repository[T]`; le choix MongoDB, PostgreSQL, MariaDB, DuckDB ou mémoire reste
+dans la configuration et l'assemblage applicatif.
 
 ## Choisir L'adapter
 
@@ -16,15 +16,21 @@ configuration et l'assemblage applicatif.
 | `mongodb` | standard document, API/MCP/agent avec état partagé |
 | `duckdb` | fichier local, démo, analytique embarquée |
 | `mariadb` | SQL serveur, intégration SI existant |
+| `postgresql` | SQL serveur robuste, JSONB générique, état partagé multi-process |
 
 ## Installer
 
 ```bash
 arclith-cli add-adapter --capability repository --adapter memory --yes
 arclith-cli add-adapter --capability repository --adapter mongodb --yes
+arclith-cli add-adapter \
+  --capability repository \
+  --adapter postgresql \
+  --param database=my_service \
+  --yes
 ```
 
-Pour MongoDB ou MariaDB, ajouter aussi le resolver de secrets adapté.
+Pour MongoDB, MariaDB ou PostgreSQL, ajouter aussi le resolver de secrets adapté.
 
 ```bash
 arclith-cli add-adapter \
@@ -72,6 +78,40 @@ multitenant: false
 
 Mapper `adapters.mariadb.url` ou `adapters.mariadb.password` via secrets.
 
+## PostgreSQL
+
+```yaml
+# config/adapters/outbound/postgresql.yaml
+url: null
+host: 127.0.0.1
+port: 5432
+database: my_service
+user: app
+password: null
+schema: public
+driver: asyncpg
+table_prefix: ""
+multitenant: false
+```
+
+PostgreSQL stocke chaque entité dans une table générique par type, avec
+`uuid`, les champs d'audit et le payload complet dans une colonne `JSONB`.
+Ce choix garde les use cases inchangés: ils continuent à dépendre uniquement du
+port `Repository[T]`.
+
+Utiliser PostgreSQL quand un service API, MCP ou agent a besoin d'une base
+serveur partagée, durable, multi-process, avec des garanties transactionnelles
+fortes à l'intérieur d'une même base. Contrairement à MongoDB, le backend reste
+relationnel; contrairement à MariaDB, le payload exploite `JSONB`; contrairement
+à DuckDB, il cible un runtime serveur.
+
+Mapper `adapters.postgresql.url` ou `adapters.postgresql.password` via secrets,
+par exemple `POSTGRESQL_URL` et `POSTGRESQL_PASSWORD`. La CLI génère les
+mappings, mais ne génère pas d'URL ou de mot de passe en clair.
+
+Le mapping relationnel riche, les colonnes métier typées, Alembic, les joins et
+les contraintes SQL métier sont des évolutions séparées.
+
 ## DuckDB
 
 ```yaml
@@ -102,7 +142,8 @@ d'application pour partager le même repository entre API, MCP et agent.
 - Un adapter inbound ne doit jamais instancier un repository concret.
 - Les use cases parlent au port `Repository[T]`.
 - `memory` ne partage pas l'état entre processus API, MCP et agent.
-- Les URI et mots de passe passent par la capability [secrets](secrets.md).
+- Les URI et mots de passe passent par la capability [secrets](secrets.md),
+  par exemple `POSTGRESQL_URL` ou `POSTGRESQL_PASSWORD`.
 - La configuration choisit l'adapter actif; le code métier reste stable.
 
 ## Validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Repository = "https://github.com/karned-rekipe/arclith"
 mongodb = ["motor==3.7.1"]
 duckdb  = ["duckdb==1.5.0", "pytz==2024.1"]
 mariadb = ["sqlalchemy[asyncio]>=2.0.36", "asyncmy>=0.2.10"]
+postgresql = ["sqlalchemy[asyncio]>=2.0.36", "asyncpg>=0.30.0"]
 fastapi = ["fastapi==0.135.1", "uvicorn==0.41.0"]
 mcp     = ["fastmcp==3.1.0"]
 vault   = ["hvac==2.3.0"]
@@ -52,6 +53,7 @@ all     = [
     "pytz==2024.1",
     "sqlalchemy[asyncio]>=2.0.36",
     "asyncmy>=0.2.10",
+    "asyncpg>=0.30.0",
     "fastapi==0.135.1",
     "uvicorn==0.41.0",
     "fastmcp==3.1.0",
@@ -98,6 +100,7 @@ omit = [
     "arclith/adapters/outbound/mongodb/*",
     "arclith/adapters/outbound/duckdb/*",
     "arclith/adapters/outbound/mariadb/*",
+    "arclith/adapters/outbound/postgresql/*",
     # Bootstrap — wired via integration tests, not unit tests
     "arclith/arclith.py",
     "**/__init__.py",

--- a/tests/units/adapters/outbound/test_postgresql_config.py
+++ b/tests/units/adapters/outbound/test_postgresql_config.py
@@ -1,0 +1,83 @@
+import pytest
+
+from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+
+
+def test_connection_url_encodes_credentials() -> None:
+    config = PostgreSQLConfig(
+        database="tenant db", user="app user", password="s e+c/r/e/t"
+    )
+
+    assert (
+        config.connection_url()
+        == "postgresql+asyncpg://app+user:s+e%2Bc%2Fr%2Fe%2Ft@127.0.0.1:5432/tenant+db"
+    )
+
+
+def test_with_tenant_params_accepts_aliases_and_schema() -> None:
+    config = PostgreSQLConfig(database="default").with_tenant_params(
+        {
+            "db_name": "tenant",
+            "username": "tenant_user",
+            "password": "secret",
+            "schema": "tenant_schema",
+            "table_prefix": "tenant_",
+        }
+    )
+
+    assert config.database == "tenant"
+    assert config.user == "tenant_user"
+    assert config.password == "secret"
+    assert config.schema == "tenant_schema"
+    assert config.table_prefix == "tenant_"
+    assert (
+        config.connection_url()
+        == "postgresql+asyncpg://tenant_user:secret@127.0.0.1:5432/tenant"
+    )
+
+
+def test_with_tenant_params_accepts_uri_alias() -> None:
+    config = PostgreSQLConfig(database="default").with_tenant_params(
+        {"uri": "postgresql+asyncpg://tenant@db:5432/tenant"}
+    )
+
+    assert config.url == "postgresql+asyncpg://tenant@db:5432/tenant"
+    assert config.connection_url() == "postgresql+asyncpg://tenant@db:5432/tenant"
+
+
+@pytest.mark.parametrize(
+    ("raw_port", "expected"),
+    [
+        ("5433", 5433),
+        (" 5433 ", 5433),
+        ("", 5432),
+        ("   ", 5432),
+    ],
+)
+def test_with_tenant_params_parses_port(raw_port: str, expected: int) -> None:
+    config = PostgreSQLConfig(database="demo").with_tenant_params({"port": raw_port})
+
+    assert config.port == expected
+
+
+@pytest.mark.parametrize("raw_port", ["0", "65536", "-1", "abc", "54.32"])
+def test_with_tenant_params_rejects_invalid_port(raw_port: str) -> None:
+    with pytest.raises(ValueError, match="PostgreSQL port"):
+        PostgreSQLConfig(database="demo").with_tenant_params({"port": raw_port})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("schema", "unsafe-name"),
+        ("table_prefix", "unsafe-name"),
+    ],
+)
+def test_rejects_unsafe_identifiers(field_name: str, value: str) -> None:
+    with pytest.raises(ValueError, match=field_name):
+        PostgreSQLConfig(database="demo", **{field_name: value})
+
+
+def test_connection_url_requires_database_when_url_is_missing() -> None:
+    with pytest.raises(ValueError, match="database is required"):
+        PostgreSQLConfig(database=None).connection_url()

--- a/tests/units/adapters/outbound/test_postgresql_repository.py
+++ b/tests/units/adapters/outbound/test_postgresql_repository.py
@@ -27,6 +27,10 @@ class FakeConnection:
     def __init__(self, engine: "FakeEngine") -> None:
         self._engine = engine
 
+    async def execute(self, statement) -> None:
+        self._engine.executed_statements.append(statement)
+        await asyncio.sleep(0)
+
     async def run_sync(self, fn) -> None:
         self._engine.run_sync_calls += 1
         await asyncio.sleep(0)
@@ -49,6 +53,7 @@ class FakeEngine:
     def __init__(self) -> None:
         self.begin_calls = 0
         self.run_sync_calls = 0
+        self.executed_statements: list[Any] = []
 
     def begin(self) -> FakeBegin:
         return FakeBegin(self)
@@ -85,7 +90,29 @@ async def test_ensure_schema_is_locked_per_url(logger) -> None:
 
     assert engine.begin_calls == 1
     assert engine.run_sync_calls == 1
+    assert engine.executed_statements == []
     assert len(repository._schema_locks) == 1
+
+
+async def test_ensure_schema_creates_custom_schema_before_tables(logger) -> None:
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(database="demo", schema="tenant_a"),
+        Item,
+        logger,
+    )
+    engine = FakeEngine()
+    metadata, _table = repository._table_for(repository._config)
+
+    await repository._ensure_schema(
+        engine, "postgresql://demo", metadata, "tenant_a.item"
+    )
+
+    assert engine.begin_calls == 1
+    assert engine.run_sync_calls == 1
+    assert len(engine.executed_statements) == 1
+    statement = engine.executed_statements[0]
+    assert statement.element == "tenant_a"
+    assert statement.if_not_exists is True
 
 
 def test_entity_serialization_round_trip_preserves_pydantic_values(logger) -> None:

--- a/tests/units/adapters/outbound/test_postgresql_repository.py
+++ b/tests/units/adapters/outbound/test_postgresql_repository.py
@@ -1,0 +1,121 @@
+import asyncio
+from datetime import date, datetime, timezone
+import json
+from typing import Any
+
+import pytest
+from pydantic import Field
+
+pytest.importorskip("sqlalchemy")
+
+from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+from arclith.domain.models.entity import Entity
+
+
+class Item(Entity):
+    name: str = "item"
+
+
+class RichItem(Entity):
+    name: str
+    due_on: date
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class FakeConnection:
+    def __init__(self, engine: "FakeEngine") -> None:
+        self._engine = engine
+
+    async def run_sync(self, fn) -> None:
+        self._engine.run_sync_calls += 1
+        await asyncio.sleep(0)
+
+
+class FakeBegin:
+    def __init__(self, engine: "FakeEngine") -> None:
+        self._engine = engine
+
+    async def __aenter__(self) -> FakeConnection:
+        self._engine.begin_calls += 1
+        await asyncio.sleep(0)
+        return FakeConnection(self._engine)
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self.begin_calls = 0
+        self.run_sync_calls = 0
+
+    def begin(self) -> FakeBegin:
+        return FakeBegin(self)
+
+
+def test_build_table_uses_schema_prefix_and_jsonb(logger) -> None:
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(database="demo", schema="app", table_prefix="svc_"),
+        Item,
+        logger,
+    )
+
+    _metadata, table = repository._table_for(repository._config)
+
+    assert table.schema == "app"
+    assert table.name == "svc_item"
+    assert table.c.uuid.type.length == 36
+    assert table.c.data.type.__class__.__name__ == "JSONB"
+
+
+async def test_ensure_schema_is_locked_per_url(logger) -> None:
+    repository = PostgreSQLRepository(PostgreSQLConfig(database="demo"), Item, logger)
+    engine = FakeEngine()
+    metadata, _table = repository._table_for(repository._config)
+
+    await asyncio.gather(
+        *(
+            repository._ensure_schema(
+                engine, "postgresql://demo", metadata, "public.item"
+            )
+            for _ in range(5)
+        )
+    )
+
+    assert engine.begin_calls == 1
+    assert engine.run_sync_calls == 1
+    assert len(repository._schema_locks) == 1
+
+
+def test_entity_serialization_round_trip_preserves_pydantic_values(logger) -> None:
+    now = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+    entity = RichItem(
+        name="deadline",
+        due_on=date(2026, 9, 1),
+        metadata={"nested": {"rank": 1}},
+        created_at=now,
+        updated_at=now,
+    )
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(database="demo"), RichItem, logger
+    )
+
+    values = repository._entity_values(entity)
+    restored = repository._row_to_entity({"data": values["data"]})
+
+    assert values["data"]["uuid"] == str(entity.uuid)
+    assert values["data"]["created_at"] == "2026-08-25T12:00:00Z"
+    assert values["data"]["due_on"] == "2026-09-01"
+    assert restored == entity
+
+
+def test_row_to_entity_accepts_serialized_json_string(logger) -> None:
+    entity = Item(name="json")
+    repository = PostgreSQLRepository(PostgreSQLConfig(database="demo"), Item, logger)
+
+    restored = repository._row_to_entity(
+        {"data": json.dumps(entity.model_dump(mode="json"))}
+    )
+
+    assert restored == entity

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -14,6 +14,7 @@ from arclith.infrastructure.config import (
     LangSmithSettings,
     MariaDBSettings,
     OpenTelemetrySettings,
+    PostgreSQLSettings,
     RabbitMQCommandBusSettings,
     SoftDeleteSettings,
     StorageSettings,
@@ -26,6 +27,7 @@ from arclith.infrastructure.config import (
 
 
 # ── AppConfig defaults ────────────────────────────────────────────────────────
+
 
 def test_default_config_uses_memory():
     assert AppConfig().adapters.repository == "memory"
@@ -52,6 +54,7 @@ def test_default_retention_is_none():
 
 # ── _resolve_key_path ─────────────────────────────────────────────────────────
 
+
 def test_resolve_root_file():
     assert _resolve_key_path(Path("app.yaml")) == ["app"]
 
@@ -69,10 +72,26 @@ def test_resolve_adapters_selector():
 
 
 def test_resolve_output_adapter():
-    assert _resolve_key_path(Path("adapters/outbound/mongodb.yaml")) == ["adapters", "mongodb"]
-    assert _resolve_key_path(Path("adapters/outbound/duckdb.yaml")) == ["adapters", "duckdb"]
-    assert _resolve_key_path(Path("adapters/outbound/mariadb.yaml")) == ["adapters", "mariadb"]
-    assert _resolve_key_path(Path("adapters/outbound/storage.yaml")) == ["adapters", "storage"]
+    assert _resolve_key_path(Path("adapters/outbound/mongodb.yaml")) == [
+        "adapters",
+        "mongodb",
+    ]
+    assert _resolve_key_path(Path("adapters/outbound/duckdb.yaml")) == [
+        "adapters",
+        "duckdb",
+    ]
+    assert _resolve_key_path(Path("adapters/outbound/mariadb.yaml")) == [
+        "adapters",
+        "mariadb",
+    ]
+    assert _resolve_key_path(Path("adapters/outbound/postgresql.yaml")) == [
+        "adapters",
+        "postgresql",
+    ]
+    assert _resolve_key_path(Path("adapters/outbound/storage.yaml")) == [
+        "adapters",
+        "storage",
+    ]
 
 
 def test_resolve_input_alias_fastapi():
@@ -98,6 +117,7 @@ def test_resolve_unknown_path_returns_empty():
 
 
 # ── _deep_merge ───────────────────────────────────────────────────────────────
+
 
 def test_deep_merge_simple():
     result = _deep_merge({"a": 1}, {"b": 2})
@@ -125,6 +145,7 @@ def test_deep_merge_does_not_mutate_base():
 
 
 # ── load_config_dir ───────────────────────────────────────────────────────────
+
 
 def _make_config_dir(files: dict[str, dict]) -> Path:
     """Helper: create a temp config/ directory with the given files."""
@@ -168,13 +189,15 @@ def test_load_config_dir_mcp_via_fastmcp_alias():
 
 
 def test_load_config_dir_probe_scoped():
-    path = _make_config_dir({
-        "adapters/inbound/probe.yaml": {
-            "host": "127.0.0.1",
-            "port": 9100,
-            "enabled": False,
+    path = _make_config_dir(
+        {
+            "adapters/inbound/probe.yaml": {
+                "host": "127.0.0.1",
+                "port": 9100,
+                "enabled": False,
+            }
         }
-    })
+    )
     config = load_config_dir(path)
     assert config.probe.host == "127.0.0.1"
     assert config.probe.port == 9100
@@ -182,13 +205,15 @@ def test_load_config_dir_probe_scoped():
 
 
 def test_load_config_dir_cache_scoped():
-    path = _make_config_dir({
-        "adapters/inbound/cache.yaml": {
-            "backend": "memory",
-            "jwks_ttl": 1200,
-            "tenant_uri_ttl": 180,
+    path = _make_config_dir(
+        {
+            "adapters/inbound/cache.yaml": {
+                "backend": "memory",
+                "jwks_ttl": 1200,
+                "tenant_uri_ttl": 180,
+            }
         }
-    })
+    )
     config = load_config_dir(path)
     assert config.cache.backend == "memory"
     assert config.cache.jwks_ttl == 1200
@@ -196,14 +221,16 @@ def test_load_config_dir_cache_scoped():
 
 
 def test_load_config_dir_redis_cache_scoped():
-    path = _make_config_dir({
-        "adapters/inbound/cache.yaml": {
-            "backend": "redis",
-            "redis_url": "redis://cache:6379/0",
-            "jwks_ttl": 900,
-            "tenant_uri_ttl": 120,
+    path = _make_config_dir(
+        {
+            "adapters/inbound/cache.yaml": {
+                "backend": "redis",
+                "redis_url": "redis://cache:6379/0",
+                "jwks_ttl": 900,
+                "tenant_uri_ttl": 120,
+            }
         }
-    })
+    )
     config = load_config_dir(path)
     assert config.cache.backend == "redis"
     assert config.cache.redis_url == "redis://cache:6379/0"
@@ -212,10 +239,12 @@ def test_load_config_dir_redis_cache_scoped():
 
 
 def test_load_config_dir_mongodb_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "mongodb"},
-        "adapters/outbound/mongodb.yaml": {"db_name": "mydb", "multitenant": False},
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "mongodb"},
+            "adapters/outbound/mongodb.yaml": {"db_name": "mydb", "multitenant": False},
+        }
+    )
     config = load_config_dir(path)
     assert config.adapters.repository == "mongodb"
     assert config.adapters.mongodb is not None
@@ -223,36 +252,60 @@ def test_load_config_dir_mongodb_scoped():
 
 
 def test_load_config_dir_duckdb_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "duckdb"},
-        "adapters/outbound/duckdb.yaml": {"path": "data/"},
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "duckdb"},
+            "adapters/outbound/duckdb.yaml": {"path": "data/"},
+        }
+    )
     config = load_config_dir(path)
     assert config.adapters.duckdb is not None
     assert config.adapters.duckdb.path == "data/"
 
 
 def test_load_config_dir_mariadb_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "mariadb"},
-        "adapters/outbound/mariadb.yaml": {"database": "demo", "user": "app"},
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "mariadb"},
+            "adapters/outbound/mariadb.yaml": {"database": "demo", "user": "app"},
+        }
+    )
     config = load_config_dir(path)
     assert config.adapters.mariadb is not None
     assert config.adapters.mariadb.database == "demo"
     assert config.adapters.mariadb.user == "app"
 
 
+def test_load_config_dir_postgresql_scoped():
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "postgresql"},
+            "adapters/outbound/postgresql.yaml": {
+                "database": "demo",
+                "user": "app",
+                "schema": "public",
+            },
+        }
+    )
+    config = load_config_dir(path)
+    assert config.adapters.postgresql is not None
+    assert config.adapters.postgresql.database == "demo"
+    assert config.adapters.postgresql.user == "app"
+    assert config.adapters.postgresql.schema_name == "public"
+
+
 def test_load_config_dir_storage_filesystem_scoped():
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "filesystem",
-            "root_path": "/data/files",
-            "prefix": "uploads",
-            "create_root": False,
-            "multitenant": False,
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "filesystem",
+                "root_path": "/data/files",
+                "prefix": "uploads",
+                "create_root": False,
+                "multitenant": False,
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
@@ -264,17 +317,19 @@ def test_load_config_dir_storage_filesystem_scoped():
 
 
 def test_load_config_dir_storage_s3_scoped():
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "s3",
-            "bucket_name": "arclith-files",
-            "prefix": "uploads",
-            "region_name": "eu-west-3",
-            "endpoint_url": "http://127.0.0.1:9000",
-            "force_path_style": True,
-            "multitenant": False,
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "s3",
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "region_name": "eu-west-3",
+                "endpoint_url": "http://127.0.0.1:9000",
+                "force_path_style": True,
+                "multitenant": False,
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
@@ -288,16 +343,18 @@ def test_load_config_dir_storage_s3_scoped():
 
 
 def test_load_config_dir_storage_gcs_scoped():
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "gcs",
-            "bucket_name": "arclith-files",
-            "prefix": "uploads",
-            "project_id": "project-a",
-            "credentials_json_b64": "encoded",
-            "multitenant": False,
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "gcs",
+                "bucket_name": "arclith-files",
+                "prefix": "uploads",
+                "project_id": "project-a",
+                "credentials_json_b64": "encoded",
+                "multitenant": False,
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
@@ -310,24 +367,28 @@ def test_load_config_dir_storage_gcs_scoped():
 
 
 def test_load_config_dir_storage_azure_blob_scoped():
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "azure-blob",
-            "account_url": "https://account.blob.core.windows.net",
-            "container_name": "arclith-files",
-            "prefix": "uploads",
-            "connection_string": "UseDevelopmentStorage=true",
-            "account_key": None,
-            "sas_token": None,
-            "use_default_credential": False,
-            "multitenant": False,
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "azure-blob",
+                "account_url": "https://account.blob.core.windows.net",
+                "container_name": "arclith-files",
+                "prefix": "uploads",
+                "connection_string": "UseDevelopmentStorage=true",
+                "account_key": None,
+                "sas_token": None,
+                "use_default_credential": False,
+                "multitenant": False,
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
     assert config.adapters.storage.adapter == "azure-blob"
-    assert config.adapters.storage.account_url == "https://account.blob.core.windows.net"
+    assert (
+        config.adapters.storage.account_url == "https://account.blob.core.windows.net"
+    )
     assert config.adapters.storage.container_name == "arclith-files"
     assert config.adapters.storage.prefix == "uploads"
     assert config.adapters.storage.connection_string == "UseDevelopmentStorage=true"
@@ -341,21 +402,23 @@ def test_load_config_dir_storage_azure_blob_credentials_from_secret_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "UseDevelopmentStorage=true")
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "azure-blob",
-            "account_url": "https://account.blob.core.windows.net",
-            "container_name": "arclith-files",
-            "connection_string": None,
-            "multitenant": False,
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.storage.connection_string": "AZURE_STORAGE_CONNECTION_STRING",
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "azure-blob",
+                "account_url": "https://account.blob.core.windows.net",
+                "container_name": "arclith-files",
+                "connection_string": None,
+                "multitenant": False,
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.storage.connection_string": "AZURE_STORAGE_CONNECTION_STRING",
+                },
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
@@ -367,19 +430,21 @@ def test_load_config_dir_storage_gcs_credentials_from_secret_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("GCS_SERVICE_ACCOUNT_JSON_B64", "encoded-from-env")
-    path = _make_config_dir({
-        "adapters/outbound/storage.yaml": {
-            "adapter": "gcs",
-            "bucket_name": "arclith-files",
-            "credentials_json_b64": None,
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.storage.credentials_json_b64": "GCS_SERVICE_ACCOUNT_JSON_B64",
+    path = _make_config_dir(
+        {
+            "adapters/outbound/storage.yaml": {
+                "adapter": "gcs",
+                "bucket_name": "arclith-files",
+                "credentials_json_b64": None,
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.storage.credentials_json_b64": "GCS_SERVICE_ACCOUNT_JSON_B64",
+                },
+            },
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.storage is not None
@@ -393,10 +458,18 @@ def test_load_config_dir_storage_gcs_credentials_from_secret_mapping(
         ({"adapter": "filesystem"}, "root_path"),
         ({"adapter": "s3"}, "bucket_name"),
         ({"adapter": "gcs"}, "bucket_name"),
-        ({"adapter": "azure-blob", "account_url": "https://account.blob.core.windows.net"}, "container_name"),
+        (
+            {
+                "adapter": "azure-blob",
+                "account_url": "https://account.blob.core.windows.net",
+            },
+            "container_name",
+        ),
     ],
 )
-def test_storage_single_tenant_requires_backend_target(payload: dict[str, str], missing: str) -> None:
+def test_storage_single_tenant_requires_backend_target(
+    payload: dict[str, str], missing: str
+) -> None:
     with pytest.raises(ValidationError, match=missing):
         StorageSettings.model_validate(payload)
 
@@ -409,28 +482,34 @@ def test_storage_multitenant_allows_tenant_resolved_target(adapter: str) -> None
     assert settings.multitenant is True
 
 
-@pytest.mark.parametrize("prefix", ["../uploads", "uploads/../private", "/uploads", "uploads//drafts"])
+@pytest.mark.parametrize(
+    "prefix", ["../uploads", "uploads/../private", "/uploads", "uploads//drafts"]
+)
 def test_storage_prefix_rejects_traversal(prefix: str) -> None:
     with pytest.raises(ValidationError, match="storage key"):
-        StorageSettings.model_validate({
-            "adapter": "filesystem",
-            "root_path": "/data/files",
-            "prefix": prefix,
-        })
+        StorageSettings.model_validate(
+            {
+                "adapter": "filesystem",
+                "root_path": "/data/files",
+                "prefix": prefix,
+            }
+        )
 
 
 def test_load_config_dir_langsmith_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith"]}},
-        "adapters/outbound/langsmith.yaml": {
-            "tracing": True,
-            "project": "agent-tests",
-            "endpoint": "https://eu.api.smith.langchain.com",
-            "api_key_env": "LANGSMITH_API_KEY",
-            "studio": "langgraph",
-            "langgraph_api_min_version": "0.11.0",
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith"]}},
+            "adapters/outbound/langsmith.yaml": {
+                "tracing": True,
+                "project": "agent-tests",
+                "endpoint": "https://eu.api.smith.langchain.com",
+                "api_key_env": "LANGSMITH_API_KEY",
+                "studio": "langgraph",
+                "langgraph_api_min_version": "0.11.0",
+            },
+        }
+    )
     config = load_config_dir(path)
     assert config.adapters.observability.enabled == ["langsmith"]
     assert config.adapters.observability.is_enabled("langsmith") is True
@@ -440,38 +519,50 @@ def test_load_config_dir_langsmith_scoped():
 
 
 def test_load_config_dir_opentelemetry_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"observability": {"enabled": ["opentelemetry"]}},
-        "adapters/outbound/opentelemetry.yaml": {
-            "service_name": "demo-api",
-            "endpoint": "http://otel-collector:4318",
-            "traces_endpoint": "http://otel-collector:4318/v1/custom-traces",
-            "metrics_endpoint": "http://otel-collector:4318/v1/custom-metrics",
-            "protocol": "http/protobuf",
-            "traces": True,
-            "metrics": True,
-            "instrument_fastapi": True,
-            "metrics_export_interval_millis": 15000,
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"observability": {"enabled": ["opentelemetry"]}},
+            "adapters/outbound/opentelemetry.yaml": {
+                "service_name": "demo-api",
+                "endpoint": "http://otel-collector:4318",
+                "traces_endpoint": "http://otel-collector:4318/v1/custom-traces",
+                "metrics_endpoint": "http://otel-collector:4318/v1/custom-metrics",
+                "protocol": "http/protobuf",
+                "traces": True,
+                "metrics": True,
+                "instrument_fastapi": True,
+                "metrics_export_interval_millis": 15000,
+            },
+        }
+    )
     config = load_config_dir(path)
     assert config.adapters.observability.enabled == ["opentelemetry"]
     assert config.adapters.observability.is_enabled("opentelemetry") is True
     assert config.adapters.opentelemetry is not None
     assert config.adapters.opentelemetry.service_name == "demo-api"
     assert config.adapters.opentelemetry.endpoint == "http://otel-collector:4318"
-    assert config.adapters.opentelemetry.traces_endpoint == "http://otel-collector:4318/v1/custom-traces"
-    assert config.adapters.opentelemetry.metrics_endpoint == "http://otel-collector:4318/v1/custom-metrics"
+    assert (
+        config.adapters.opentelemetry.traces_endpoint
+        == "http://otel-collector:4318/v1/custom-traces"
+    )
+    assert (
+        config.adapters.opentelemetry.metrics_endpoint
+        == "http://otel-collector:4318/v1/custom-metrics"
+    )
     assert config.adapters.opentelemetry.metrics is True
     assert config.adapters.opentelemetry.metrics_export_interval_millis == 15000
 
 
 def test_load_config_dir_parallel_observability_scoped():
-    path = _make_config_dir({
-        "adapters/adapters.yaml": {"observability": {"enabled": ["langsmith", "opentelemetry"]}},
-        "adapters/outbound/langsmith.yaml": {"project": "agent-tests"},
-        "adapters/outbound/opentelemetry.yaml": {"instrument_fastapi": True},
-    })
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {
+                "observability": {"enabled": ["langsmith", "opentelemetry"]}
+            },
+            "adapters/outbound/langsmith.yaml": {"project": "agent-tests"},
+            "adapters/outbound/opentelemetry.yaml": {"instrument_fastapi": True},
+        }
+    )
     config = load_config_dir(path)
 
     assert config.adapters.observability.enabled == ["langsmith", "opentelemetry"]
@@ -480,32 +571,45 @@ def test_load_config_dir_parallel_observability_scoped():
 
 
 def test_load_config_dir_langgraph_scoped():
-    path = _make_config_dir({
-        "adapters/inbound/langgraph.yaml": {
-            "name": "todo_agent",
-            "graph": "todo_agent",
-            "entrypoint": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent",
-            "env": ".env",
-            "stream_mode": ["updates", "custom"],
-        },
-    })
+    path = _make_config_dir(
+        {
+            "adapters/inbound/langgraph.yaml": {
+                "name": "todo_agent",
+                "graph": "todo_agent",
+                "entrypoint": "./src/demo_service/adapters/inbound/langgraph/agent.py:agent",
+                "env": ".env",
+                "stream_mode": ["updates", "custom"],
+            },
+        }
+    )
     config = load_config_dir(path)
     assert config.langgraph is not None
     assert config.langgraph.name == "todo_agent"
     assert config.langgraph.graph == "todo_agent"
-    assert config.langgraph.entrypoint == "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+    assert (
+        config.langgraph.entrypoint
+        == "./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+    )
     assert config.langgraph.env == ".env"
     assert config.langgraph.stream_mode == ["updates", "custom"]
 
 
 def test_langsmith_observability_requires_scoped_config():
-    with pytest.raises(ValidationError, match="observability.enabled contient langsmith"):
-        AppConfig.model_validate({"adapters": {"observability": {"enabled": ["langsmith"]}}})
+    with pytest.raises(
+        ValidationError, match="observability.enabled contient langsmith"
+    ):
+        AppConfig.model_validate(
+            {"adapters": {"observability": {"enabled": ["langsmith"]}}}
+        )
 
 
 def test_opentelemetry_observability_requires_scoped_config():
-    with pytest.raises(ValidationError, match="observability.enabled contient opentelemetry"):
-        AppConfig.model_validate({"adapters": {"observability": {"enabled": ["opentelemetry"]}}})
+    with pytest.raises(
+        ValidationError, match="observability.enabled contient opentelemetry"
+    ):
+        AppConfig.model_validate(
+            {"adapters": {"observability": {"enabled": ["opentelemetry"]}}}
+        )
 
 
 def test_observability_scalar_format_is_rejected():
@@ -515,16 +619,20 @@ def test_observability_scalar_format_is_rejected():
 
 def test_observability_enabled_rejects_duplicates():
     with pytest.raises(ValidationError, match="doublons"):
-        AppConfig.model_validate({
-            "adapters": {
-                "observability": {"enabled": ["langsmith", "langsmith"]},
-                "langsmith": {"project": "agent-tests"},
+        AppConfig.model_validate(
+            {
+                "adapters": {
+                    "observability": {"enabled": ["langsmith", "langsmith"]},
+                    "langsmith": {"project": "agent-tests"},
+                }
             }
-        })
+        )
 
 
 def test_langgraph_settings_defaults():
-    settings = LangGraphSettings(entrypoint="./src/demo_service/adapters/inbound/langgraph/agent.py:agent")
+    settings = LangGraphSettings(
+        entrypoint="./src/demo_service/adapters/inbound/langgraph/agent.py:agent"
+    )
 
     assert settings.name == "agent"
     assert settings.graph == "agent"
@@ -582,10 +690,12 @@ def test_load_config_dir_soft_delete():
 
 
 def test_load_config_dir_unknown_path_ignored():
-    path = _make_config_dir({
-        "some/deep/unknown.yaml": {"foo": "bar"},
-        "app.yaml": {"name": "OK"},
-    })
+    path = _make_config_dir(
+        {
+            "some/deep/unknown.yaml": {"foo": "bar"},
+            "app.yaml": {"name": "OK"},
+        }
+    )
     config = load_config_dir(path)
     assert config.app.name == "OK"
 
@@ -597,6 +707,7 @@ def test_load_config_dir_raises_if_not_directory():
 
 
 # ── DuckDBSettings / SoftDeleteSettings ──────────────────────────────────────
+
 
 @pytest.mark.parametrize(
     "path",
@@ -618,7 +729,9 @@ def test_duckdb_settings_directory_path():
 
 
 def test_duckdb_settings_invalid_extension():
-    with pytest.raises(ValidationError, match=r"Format '\.txt' non supporté par DuckDB"):
+    with pytest.raises(
+        ValidationError, match=r"Format '\.txt' non supporté par DuckDB"
+    ):
         DuckDBSettings(path="data/file.txt")
 
 
@@ -651,7 +764,9 @@ def test_command_bus_settings_detect_enabled_adapter():
 
 
 def test_command_bus_settings_rejects_duplicate_enabled_adapter():
-    with pytest.raises(ValidationError, match="command_bus.enabled ne doit pas contenir de doublons"):
+    with pytest.raises(
+        ValidationError, match="command_bus.enabled ne doit pas contenir de doublons"
+    ):
         CommandBusSettings(enabled=["rabbitmq", "rabbitmq"])
 
 
@@ -666,23 +781,27 @@ def test_rabbitmq_command_bus_settings_rejects_empty_names():
 
 
 def test_mongodb_uri_optional_at_parse_time():
-    config = AppConfig.model_validate({
-        "adapters": {
-            "repository": "mongodb",
-            "mongodb": {"db_name": "test"},
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "mongodb",
+                "mongodb": {"db_name": "test"},
+            }
         }
-    })
+    )
     assert config.adapters.mongodb is not None
     assert config.adapters.mongodb.uri is None
 
 
 def test_mongodb_multitenant_no_uri_required():
-    config = AppConfig.model_validate({
-        "adapters": {
-            "repository": "mongodb",
-            "mongodb": {"db_name": "test", "multitenant": True},
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "mongodb",
+                "mongodb": {"db_name": "test", "multitenant": True},
+            }
         }
-    })
+    )
     assert config.adapters.multitenant is True
 
 
@@ -702,20 +821,76 @@ def test_mariadb_settings_with_url_only():
 
 
 def test_mariadb_settings_requires_url_or_database():
-    with pytest.raises(ValidationError, match="database est requis quand url n'est pas configure"):
+    with pytest.raises(
+        ValidationError, match="database est requis quand url n'est pas configure"
+    ):
         MariaDBSettings()
 
 
 def test_mariadb_multitenant_no_database_required():
-    config = AppConfig.model_validate({
-        "adapters": {
-            "repository": "mariadb",
-            "mariadb": {"multitenant": True},
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "mariadb",
+                "mariadb": {"multitenant": True},
+            }
         }
-    })
+    )
 
     assert config.adapters.mariadb is not None
     assert config.adapters.multitenant is True
+
+
+def test_postgresql_settings_with_database():
+    settings = PostgreSQLSettings(
+        database="demo", port=5433, schema="app", table_prefix="svc_"
+    )
+
+    assert settings.database == "demo"
+    assert settings.port == 5433
+    assert settings.schema_name == "app"
+    assert settings.table_prefix == "svc_"
+
+
+def test_postgresql_settings_serializes_schema_alias():
+    settings = PostgreSQLSettings(database="demo", schema="app")
+
+    assert "schema" in settings.model_dump()
+    assert "schema_name" not in settings.model_dump()
+
+
+def test_postgresql_settings_with_url_only():
+    settings = PostgreSQLSettings(url="postgresql+asyncpg://app@localhost:5432/demo")
+
+    assert settings.url == "postgresql+asyncpg://app@localhost:5432/demo"
+    assert settings.database is None
+
+
+def test_postgresql_settings_requires_url_or_database():
+    with pytest.raises(
+        ValidationError, match="database est requis quand url n'est pas configure"
+    ):
+        PostgreSQLSettings()
+
+
+def test_postgresql_multitenant_no_database_required():
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "postgresql",
+                "postgresql": {"multitenant": True},
+            }
+        }
+    )
+
+    assert config.adapters.postgresql is not None
+    assert config.adapters.multitenant is True
+
+
+@pytest.mark.parametrize("field_name", ["schema", "table_prefix"])
+def test_postgresql_settings_rejects_unsafe_identifiers(field_name: str):
+    with pytest.raises(ValidationError, match=field_name):
+        PostgreSQLSettings(database="demo", **{field_name: "unsafe-name"})
 
 
 def test_duckdb_requires_section():
@@ -724,16 +899,31 @@ def test_duckdb_requires_section():
 
 
 def test_mongodb_requires_section():
-    with pytest.raises(ValidationError, match=r"repository=mongodb mais aucune section \[adapters.mongodb\]"):
+    with pytest.raises(
+        ValidationError,
+        match=r"repository=mongodb mais aucune section \[adapters.mongodb\]",
+    ):
         AppConfig.model_validate({"adapters": {"repository": "mongodb"}})
 
 
 def test_mariadb_requires_section():
-    with pytest.raises(ValidationError, match=r"repository=mariadb mais aucune section \[adapters.mariadb\]"):
+    with pytest.raises(
+        ValidationError,
+        match=r"repository=mariadb mais aucune section \[adapters.mariadb\]",
+    ):
         AppConfig.model_validate({"adapters": {"repository": "mariadb"}})
 
 
+def test_postgresql_requires_section():
+    with pytest.raises(
+        ValidationError,
+        match=r"repository=postgresql mais aucune section \[adapters.postgresql\]",
+    ):
+        AppConfig.model_validate({"adapters": {"repository": "postgresql"}})
+
+
 # ── load_config_file ──────────────────────────────────────────────────────────
+
 
 def test_load_config_file_simple():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -766,22 +956,27 @@ def test_load_config_file_raises_if_not_file():
 
 # ── export_config_yaml ────────────────────────────────────────────────────────
 
+
 def test_export_config_yaml_creates_file():
-    config_dir = _make_config_dir({
-        "app.yaml": {"name": "ExportTest"},
-        "adapters/adapters.yaml": {"repository": "memory"},
-    })
+    config_dir = _make_config_dir(
+        {
+            "app.yaml": {"name": "ExportTest"},
+            "adapters/adapters.yaml": {"repository": "memory"},
+        }
+    )
     out = config_dir / "config.yaml"
     export_config_yaml(config_dir, out)
     assert out.exists()
 
 
 def test_export_config_yaml_content_is_valid_yaml():
-    config_dir = _make_config_dir({
-        "app.yaml": {"name": "RoundTrip"},
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/inbound/fastapi.yaml": {"port": 7777},
-    })
+    config_dir = _make_config_dir(
+        {
+            "app.yaml": {"name": "RoundTrip"},
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/inbound/fastapi.yaml": {"port": 7777},
+        }
+    )
     out = config_dir / "config.yaml"
     export_config_yaml(config_dir, out)
     with open(out) as f:
@@ -792,19 +987,21 @@ def test_export_config_yaml_content_is_valid_yaml():
 
 def test_export_config_yaml_round_trip():
     """load_config_dir and load_config_file must produce identical AppConfig."""
-    config_dir = _make_config_dir({
-        "app.yaml": {"name": "RoundTrip", "version": "1.0.0"},
-        "soft_delete.yaml": {"retention_days": 14},
-        "adapters/adapters.yaml": {"repository": "duckdb"},
-        "adapters/outbound/duckdb.yaml": {"path": "data/"},
-        "adapters/outbound/storage.yaml": {
-            "adapter": "filesystem",
-            "root_path": "/data/files",
-            "prefix": "uploads",
-            "create_root": True,
-        },
-        "adapters/inbound/fastapi.yaml": {"port": 8765},
-    })
+    config_dir = _make_config_dir(
+        {
+            "app.yaml": {"name": "RoundTrip", "version": "1.0.0"},
+            "soft_delete.yaml": {"retention_days": 14},
+            "adapters/adapters.yaml": {"repository": "duckdb"},
+            "adapters/outbound/duckdb.yaml": {"path": "data/"},
+            "adapters/outbound/storage.yaml": {
+                "adapter": "filesystem",
+                "root_path": "/data/files",
+                "prefix": "uploads",
+                "create_root": True,
+            },
+            "adapters/inbound/fastapi.yaml": {"port": 8765},
+        }
+    )
     out = config_dir / "config.yaml"
     export_config_yaml(config_dir, out)
 
@@ -835,20 +1032,23 @@ def test_export_config_yaml_has_generated_header():
 
 # ── LMSettings ────────────────────────────────────────────────────────────────
 
+
 def test_adapters_lm_defaults_to_none():
     assert AppConfig().adapters.lm is None
 
 
 def test_adapters_lm_parsed_from_yaml():
-    config = AppConfig.model_validate({
-        "adapters": {
-            "lm": {
-                "provider": "anthropic",
-                "model_name": "claude-opus-4-5",
-                "api_key": "sk-ant-test",
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "lm": {
+                    "provider": "anthropic",
+                    "model_name": "claude-opus-4-5",
+                    "api_key": "sk-ant-test",
+                }
             }
         }
-    })
+    )
     assert config.adapters.lm is not None
     assert config.adapters.lm.provider == "anthropic"
     assert config.adapters.lm.model_name == "claude-opus-4-5"
@@ -857,26 +1057,34 @@ def test_adapters_lm_parsed_from_yaml():
 
 
 def test_adapters_lm_openai_with_base_url():
-    config = AppConfig.model_validate({
-        "adapters": {
-            "lm": {
-                "provider": "openai",
-                "model_name": "llama3",
-                "api_key": "ollama",
-                "base_url": "http://localhost:11434/v1",
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "lm": {
+                    "provider": "openai",
+                    "model_name": "llama3",
+                    "api_key": "ollama",
+                    "base_url": "http://localhost:11434/v1",
+                }
             }
         }
-    })
+    )
     assert config.adapters.lm is not None
     assert config.adapters.lm.provider == "openai"
     assert config.adapters.lm.base_url == "http://localhost:11434/v1"
 
 
 def test_adapters_lm_loaded_from_config_dir():
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/outbound/lm.yaml": {"provider": "anthropic", "model_name": "claude-sonnet-4-5", "api_key": ""},
-    })
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/outbound/lm.yaml": {
+                "provider": "anthropic",
+                "model_name": "claude-sonnet-4-5",
+                "api_key": "",
+            },
+        }
+    )
     config = load_config_dir(config_dir)
     assert config.adapters.lm is not None
     assert config.adapters.lm.provider == "anthropic"
@@ -884,21 +1092,23 @@ def test_adapters_lm_loaded_from_config_dir():
 
 def test_adapters_lm_api_key_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/outbound/lm.yaml": {
-            "provider": "openai",
-            "model_name": "gpt-4o-mini",
-            "api_key": "",
-            "base_url": "https://api.openai.com/v1",
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.lm.api_key": "OPENAI_API_KEY",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/outbound/lm.yaml": {
+                "provider": "openai",
+                "model_name": "gpt-4o-mini",
+                "api_key": "",
+                "base_url": "https://api.openai.com/v1",
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.lm.api_key": "OPENAI_API_KEY",
+                },
+            },
+        }
+    )
 
     config = load_config_dir(config_dir)
 
@@ -910,21 +1120,23 @@ def test_adapters_lm_missing_env_secret_raises_actionable_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/outbound/lm.yaml": {
-            "provider": "openai",
-            "model_name": "gpt-4o-mini",
-            "api_key": "",
-            "base_url": "https://api.openai.com/v1",
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.lm.api_key": "OPENAI_API_KEY",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/outbound/lm.yaml": {
+                "provider": "openai",
+                "model_name": "gpt-4o-mini",
+                "api_key": "",
+                "base_url": "https://api.openai.com/v1",
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.lm.api_key": "OPENAI_API_KEY",
+                },
+            },
+        }
+    )
 
     with pytest.raises(RuntimeError, match="Secrets non résolus.*adapters.lm.api_key"):
         load_config_dir(config_dir)
@@ -934,20 +1146,22 @@ def test_adapters_lm_anthropic_api_key_loaded_from_env_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/outbound/lm.yaml": {
-            "provider": "anthropic",
-            "model_name": "claude-dev-model",
-            "api_key": "",
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/outbound/lm.yaml": {
+                "provider": "anthropic",
+                "model_name": "claude-dev-model",
+                "api_key": "",
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+                },
+            },
+        }
+    )
 
     config = load_config_dir(config_dir)
 
@@ -961,20 +1175,22 @@ def test_adapters_lm_missing_anthropic_env_secret_raises_actionable_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "memory"},
-        "adapters/outbound/lm.yaml": {
-            "provider": "anthropic",
-            "model_name": "claude-dev-model",
-            "api_key": "",
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "memory"},
+            "adapters/outbound/lm.yaml": {
+                "provider": "anthropic",
+                "model_name": "claude-dev-model",
+                "api_key": "",
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.lm.api_key": "ANTHROPIC_API_KEY",
+                },
+            },
+        }
+    )
 
     with pytest.raises(RuntimeError, match="Secrets non résolus.*adapters.lm.api_key"):
         load_config_dir(config_dir)
@@ -982,21 +1198,23 @@ def test_adapters_lm_missing_anthropic_env_secret_raises_actionable_error(
 
 def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MONGODB_URI", "mongodb://env-mongo:27017")
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "mongodb"},
-        "adapters/outbound/mongodb.yaml": {
-            "uri": None,
-            "db_name": "demo_shared",
-            "collection_name": None,
-            "multitenant": False,
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.mongodb.uri": "MONGODB_URI",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "mongodb"},
+            "adapters/outbound/mongodb.yaml": {
+                "uri": None,
+                "db_name": "demo_shared",
+                "collection_name": None,
+                "multitenant": False,
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.mongodb.uri": "MONGODB_URI",
+                },
+            },
+        }
+    )
 
     config = load_config_dir(config_dir)
 
@@ -1005,30 +1223,34 @@ def test_adapters_mongodb_uri_loaded_from_env_mapping(monkeypatch: pytest.Monkey
     assert config.adapters.mongodb.db_name == "demo_shared"
 
 
-def test_adapters_mariadb_url_and_password_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
+def test_adapters_mariadb_url_and_password_loaded_from_env_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.setenv("MARIADB_URL", "mysql+asyncmy://env-app@db:3306/env_demo")
     monkeypatch.setenv("MARIADB_PASSWORD", "env-password")
-    config_dir = _make_config_dir({
-        "adapters/adapters.yaml": {"repository": "mariadb"},
-        "adapters/outbound/mariadb.yaml": {
-            "url": None,
-            "host": "127.0.0.1",
-            "port": 3306,
-            "database": "demo_shared",
-            "user": "app",
-            "password": None,
-            "driver": "asyncmy",
-            "table_prefix": "",
-            "multitenant": False,
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "adapters.mariadb.url": "MARIADB_URL",
-                "adapters.mariadb.password": "MARIADB_PASSWORD",
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "mariadb"},
+            "adapters/outbound/mariadb.yaml": {
+                "url": None,
+                "host": "127.0.0.1",
+                "port": 3306,
+                "database": "demo_shared",
+                "user": "app",
+                "password": None,
+                "driver": "asyncmy",
+                "table_prefix": "",
+                "multitenant": False,
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.mariadb.url": "MARIADB_URL",
+                    "adapters.mariadb.password": "MARIADB_PASSWORD",
+                },
+            },
+        }
+    )
 
     config = load_config_dir(config_dir)
 
@@ -1037,22 +1259,66 @@ def test_adapters_mariadb_url_and_password_loaded_from_env_mapping(monkeypatch: 
     assert config.adapters.mariadb.password == "env-password"
 
 
+def test_adapters_postgresql_url_and_password_loaded_from_env_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(
+        "POSTGRESQL_URL", "postgresql+asyncpg://env-app@db:5432/env_demo"
+    )
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "env-password")
+    config_dir = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {"repository": "postgresql"},
+            "adapters/outbound/postgresql.yaml": {
+                "url": None,
+                "host": "127.0.0.1",
+                "port": 5432,
+                "database": "demo_shared",
+                "user": "app",
+                "password": None,
+                "schema": "public",
+                "driver": "asyncpg",
+                "table_prefix": "",
+                "multitenant": False,
+            },
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "adapters.postgresql.url": "POSTGRESQL_URL",
+                    "adapters.postgresql.password": "POSTGRESQL_PASSWORD",
+                },
+            },
+        }
+    )
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.postgresql is not None
+    assert (
+        config.adapters.postgresql.url
+        == "postgresql+asyncpg://env-app@db:5432/env_demo"
+    )
+    assert config.adapters.postgresql.password == "env-password"
+
+
 def test_cache_redis_url_loaded_from_env_mapping(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("REDIS_URL", "redis://cache:6379/0")
-    config_dir = _make_config_dir({
-        "adapters/inbound/cache.yaml": {
-            "backend": "redis",
-            "redis_url": "",
-            "jwks_ttl": 900,
-            "tenant_uri_ttl": 120,
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "cache.redis_url": "REDIS_URL",
+    config_dir = _make_config_dir(
+        {
+            "adapters/inbound/cache.yaml": {
+                "backend": "redis",
+                "redis_url": "",
+                "jwks_ttl": 900,
+                "tenant_uri_ttl": 120,
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "cache.redis_url": "REDIS_URL",
+                },
+            },
+        }
+    )
 
     config = load_config_dir(config_dir)
 
@@ -1064,18 +1330,20 @@ def test_cache_missing_redis_env_secret_raises_actionable_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("REDIS_URL", raising=False)
-    config_dir = _make_config_dir({
-        "adapters/inbound/cache.yaml": {
-            "backend": "redis",
-            "redis_url": "",
-        },
-        "secrets.yaml": {
-            "resolver": "env",
-            "mappings": {
-                "cache.redis_url": "REDIS_URL",
+    config_dir = _make_config_dir(
+        {
+            "adapters/inbound/cache.yaml": {
+                "backend": "redis",
+                "redis_url": "",
             },
-        },
-    })
+            "secrets.yaml": {
+                "resolver": "env",
+                "mappings": {
+                    "cache.redis_url": "REDIS_URL",
+                },
+            },
+        }
+    )
 
     with pytest.raises(RuntimeError, match="Secrets non résolus.*cache.redis_url"):
         load_config_dir(config_dir)

--- a/tests/units/infrastructure/test_repository_factory.py
+++ b/tests/units/infrastructure/test_repository_factory.py
@@ -6,8 +6,18 @@ import pytest
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.repository import Repository
-from arclith.infrastructure.config import AppConfig, AdaptersSettings, DuckDBSettings, MariaDBSettings, MongoDBSettings
-from arclith.infrastructure.repository_factory import RepositoryRegistry, build_repository
+from arclith.infrastructure.config import (
+    AppConfig,
+    AdaptersSettings,
+    DuckDBSettings,
+    MariaDBSettings,
+    MongoDBSettings,
+    PostgreSQLSettings,
+)
+from arclith.infrastructure.repository_factory import (
+    RepositoryRegistry,
+    build_repository,
+)
 
 
 class Item(Entity):
@@ -15,7 +25,7 @@ class Item(Entity):
 
 
 def test_memory_returns_in_memory_repository(logger):
-    config = AppConfig(adapters = AdaptersSettings(repository = "memory"))
+    config = AppConfig(adapters=AdaptersSettings(repository="memory"))
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, InMemoryRepository)
 
@@ -43,10 +53,13 @@ def test_custom_repository_registry_builds_unknown_adapter(logger):
 def test_mongodb_returns_mongodb_repository(logger):
     pytest.importorskip("motor")
     from arclith.adapters.outbound.mongodb.repository import MongoDBRepository
-    config = AppConfig(adapters = AdaptersSettings(
-        repository = "mongodb",
-        mongodb = MongoDBSettings(db_name = "test", collection_name = "items"),
-    ))
+
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="mongodb",
+            mongodb=MongoDBSettings(db_name="test", collection_name="items"),
+        )
+    )
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, MongoDBRepository)
     assert repo._config.uri is None
@@ -56,10 +69,13 @@ def test_mongodb_returns_mongodb_repository(logger):
 def test_duckdb_returns_duckdb_repository(logger, tmp_path):
     pytest.importorskip("duckdb")
     from arclith.adapters.outbound.duckdb.repository import DuckDBRepository
-    config = AppConfig(adapters = AdaptersSettings(
-        repository = "duckdb",
-        duckdb = DuckDBSettings(path = str(tmp_path) + "/"),
-    ))
+
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="duckdb",
+            duckdb=DuckDBSettings(path=str(tmp_path) + "/"),
+        )
+    )
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, DuckDBRepository)
 
@@ -69,30 +85,49 @@ def test_mariadb_returns_mariadb_repository(logger):
     pytest.importorskip("asyncmy")
     from arclith.adapters.outbound.mariadb.repository import MariaDBRepository
 
-    config = AppConfig(adapters=AdaptersSettings(
-        repository="mariadb",
-        mariadb=MariaDBSettings(database="test"),
-    ))
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="mariadb",
+            mariadb=MariaDBSettings(database="test"),
+        )
+    )
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, MariaDBRepository)
 
 
-def test_import_arclith_does_not_require_mariadb_extra():
+def test_postgresql_returns_postgresql_repository(logger):
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("asyncpg")
+    from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="postgresql",
+            postgresql=PostgreSQLSettings(database="test"),
+        )
+    )
+    repo = build_repository(config, Item, logger)
+    assert isinstance(repo, PostgreSQLRepository)
+
+
+def test_import_arclith_does_not_require_sql_repository_extras():
     script = """
 import importlib.abc
 import sys
 
 
-class BlockMariaDBExtras(importlib.abc.MetaPathFinder):
+class BlockSQLRepositoryExtras(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path, target=None):
         if fullname == "sqlalchemy" or fullname.startswith("sqlalchemy."):
             raise ModuleNotFoundError(fullname)
         if fullname == "asyncmy" or fullname.startswith("asyncmy."):
             raise ModuleNotFoundError(fullname)
+        if fullname == "asyncpg" or fullname.startswith("asyncpg."):
+            raise ModuleNotFoundError(fullname)
         return None
 
 
-sys.meta_path.insert(0, BlockMariaDBExtras())
+sys.meta_path.insert(0, BlockSQLRepositoryExtras())
 
 import arclith
 from arclith.domain.models.entity import Entity

--- a/uv.lock
+++ b/uv.lock
@@ -110,6 +110,7 @@ dependencies = [
 all = [
     { name = "aio-pika" },
     { name = "asyncmy" },
+    { name = "asyncpg" },
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
@@ -182,6 +183,10 @@ opentelemetry = [
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
 ]
+postgresql = [
+    { name = "asyncpg" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
 rabbitmq = [
     { name = "aio-pika" },
 ]
@@ -216,6 +221,8 @@ requires-dist = [
     { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=10.0.1,<11.0.0" },
     { name = "asyncmy", marker = "extra == 'all'", specifier = ">=0.2.10" },
     { name = "asyncmy", marker = "extra == 'mariadb'", specifier = ">=0.2.10" },
+    { name = "asyncpg", marker = "extra == 'all'", specifier = ">=0.30.0" },
+    { name = "asyncpg", marker = "extra == 'postgresql'", specifier = ">=0.30.0" },
     { name = "azure-identity", marker = "extra == 'all'", specifier = ">=1.25.1,<2.0.0" },
     { name = "azure-identity", marker = "extra == 'azure-blob'", specifier = ">=1.25.1,<2.0.0" },
     { name = "azure-storage-blob", marker = "extra == 'all'", specifier = ">=12.27.1,<13.0.0" },
@@ -269,11 +276,12 @@ requires-dist = [
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'all'", specifier = ">=2.0.36" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'mariadb'", specifier = ">=2.0.36" },
+    { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'postgresql'", specifier = ">=2.0.36" },
     { name = "uuid6", specifier = "==2025.0.1" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -316,6 +324,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/65/68e576aecd2a43d383123e3a66339e6a3535495b0e81443e374a3d3c356d/asyncmy-0.2.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:577272e238aff9b985eb880b49b1ba009e1fd1133b754fc71c833ab5bd9561ee", size = 5143375, upload-time = "2026-01-15T11:32:15.38Z" },
     { url = "https://files.pythonhosted.org/packages/4e/e4/cd30ea75ab96e5c6fe0daf6bd1871753fe5a1677515530fa0bc1a807dd6c/asyncmy-0.2.11-cp313-cp313-win32.whl", hash = "sha256:29536a08bf8c96437188ae4080fdd09c5a82cbe93794d0996cd0dd238f632664", size = 1559106, upload-time = "2026-01-15T11:32:16.895Z" },
     { url = "https://files.pythonhosted.org/packages/0c/3e/497e3ac839d7d18e79770b977f90e6f17a87181f95b8aed59359ff4aba0c/asyncmy-0.2.11-cp313-cp313-win_amd64.whl", hash = "sha256:f095af7b980505158609ca0bcdd0d14d1e48893e43fc1856c7cecfd9439f498c", size = 1635619, upload-time = "2026-01-15T11:32:18.241Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add the optional `repository/postgresql` adapter behind the existing `Repository[T]` port, storing each entity payload in PostgreSQL `JSONB`.
- Wire runtime config, repository factory, CLI capability/catalog templates, package extras, and docs.
- Add targeted tests for config validation, lazy optional imports, factory routing, CLI generation, schema locking, and Pydantic JSON round-trips.

## Architecture Notes

- Uses `String(36)` for `uuid`, matching the MariaDB generic SQL repository and avoiding divergent UUID conversions in this first iteration.
- Keeps PostgreSQL behind `Repository[T]`; no SQL-specific port, ORM entity, Alembic, query DSL, or relational field mapping is introduced.
- YAML config keeps the `schema` key. Internally `PostgreSQLSettings` uses `schema_name` with alias `schema` to avoid shadowing Pydantic `BaseModel.schema()`.
- Real PostgreSQL integration tests remain out of scope; the unit tests avoid requiring a live PostgreSQL server.

Closes #176

## Validation

- `git diff --check`
- `uv run --frozen --extra all python -m pytest tests/units/infrastructure/test_repository_factory.py tests/units/adapters/outbound/test_postgresql_repository.py -v` -> 12 passed
- `uv run --frozen python -m pytest tests/units/infrastructure/test_config.py -v` -> 117 passed
- `uv run --frozen python -m pytest tests/test_capabilities.py tests/test_add_adapter.py -v` from `cli/` -> 85 passed, 1 skipped
- `uv run --frozen python -m ruff check arclith_cli tests` from `cli/` -> passed
- `uv run --frozen python -m ruff format --check arclith_cli/capabilities.py arclith_cli/adapter_templates.py tests/test_capabilities.py tests/test_add_adapter.py` from `cli/` -> passed
- `make quality` -> ruff, bandit, mypy, pytest coverage passed; 549 passed, 1 skipped, coverage 91.73%
- `make docs` -> passed; MkDocs Material emitted its upstream MkDocs 2.0 warning
