### PR TITLE
feat(agent): add optional LangGraph persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Persistance agent LangGraph** — capability optionnelle `agent-persistence`, configuration
+  checkpointer/store, registry custom, wiring embedded/Agent Server et extras SQLite, PostgreSQL,
+  MongoDB et Redis granulaires.
+
 ---
 
 ## [0.18.0] — 2026-08-25

--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -1,8 +1,14 @@
 from typing import TYPE_CHECKING
 
 from arclith.adapters.inbound.schemas.base_schema import BaseSchema
-from arclith.adapters.outbound.azure_blob import AzureBlobFileStorage, AzureBlobStorageConfig
-from arclith.adapters.outbound.filesystem import FilesystemFileStorage, FilesystemStorageConfig
+from arclith.adapters.outbound.azure_blob import (
+    AzureBlobFileStorage,
+    AzureBlobStorageConfig,
+)
+from arclith.adapters.outbound.filesystem import (
+    FilesystemFileStorage,
+    FilesystemStorageConfig,
+)
 from arclith.adapters.outbound.gcs import GCSFileStorage, GCSStorageConfig
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
@@ -29,14 +35,35 @@ from arclith.domain.ports.outbound.file_storage import (
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.adapter_registry import AdapterRegistry
-from arclith.infrastructure.config import AppConfig, LMSettings, export_config_yaml, load_config_dir, load_config_file
+from arclith.infrastructure.config import (
+    AppConfig,
+    LangGraphPersistenceSettings,
+    LMSettings,
+    export_config_yaml,
+    load_config_dir,
+    load_config_file,
+)
 from arclith.infrastructure.file_storage_factory import (
     FileStorageRegistry,
     build_file_storage,
     default_file_storage_registry,
 )
-from arclith.infrastructure.project_layout import ProjectLayout, ProjectLayoutKind, canonical_project_layout
-from arclith.infrastructure.repository_factory import RepositoryRegistry, build_repository, default_repository_registry
+from arclith.infrastructure.langgraph_persistence_factory import (
+    LangGraphPersistenceRegistry,
+    build_langgraph_persistence,
+    default_langgraph_persistence_registry,
+    render_langgraph_namespace,
+)
+from arclith.infrastructure.project_layout import (
+    ProjectLayout,
+    ProjectLayoutKind,
+    canonical_project_layout,
+)
+from arclith.infrastructure.repository_factory import (
+    RepositoryRegistry,
+    build_repository,
+    default_repository_registry,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
     from arclith.adapters.outbound.console.logger import ConsoleLogger as _ConsoleLogger, ConsoleLogger  # noqa: F401
@@ -76,6 +103,7 @@ __all__ = [
     "MongoDBConfig",
     "AppConfig",
     "LMSettings",
+    "LangGraphPersistenceSettings",
     "load_config_dir",
     "load_config_file",
     "export_config_yaml",
@@ -86,12 +114,17 @@ __all__ = [
     "FileStorageRegistry",
     "build_file_storage",
     "default_file_storage_registry",
+    "LangGraphPersistenceRegistry",
+    "build_langgraph_persistence",
+    "default_langgraph_persistence_registry",
+    "render_langgraph_namespace",
     "ProjectLayout",
     "ProjectLayoutKind",
     "canonical_project_layout",
     "Arclith",
     "build_pydantic_ai_model",
 ]
+
 
 def __getattr__(name):
     """
@@ -101,12 +134,16 @@ def __getattr__(name):
     configuration) from being imported merely by doing ``import arclith``.
     """
     if name == "ConsoleLogger":
-        from arclith.adapters.outbound.console.logger import ConsoleLogger as _ConsoleLoggerRuntime
+        from arclith.adapters.outbound.console.logger import (
+            ConsoleLogger as _ConsoleLoggerRuntime,
+        )
 
         globals()["ConsoleLogger"] = _ConsoleLoggerRuntime
         return _ConsoleLoggerRuntime
     if name == "build_pydantic_ai_model":
-        from arclith.infrastructure.lm import build_pydantic_ai_model as _build_pydantic_ai_model
+        from arclith.infrastructure.lm import (
+            build_pydantic_ai_model as _build_pydantic_ai_model,
+        )
 
         globals()["build_pydantic_ai_model"] = _build_pydantic_ai_model
         return _build_pydantic_ai_model

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -10,12 +10,20 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, TypeVar, overload
 
-from arclith.adapters.outbound.opentelemetry.correlation import log_record_trace_metadata
+from arclith.adapters.outbound.opentelemetry.correlation import (
+    log_record_trace_metadata,
+)
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.repository import Repository
-from arclith.infrastructure.config import AppConfig, LangGraphStreamMode, load_config_dir, load_config_file
+from arclith.infrastructure.config import (
+    AppConfig,
+    LangGraphPersistenceSettings,
+    LangGraphStreamMode,
+    load_config_dir,
+    load_config_file,
+)
 from arclith.infrastructure.file_storage_factory import FileStorageRegistry
 from arclith.infrastructure.repository_factory import RepositoryRegistry
 
@@ -24,9 +32,14 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
     from arclith.adapters.bidirectional.rabbitmq import RabbitMQCommandBus
     from arclith.application.command_bus import CommandDispatcher
+    from arclith.infrastructure.langgraph_persistence_factory import (
+        LangGraphPersistenceComponents,
+        LangGraphPersistenceRegistry,
+    )
 
 T = TypeVar("T", bound=Entity)
 R = TypeVar("R", bound=Repository[Any])
+_LANGGRAPH_UNSET = object()
 _UVICORN_LOG_CONFIG: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -54,6 +67,41 @@ def _normalize_langgraph_stream_mode(
     return list(stream_mode)
 
 
+def _langgraph_persistence_settings(
+    config: AppConfig,
+) -> LangGraphPersistenceSettings | None:
+    if config.langgraph is None:
+        return None
+    return config.langgraph.persistence
+
+
+def _langgraph_persistence_requested(
+    settings: LangGraphPersistenceSettings | None,
+    override: bool | None,
+) -> bool:
+    if override is not None:
+        return override
+    return settings is not None and settings.enabled
+
+
+def _require_langgraph_persistence(
+    settings: LangGraphPersistenceSettings | None,
+) -> LangGraphPersistenceSettings:
+    if settings is None or not settings.enabled:
+        raise RuntimeError(
+            "persistence=True requiert langgraph.persistence.enabled=true dans la configuration Arclith"
+        )
+    return settings
+
+
+def _langgraph_compile_value(value: Any) -> Any:
+    return None if value is _LANGGRAPH_UNSET else value
+
+
+def _langgraph_configured_value(explicit: Any, configured: object | None) -> Any:
+    return configured if explicit is _LANGGRAPH_UNSET else explicit
+
+
 class _UvicornLogInterceptHandler(logging.Handler):
     def __init__(self, logger: Logger) -> None:
         super().__init__()
@@ -70,6 +118,8 @@ class _UvicornLogInterceptHandler(logging.Handler):
             message,
             **log_record_trace_metadata(record),
         )
+
+
 class Arclith:
     def __init__(self, config_path: str | Path) -> None:
         p = Path(config_path)
@@ -91,6 +141,7 @@ class Arclith:
             f"logger={self.config.adapters.logger} non supporte. "
             "Adapters logger supportes: console"
         )
+
     @overload
     def repository(
         self,
@@ -117,7 +168,9 @@ class Arclith:
     ) -> Repository[T] | R:
         from arclith.infrastructure.repository_factory import build_repository
 
-        return build_repository(self.config, entity_class, self.logger, registry=registry)
+        return build_repository(
+            self.config, entity_class, self.logger, registry=registry
+        )
 
     def file_storage(
         self,
@@ -201,6 +254,7 @@ class Arclith:
     def _add_fastapi_observability(self, app: "FastAPI") -> None:
         if self.config.probe.enabled:
             from arclith.adapters.inbound.probes.metrics import ApiMetricsCollector
+
             app.add_middleware(ApiMetricsCollector, registry=self._metrics_registry)
             self._probe_server.add_collector(
                 ApiMetricsCollector(app=None, registry=self._metrics_registry)  # type: ignore[arg-type]
@@ -211,7 +265,9 @@ class Arclith:
         if settings is None:
             return
 
-        from arclith.adapters.outbound.opentelemetry.fastapi import instrument_fastapi_app
+        from arclith.adapters.outbound.opentelemetry.fastapi import (
+            instrument_fastapi_app,
+        )
 
         instrument_fastapi_app(
             app,
@@ -223,28 +279,34 @@ class Arclith:
     def _add_fastapi_http_middlewares(self, app: "FastAPI") -> None:
         # Order matters: Starlette applies the last registered middleware first.
         from arclith.adapters.inbound.fastapi.timing import TimingMiddleware
+
         app.add_middleware(TimingMiddleware, logger=self.logger)
 
-        from arclith.adapters.inbound.fastapi.cache_control import CacheControlMiddleware
+        from arclith.adapters.inbound.fastapi.cache_control import (
+            CacheControlMiddleware,
+        )
+
         app.add_middleware(
             CacheControlMiddleware,
-            logger = self.logger,
-            get_single_max_age = self.config.http.cache_control.get_single_max_age,
-            get_list_max_age = self.config.http.cache_control.get_list_max_age,
+            logger=self.logger,
+            get_single_max_age=self.config.http.cache_control.get_single_max_age,
+            get_list_max_age=self.config.http.cache_control.get_list_max_age,
         )
 
         from arclith.adapters.inbound.fastapi.etag import ETaggerMiddleware
+
         if self.config.http.etag.enabled:
-            app.add_middleware(ETaggerMiddleware, logger = self.logger)
+            app.add_middleware(ETaggerMiddleware, logger=self.logger)
 
         from arclith.adapters.inbound.fastapi.idempotency import IdempotencyMiddleware
+
         if self.config.http.idempotency.enabled:
             app.add_middleware(
                 IdempotencyMiddleware,
-                cache = self._cache,
-                logger = self.logger,
-                ttl = self.config.http.idempotency.ttl_seconds,
-                required = self.config.http.idempotency.required,
+                cache=self._cache,
+                logger=self.logger,
+                ttl=self.config.http.idempotency.ttl_seconds,
+                required=self.config.http.idempotency.required,
             )
 
     def _patch_openapi_keycloak(self, app: "FastAPI") -> None:
@@ -266,7 +328,9 @@ class Arclith:
             if app.openapi_schema:
                 return app.openapi_schema
             schema: dict = _original()
-            schemes = schema.setdefault("components", {}).setdefault("securitySchemes", {})
+            schemes = schema.setdefault("components", {}).setdefault(
+                "securitySchemes", {}
+            )
             schemes["keycloak"] = {
                 "type": "oauth2",
                 "flows": {
@@ -346,15 +410,23 @@ class Arclith:
             ttl_s=self.config.cache.jwks_ttl,
         )
         license_validator = (
-            RoleLicenseValidator(self.config.license.role) if self.config.license else None
+            RoleLicenseValidator(self.config.license.role)
+            if self.config.license
+            else None
         )
 
         if transport == "mcp":
             from arclith.adapters.inbound.fastmcp.auth import make_require_auth_tool
-            return make_require_auth_tool(jwt_decoder=decoder, license_validator=license_validator)
+
+            return make_require_auth_tool(
+                jwt_decoder=decoder, license_validator=license_validator
+            )
 
         from arclith.adapters.inbound.fastapi.auth import make_require_auth
-        return make_require_auth(jwt_decoder=decoder, license_validator=license_validator)
+
+        return make_require_auth(
+            jwt_decoder=decoder, license_validator=license_validator
+        )
 
     # ── probe helpers ─────────────────────────────────────────────────────────
 
@@ -377,7 +449,9 @@ class Arclith:
             # fastmcp 3.x: tools live in _local_provider._components as FunctionTool objects
             components: dict[str, Any] = mcp._local_provider._components  # type: ignore[attr-defined]
         except AttributeError:
-            self.logger.warning("⚠️ instrument_mcp: cannot access FastMCP components (API changed?)")
+            self.logger.warning(
+                "⚠️ instrument_mcp: cannot access FastMCP components (API changed?)"
+            )
             return
         count = 0
         for component in components.values():
@@ -426,6 +500,7 @@ class Arclith:
 
     def fastmcp(self, name: str, **kwargs: Any) -> "_fastmcp.FastMCP":
         import fastmcp
+
         return fastmcp.FastMCP(name, **kwargs)
 
     def langgraph(
@@ -437,14 +512,16 @@ class Arclith:
         input_schema: type[Any] | None = None,
         output_schema: type[Any] | None = None,
         name: str = "agent",
-        checkpointer: Any = None,
+        checkpointer: Any = _LANGGRAPH_UNSET,
         cache: Any = None,
-        store: Any = None,
+        store: Any = _LANGGRAPH_UNSET,
         interrupt_before: Any = None,
         interrupt_after: Any = None,
         debug: bool = False,
         stream_mode: LangGraphStreamMode | Sequence[LangGraphStreamMode] | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        persistence: bool | None = None,
+        persistence_registry: "LangGraphPersistenceRegistry | None" = None,
     ) -> Any:
         from langgraph.graph import StateGraph
 
@@ -455,41 +532,132 @@ class Arclith:
             output_schema=output_schema,
         )
         register_graph(builder, self)
-        compiled = builder.compile(
+        (
+            resolved_checkpointer,
+            resolved_store,
+            persistence_components,
+        ) = self._resolve_langgraph_persistence(
             checkpointer=checkpointer,
-            cache=cache,
             store=store,
-            interrupt_before=interrupt_before,
-            interrupt_after=interrupt_after,
-            debug=debug,
-            name=name,
-            transformers=transformers,
+            persistence=persistence,
+            registry=persistence_registry,
         )
+        try:
+            compiled = builder.compile(
+                checkpointer=resolved_checkpointer,
+                cache=cache,
+                store=resolved_store,
+                interrupt_before=interrupt_before,
+                interrupt_after=interrupt_after,
+                debug=debug,
+                name=name,
+                transformers=transformers,
+            )
+        except BaseException:
+            if persistence_components is not None:
+                persistence_components.close()
+            raise
+        if persistence_components is not None:
+            self._remember_langgraph_persistence(persistence_components)
+            setattr(compiled, "_arclith_persistence", persistence_components)
         resolved_stream_mode = stream_mode
         if resolved_stream_mode is None and self.config.langgraph is not None:
             resolved_stream_mode = self.config.langgraph.stream_mode
         if resolved_stream_mode is not None:
-            setattr(compiled, "stream_mode", _normalize_langgraph_stream_mode(resolved_stream_mode))
+            setattr(
+                compiled,
+                "stream_mode",
+                _normalize_langgraph_stream_mode(resolved_stream_mode),
+            )
         return compiled
+
+    def _resolve_langgraph_persistence(
+        self,
+        *,
+        checkpointer: Any,
+        store: Any,
+        persistence: bool | None,
+        registry: "LangGraphPersistenceRegistry | None",
+    ) -> tuple[Any, Any, "LangGraphPersistenceComponents | None"]:
+        checkpointer_is_explicit = checkpointer is not _LANGGRAPH_UNSET
+        store_is_explicit = store is not _LANGGRAPH_UNSET
+        persistence_settings = _langgraph_persistence_settings(self.config)
+        if not _langgraph_persistence_requested(persistence_settings, persistence):
+            return _langgraph_compile_value(checkpointer), _langgraph_compile_value(store), None
+        if checkpointer_is_explicit and store_is_explicit:
+            return checkpointer, store, None
+
+        persistence_settings = _require_langgraph_persistence(persistence_settings)
+        from arclith.infrastructure.langgraph_persistence_factory import (
+            build_langgraph_persistence,
+        )
+
+        components = build_langgraph_persistence(
+            persistence_settings,
+            registry=registry,
+            include_checkpointer=not checkpointer_is_explicit,
+            include_store=not store_is_explicit,
+        )
+        resolved_checkpointer = _langgraph_configured_value(
+            checkpointer, components.checkpointer
+        )
+        resolved_store = _langgraph_configured_value(store, components.store)
+        if components.mode == "agent_server":
+            components.close()
+            return resolved_checkpointer, resolved_store, None
+        return resolved_checkpointer, resolved_store, components
+
+    def langgraph_memory_namespace(self, **values: object) -> tuple[str, ...]:
+        settings = (
+            self.config.langgraph.persistence
+            if self.config.langgraph is not None
+            else None
+        )
+        if settings is None:
+            raise RuntimeError("langgraph.persistence n'est pas configure")
+        from arclith.infrastructure.langgraph_persistence_factory import (
+            render_langgraph_namespace,
+        )
+
+        return render_langgraph_namespace(settings.store.namespace_template, values)
+
+    def close_langgraph_persistence(self) -> None:
+        resources: list[LangGraphPersistenceComponents] = self.__dict__.pop(
+            "_langgraph_persistence_resources", []
+        )
+        for resource in reversed(resources):
+            resource.close()
+
+    def _remember_langgraph_persistence(
+        self, components: "LangGraphPersistenceComponents"
+    ) -> None:
+        resources = self.__dict__.setdefault("_langgraph_persistence_resources", [])
+        resources.append(components)
 
     def run_api(self, app: "FastAPI | str") -> None:
         import uvicorn
+
         in_main_thread = threading.current_thread() is threading.main_thread()
         uvicorn.run(
             app,  # type: ignore[arg-type]
             host=self.config.api.host,
             port=self.config.api.port,
-            reload=self.config.api.reload if isinstance(app, str) and in_main_thread else False,
+            reload=self.config.api.reload
+            if isinstance(app, str) and in_main_thread
+            else False,
             log_config=_UVICORN_LOG_CONFIG,
             ws="websockets-sansio",
         )
-
 
     def run_mcp_sse(self, mcp: "_fastmcp.FastMCP") -> None:
         mcp.run(transport="sse", host=self.config.mcp.host, port=self.config.mcp.port)
 
     def run_mcp_http(self, mcp: "_fastmcp.FastMCP") -> None:
-        mcp.run(transport="streamable-http", host=self.config.mcp.host, port=self.config.mcp.port)
+        mcp.run(
+            transport="streamable-http",
+            host=self.config.mcp.host,
+            port=self.config.mcp.port,
+        )
 
     # ── private cached helpers ────────────────────────────────────────────────
 
@@ -502,18 +670,22 @@ class Arclith:
         """
         if self.config.cache.backend == "redis":
             from arclith.adapters.outbound.redis.cache_adapter import RedisCacheAdapter
+
             return RedisCacheAdapter(self.config.cache.redis_url)
         from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
+
         return MemoryCacheAdapter()
 
     @cached_property
     def _metrics_registry(self) -> Any:
         from arclith.adapters.inbound.probes.metrics import MetricsRegistry
+
         return MetricsRegistry()
 
     @cached_property
     def _mcp_collector(self) -> Any:
         from arclith.adapters.inbound.probes.metrics import McpMetricsCollector
+
         collector = McpMetricsCollector(self._metrics_registry, logger=self.logger)
         if self.config.probe.enabled:
             self._probe_server.add_collector(collector)
@@ -522,6 +694,7 @@ class Arclith:
     @cached_property
     def _probe_server(self) -> Any:
         from arclith.adapters.inbound.probes.server import ProbeServer
+
         probe = self.config.probe
         return ProbeServer(
             host=probe.host,

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -521,7 +521,7 @@ class Arclith:
         stream_mode: LangGraphStreamMode | Sequence[LangGraphStreamMode] | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
         persistence: bool | None = None,
-        persistence_registry: "LangGraphPersistenceRegistry | None" = None,
+        persistence_registry: LangGraphPersistenceRegistry | None = None,
     ) -> Any:
         from langgraph.graph import StateGraph
 
@@ -577,7 +577,7 @@ class Arclith:
         checkpointer: Any,
         store: Any,
         persistence: bool | None,
-        registry: "LangGraphPersistenceRegistry | None",
+        registry: LangGraphPersistenceRegistry | None,
     ) -> tuple[Any, Any, "LangGraphPersistenceComponents | None"]:
         checkpointer_is_explicit = checkpointer is not _LANGGRAPH_UNSET
         store_is_explicit = store is not _LANGGRAPH_UNSET

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -232,7 +232,15 @@ class LangGraphCheckpointerSettings(BaseModel):
     factory: str | None = None
     options: dict[str, object] = Field(default_factory=dict)
 
-    @field_validator("adapter", "path", "database")
+    @field_validator("adapter")
+    @classmethod
+    def normalize_adapter(cls, v: str) -> str:
+        value = v.strip().lower()
+        if not value:
+            raise ValueError("la valeur ne doit pas etre vide")
+        return value
+
+    @field_validator("path", "database")
     @classmethod
     def must_not_be_blank(cls, v: str) -> str:
         value = v.strip()
@@ -263,7 +271,15 @@ class LangGraphStoreSettings(BaseModel):
         default_factory=LangGraphSemanticSearchSettings
     )
 
-    @field_validator("adapter", "database", "collection")
+    @field_validator("adapter")
+    @classmethod
+    def normalize_adapter(cls, v: str) -> str:
+        value = v.strip().lower()
+        if not value:
+            raise ValueError("la valeur ne doit pas etre vide")
+        return value
+
+    @field_validator("database", "collection")
     @classmethod
     def must_not_be_blank(cls, v: str) -> str:
         value = v.strip()

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -187,12 +187,119 @@ class ObservabilitySettings(BaseModel):
         return adapter in self.enabled
 
 
+class LangGraphSemanticSearchSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    embed: str | None = None
+    dims: int | None = None
+    fields: list[str] = Field(default_factory=lambda: ["$"])
+
+    @field_validator("dims")
+    @classmethod
+    def must_have_positive_dimensions(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("semantic_search.dims doit etre > 0")
+        return v
+
+    @field_validator("fields")
+    @classmethod
+    def must_have_non_empty_fields(cls, v: list[str]) -> list[str]:
+        if not v or any(not field.strip() for field in v):
+            raise ValueError(
+                "semantic_search.fields doit contenir des chemins non vides"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_enabled_search(self) -> "LangGraphSemanticSearchSettings":
+        if self.enabled and (not self.embed or self.dims is None):
+            raise ValueError(
+                "semantic_search.embed et semantic_search.dims sont requis quand la recherche est activee"
+            )
+        return self
+
+
+class LangGraphCheckpointerSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter: str = "none"
+    setup: bool = False
+    ttl_seconds: int | None = None
+    path: str = ".arclith/langgraph-checkpoints.sqlite"
+    connection_uri_env: str | None = None
+    database: str = "langgraph"
+    factory: str | None = None
+    options: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("adapter", "path", "database")
+    @classmethod
+    def must_not_be_blank(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("la valeur ne doit pas etre vide")
+        return value
+
+    @field_validator("ttl_seconds")
+    @classmethod
+    def must_have_positive_ttl(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("ttl_seconds doit etre > 0")
+        return v
+
+
+class LangGraphStoreSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter: str = "none"
+    setup: bool = False
+    connection_uri_env: str | None = None
+    database: str = "langgraph"
+    collection: str = "memories"
+    factory: str | None = None
+    options: dict[str, object] = Field(default_factory=dict)
+    namespace_template: str = "{tenant_id}:{user_id}:memories"
+    semantic_search: LangGraphSemanticSearchSettings = Field(
+        default_factory=LangGraphSemanticSearchSettings
+    )
+
+    @field_validator("adapter", "database", "collection")
+    @classmethod
+    def must_not_be_blank(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("la valeur ne doit pas etre vide")
+        return value
+
+    @field_validator("namespace_template")
+    @classmethod
+    def must_have_valid_namespace_template(cls, v: str) -> str:
+        value = v.strip()
+        if not value or any(not part.strip() for part in value.split(":")):
+            raise ValueError(
+                "namespace_template doit contenir des segments non vides separes par ':'"
+            )
+        return value
+
+
+class LangGraphPersistenceSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    mode: Literal["auto", "embedded", "agent_server"] = "auto"
+    checkpointer: LangGraphCheckpointerSettings = Field(
+        default_factory=LangGraphCheckpointerSettings
+    )
+    store: LangGraphStoreSettings = Field(default_factory=LangGraphStoreSettings)
+
+
 class LangGraphSettings(BaseModel):
     name: str = "agent"
     graph: str = "agent"
     entrypoint: str
     env: str = ".env"
     stream_mode: LangGraphStreamMode | list[LangGraphStreamMode] = "updates"
+    persistence: LangGraphPersistenceSettings | None = None
 
 
 StorageAdapter = Literal["filesystem", "s3", "azure-blob", "gcs"]

--- a/arclith/infrastructure/langgraph_persistence_factory.py
+++ b/arclith/infrastructure/langgraph_persistence_factory.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager, ExitStack
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from arclith.infrastructure.config import (
+    LangGraphCheckpointerSettings,
+    LangGraphPersistenceSettings,
+    LangGraphSemanticSearchSettings,
+    LangGraphStoreSettings,
+)
+
+PersistenceRole = Literal["checkpointer", "store"]
+CheckpointerFactory = Callable[[LangGraphCheckpointerSettings], object]
+StoreFactory = Callable[[LangGraphStoreSettings], object]
+
+_DEFAULT_CONNECTION_ENV: dict[tuple[PersistenceRole, str], str] = {
+    ("checkpointer", "postgresql"): "POSTGRESQL_URL",
+    ("checkpointer", "mongodb"): "MONGODB_URI",
+    ("store", "postgresql"): "POSTGRESQL_URL",
+    ("store", "mongodb"): "MONGODB_URI",
+    ("store", "redis"): "REDIS_URL",
+}
+_EXTRA_BY_BACKEND: dict[tuple[PersistenceRole, str], str] = {
+    ("checkpointer", "memory"): "langgraph",
+    ("checkpointer", "sqlite"): "langgraph-persistence-sqlite",
+    ("checkpointer", "postgresql"): "langgraph-persistence-postgresql",
+    ("checkpointer", "mongodb"): "langgraph-persistence-mongodb",
+    ("store", "memory"): "langgraph",
+    ("store", "postgresql"): "langgraph-persistence-postgresql",
+    ("store", "mongodb"): "langgraph-persistence-mongodb",
+    ("store", "redis"): "langgraph-persistence-redis",
+}
+_AGENT_SERVER_MARKERS = (
+    "LANGSERVE_GRAPHS",
+    "LANGSMITH_LANGGRAPH_API_VARIANT",
+    "LANGGRAPH_RUNTIME_EDITION",
+)
+
+
+@dataclass
+class LangGraphPersistenceComponents:
+    """Persistence objects and their owned connection lifecycle."""
+
+    checkpointer: object | None = None
+    store: object | None = None
+    mode: Literal["embedded", "agent_server"] = "embedded"
+    _stack: ExitStack = field(default_factory=ExitStack, repr=False)
+
+    def close(self) -> None:
+        self._stack.close()
+
+
+class LangGraphPersistenceRegistry:
+    """Registry for project-specific embedded checkpointer and store factories."""
+
+    def __init__(self) -> None:
+        self._checkpointers: dict[str, CheckpointerFactory] = {}
+        self._stores: dict[str, StoreFactory] = {}
+
+    def register_checkpointer(
+        self, name: str, factory: CheckpointerFactory
+    ) -> "LangGraphPersistenceRegistry":
+        self._checkpointers[_normalize_adapter_name(name)] = factory
+        return self
+
+    def register_store(
+        self, name: str, factory: StoreFactory
+    ) -> "LangGraphPersistenceRegistry":
+        self._stores[_normalize_adapter_name(name)] = factory
+        return self
+
+    def checkpointer_factory(self, name: str) -> CheckpointerFactory | None:
+        return self._checkpointers.get(_normalize_adapter_name(name))
+
+    def store_factory(self, name: str) -> StoreFactory | None:
+        return self._stores.get(_normalize_adapter_name(name))
+
+
+def default_langgraph_persistence_registry() -> LangGraphPersistenceRegistry:
+    return (
+        LangGraphPersistenceRegistry()
+        .register_checkpointer("memory", _build_memory_checkpointer)
+        .register_checkpointer("sqlite", _build_sqlite_checkpointer)
+        .register_checkpointer("postgresql", _build_postgresql_checkpointer)
+        .register_checkpointer("mongodb", _build_mongodb_checkpointer)
+        .register_checkpointer("custom", _build_custom_checkpointer)
+        .register_store("memory", _build_memory_store)
+        .register_store("postgresql", _build_postgresql_store)
+        .register_store("mongodb", _build_mongodb_store)
+        .register_store("redis", _build_redis_store)
+        .register_store("custom", _build_custom_store)
+    )
+
+
+def resolve_langgraph_persistence_mode(
+    settings: LangGraphPersistenceSettings,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Literal["embedded", "agent_server"]:
+    if settings.mode != "auto":
+        return settings.mode
+
+    environment = os.environ if environ is None else environ
+    override = environment.get("ARCLITH_LANGGRAPH_PERSISTENCE_MODE")
+    if override:
+        if override not in {"embedded", "agent_server"}:
+            raise ValueError(
+                "ARCLITH_LANGGRAPH_PERSISTENCE_MODE doit valoir embedded ou agent_server"
+            )
+        return cast(Literal["embedded", "agent_server"], override)
+    if any(environment.get(marker) for marker in _AGENT_SERVER_MARKERS):
+        return "agent_server"
+    return "embedded"
+
+
+def build_langgraph_persistence(
+    settings: LangGraphPersistenceSettings,
+    *,
+    registry: LangGraphPersistenceRegistry | None = None,
+    include_checkpointer: bool = True,
+    include_store: bool = True,
+) -> LangGraphPersistenceComponents:
+    mode = resolve_langgraph_persistence_mode(settings)
+    components = LangGraphPersistenceComponents(mode=mode)
+    if mode == "agent_server":
+        return components
+
+    defaults = default_langgraph_persistence_registry()
+    try:
+        if include_checkpointer and settings.checkpointer.adapter != "none":
+            checkpointer_factory = _select_checkpointer_factory(
+                settings.checkpointer.adapter, registry, defaults
+            )
+            created = checkpointer_factory(settings.checkpointer)
+            components.checkpointer = _enter_resource(
+                components._stack,
+                created,
+                role="checkpointer",
+                adapter=settings.checkpointer.adapter,
+            )
+            _run_setup(components.checkpointer, settings.checkpointer.setup)
+
+        if include_store and settings.store.adapter != "none":
+            store_factory = _select_store_factory(
+                settings.store.adapter, registry, defaults
+            )
+            created = store_factory(settings.store)
+            components.store = _enter_resource(
+                components._stack,
+                created,
+                role="store",
+                adapter=settings.store.adapter,
+            )
+            _run_setup(components.store, settings.store.setup)
+    except BaseException:
+        components.close()
+        raise
+    return components
+
+
+def render_langgraph_namespace(
+    template: str,
+    values: Mapping[str, object],
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    for segment in template.split(":"):
+        try:
+            rendered = segment.format_map(dict(values)).strip()
+        except KeyError as exc:
+            missing = exc.args[0]
+            raise ValueError(
+                f"Valeur de namespace LangGraph manquante: {missing}"
+            ) from exc
+        if not rendered:
+            raise ValueError("Un segment du namespace LangGraph est vide")
+        parts.append(rendered)
+    return tuple(parts)
+
+
+def _select_checkpointer_factory(
+    adapter: str,
+    registry: LangGraphPersistenceRegistry | None,
+    defaults: LangGraphPersistenceRegistry,
+) -> CheckpointerFactory:
+    factory = registry.checkpointer_factory(adapter) if registry is not None else None
+    factory = factory or defaults.checkpointer_factory(adapter)
+    if factory is None:
+        raise ValueError(
+            f"Checkpointer LangGraph '{adapter}' non enregistre. "
+            "Utilisez LangGraphPersistenceRegistry.register_checkpointer()."
+        )
+    return factory
+
+
+def _select_store_factory(
+    adapter: str,
+    registry: LangGraphPersistenceRegistry | None,
+    defaults: LangGraphPersistenceRegistry,
+) -> StoreFactory:
+    factory = registry.store_factory(adapter) if registry is not None else None
+    factory = factory or defaults.store_factory(adapter)
+    if factory is None:
+        raise ValueError(
+            f"Store LangGraph '{adapter}' non enregistre. "
+            "Utilisez LangGraphPersistenceRegistry.register_store()."
+        )
+    return factory
+
+
+def _enter_resource(
+    stack: ExitStack,
+    resource: object,
+    *,
+    role: PersistenceRole,
+    adapter: str,
+) -> object:
+    if resource is None:
+        raise TypeError(f"La factory {role} '{adapter}' a retourne None")
+    if hasattr(resource, "__aenter__") and not hasattr(resource, "__enter__"):
+        raise TypeError(
+            f"La factory {role} '{adapter}' retourne un context manager async. "
+            "Utilisez un backend synchrone en mode embedded ou configurez l'Agent Server."
+        )
+    if hasattr(resource, "__enter__") and hasattr(resource, "__exit__"):
+        context = cast(AbstractContextManager[object], resource)
+        return stack.enter_context(context)
+    close = getattr(resource, "close", None)
+    if callable(close):
+        stack.callback(close)
+    return resource
+
+
+def _run_setup(resource: object | None, enabled: bool) -> None:
+    if not enabled or resource is None:
+        return
+    setup = getattr(resource, "setup", None)
+    if not callable(setup):
+        return
+    result = setup()
+    if inspect.isawaitable(result):
+        close = getattr(result, "close", None)
+        if callable(close):
+            close()
+        raise TypeError(
+            "setup() est asynchrone; utilisez un backend synchrone en mode embedded "
+            "ou laissez l'Agent Server gerer son cycle de vie."
+        )
+
+
+def _build_memory_checkpointer(settings: LangGraphCheckpointerSettings) -> object:
+    _reject_unsupported_ttl(settings, adapter="memory")
+    module = _optional_module(
+        "langgraph.checkpoint.memory", role="checkpointer", adapter="memory"
+    )
+    return module.InMemorySaver(**settings.options)
+
+
+def _build_sqlite_checkpointer(settings: LangGraphCheckpointerSettings) -> object:
+    _reject_unsupported_ttl(settings, adapter="sqlite")
+    module = _optional_module(
+        "langgraph.checkpoint.sqlite", role="checkpointer", adapter="sqlite"
+    )
+    path = Path(settings.path).expanduser()
+    if settings.path != ":memory:":
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return module.SqliteSaver.from_conn_string(str(path))
+
+
+def _build_postgresql_checkpointer(settings: LangGraphCheckpointerSettings) -> object:
+    _reject_unsupported_ttl(settings, adapter="postgresql")
+    module = _optional_module(
+        "langgraph.checkpoint.postgres", role="checkpointer", adapter="postgresql"
+    )
+    uri = _connection_uri("checkpointer", settings.adapter, settings.connection_uri_env)
+    return module.PostgresSaver.from_conn_string(uri, **settings.options)
+
+
+def _build_mongodb_checkpointer(settings: LangGraphCheckpointerSettings) -> object:
+    module = _optional_module(
+        "langgraph.checkpoint.mongodb", role="checkpointer", adapter="mongodb"
+    )
+    uri = _connection_uri("checkpointer", settings.adapter, settings.connection_uri_env)
+    options = dict(settings.options)
+    options.setdefault("db_name", settings.database)
+    if settings.ttl_seconds is not None:
+        options.setdefault("ttl", settings.ttl_seconds)
+    return module.MongoDBSaver.from_conn_string(uri, **options)
+
+
+def _build_memory_store(settings: LangGraphStoreSettings) -> object:
+    module = _optional_module("langgraph.store.memory", role="store", adapter="memory")
+    options = dict(settings.options)
+    index = _semantic_index(settings.semantic_search)
+    if index is not None:
+        options.setdefault("index", index)
+    return module.InMemoryStore(**options)
+
+
+def _build_postgresql_store(settings: LangGraphStoreSettings) -> object:
+    module = _optional_module(
+        "langgraph.store.postgres", role="store", adapter="postgresql"
+    )
+    uri = _connection_uri("store", settings.adapter, settings.connection_uri_env)
+    options = dict(settings.options)
+    index = _semantic_index(settings.semantic_search)
+    if index is not None:
+        options.setdefault("index", index)
+    return module.PostgresStore.from_conn_string(uri, **options)
+
+
+def _build_mongodb_store(settings: LangGraphStoreSettings) -> object:
+    module = _optional_module(
+        "langgraph.store.mongodb", role="store", adapter="mongodb"
+    )
+    uri = _connection_uri("store", settings.adapter, settings.connection_uri_env)
+    options = dict(settings.options)
+    options.setdefault("db_name", settings.database)
+    options.setdefault("collection_name", settings.collection)
+    semantic = settings.semantic_search
+    if semantic.enabled:
+        options.setdefault(
+            "index_config",
+            module.create_vector_index_config(
+                dims=semantic.dims,
+                embed=semantic.embed,
+                fields=semantic.fields,
+            ),
+        )
+    return module.MongoDBStore.from_conn_string(uri, **options)
+
+
+def _build_redis_store(settings: LangGraphStoreSettings) -> object:
+    module = _optional_module("langgraph.store.redis", role="store", adapter="redis")
+    uri = _connection_uri("store", settings.adapter, settings.connection_uri_env)
+    options = dict(settings.options)
+    index = _semantic_index(settings.semantic_search)
+    if index is not None:
+        options.setdefault("index", index)
+    return module.RedisStore.from_conn_string(uri, **options)
+
+
+def _build_custom_checkpointer(settings: LangGraphCheckpointerSettings) -> object:
+    factory = _import_factory(settings.factory, role="checkpointer")
+    return factory(settings)
+
+
+def _build_custom_store(settings: LangGraphStoreSettings) -> object:
+    factory = _import_factory(settings.factory, role="store")
+    return factory(settings)
+
+
+def _import_factory(
+    path: str | None,
+    *,
+    role: PersistenceRole,
+) -> Callable[[Any], object]:
+    if not path or ":" not in path:
+        raise ValueError(
+            f"{role}.factory doit utiliser le format 'package.module:factory' "
+            "quand adapter=custom"
+        )
+    module_name, attribute = path.split(":", 1)
+    module = importlib.import_module(module_name)
+    factory = getattr(module, attribute, None)
+    if not callable(factory):
+        raise TypeError(f"La factory {role} '{path}' est introuvable ou non appelable")
+    return factory
+
+
+def _connection_uri(
+    role: PersistenceRole,
+    adapter: str,
+    configured_env: str | None,
+) -> str:
+    env_name = configured_env or _DEFAULT_CONNECTION_ENV.get((role, adapter))
+    if env_name is None:
+        raise ValueError(
+            f"Aucune variable de connexion par defaut pour {role}={adapter}"
+        )
+    value = os.getenv(env_name)
+    if not value:
+        raise RuntimeError(
+            f"Variable d'environnement {env_name} requise pour le {role} LangGraph '{adapter}'. "
+            "Injectez-la au runtime ou configurez connection_uri_env."
+        )
+    return value
+
+
+def _semantic_index(
+    settings: LangGraphSemanticSearchSettings,
+) -> dict[str, object] | None:
+    if not settings.enabled:
+        return None
+    return {
+        "embed": cast(str, settings.embed),
+        "dims": cast(int, settings.dims),
+        "fields": list(settings.fields),
+    }
+
+
+def _optional_module(
+    module_name: str,
+    *,
+    role: PersistenceRole,
+    adapter: str,
+) -> Any:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        extra = _EXTRA_BY_BACKEND[(role, adapter)]
+        raise RuntimeError(
+            f"Backend LangGraph {role} '{adapter}' non installe. "
+            f"Installez `arclith[{extra}]`."
+        ) from exc
+
+
+def _reject_unsupported_ttl(
+    settings: LangGraphCheckpointerSettings,
+    *,
+    adapter: str,
+) -> None:
+    if settings.ttl_seconds is not None:
+        raise ValueError(
+            f"ttl_seconds n'est pas supporte par le checkpointer embedded '{adapter}'. "
+            "Utilisez MongoDB, un backend custom ou la configuration Agent Server."
+        )
+
+
+def _normalize_adapter_name(name: str) -> str:
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("Le nom d'un backend LangGraph ne doit pas etre vide")
+    return normalized

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -30,9 +30,13 @@ from .project_paths import ProjectPaths, detect_project_paths
 
 console = Console()
 _UV_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$")
+_ARCLITH_DEPENDENCY_RE = re.compile(
+    r"(?P<quote>[\"'])arclith(?:\[(?P<extras>[^\]]*)\])?(?P<constraint>[^\"']*)(?P=quote)"
+)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
+
 
 def add_adapter_cmd(
     *,
@@ -55,8 +59,11 @@ def add_adapter_cmd(
 
     capability = _resolve_capability(capability_name)
     adapter_spec = _resolve_adapter_type(capability, adapter)
+    _assert_capability_prerequisites(project_dir, adapter_spec)
     adapter = adapter_spec.name
-    entities = _resolve_entities(project_dir, entity_names, all_entities, yes=yes, adapter=adapter_spec)
+    entities = _resolve_entities(
+        project_dir, entity_names, all_entities, yes=yes, adapter=adapter_spec
+    )
     params = _resolve_adapter_params(
         adapter_spec,
         project_dir,
@@ -76,7 +83,9 @@ def add_adapter_cmd(
 
     _show_recap(project_dir, capability, adapter_spec, entities, params, activate)
 
-    if not yes and not Confirm.ask("\n  [bold]Confirmer la génération ?[/bold]", default=True):
+    if not yes and not Confirm.ask(
+        "\n  [bold]Confirmer la génération ?[/bold]", default=True
+    ):
         console.print("[yellow]Annulé.[/yellow]")
         raise typer.Exit(0)
 
@@ -84,6 +93,7 @@ def add_adapter_cmd(
 
 
 # ── Validation ────────────────────────────────────────────────────────────────
+
 
 def _assert_arclith_project(project_dir: Path) -> None:
     paths = detect_project_paths(project_dir)
@@ -101,7 +111,35 @@ def _assert_arclith_project(project_dir: Path) -> None:
         raise typer.Exit(1)
 
 
+def _assert_capability_prerequisites(
+    project_dir: Path,
+    adapter: AdapterSpec,
+) -> None:
+    if adapter.capability != "agent-persistence":
+        return
+    langgraph_config = (
+        project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml"
+    )
+    existing = _read_yaml_mapping(langgraph_config)
+    if not isinstance(existing.get("entrypoint"), str):
+        console.print(
+            "[red]✗[/red] La capability [bold]agent-persistence[/bold] complete "
+            "[bold]agent/langgraph[/bold]. Generez d'abord cet adapter."
+        )
+        raise typer.Exit(1)
+    pyproject = project_dir / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8") if pyproject.exists() else ""
+    if _ARCLITH_DEPENDENCY_RE.search(text):
+        return
+    console.print(
+        "[red]✗[/red] Impossible d'ajouter les extras de persistance: "
+        "dependance [bold]arclith[/bold] absente de pyproject.toml."
+    )
+    raise typer.Exit(1)
+
+
 # ── Step 1 : adapter type ─────────────────────────────────────────────────────
+
 
 def _resolve_capability(capability_name: str) -> CapabilitySpec:
     capability = get_capability(capability_name)
@@ -109,7 +147,9 @@ def _resolve_capability(capability_name: str) -> CapabilitySpec:
         return capability
 
     supported = ", ".join(capability_names())
-    console.print(f"[red]✗[/red] Capacité inconnue: [bold]{capability_name}[/bold]. Valeurs: {supported}.")
+    console.print(
+        f"[red]✗[/red] Capacité inconnue: [bold]{capability_name}[/bold]. Valeurs: {supported}."
+    )
     raise typer.Exit(1)
 
 
@@ -131,10 +171,14 @@ def _prompt_adapter_type(capability: CapabilitySpec) -> AdapterSpec:
             selected = capability.get_adapter(raw)
             if selected is not None:
                 return selected
-        console.print(f"  [red]Choix invalide.[/red] Entrez 1-{len(adapter_names)} ou le nom.")
+        console.print(
+            f"  [red]Choix invalide.[/red] Entrez 1-{len(adapter_names)} ou le nom."
+        )
 
 
-def _resolve_adapter_type(capability: CapabilitySpec, adapter: str | None) -> AdapterSpec:
+def _resolve_adapter_type(
+    capability: CapabilitySpec, adapter: str | None
+) -> AdapterSpec:
     if adapter is None:
         return _prompt_adapter_type(capability)
 
@@ -143,25 +187,36 @@ def _resolve_adapter_type(capability: CapabilitySpec, adapter: str | None) -> Ad
         return selected
 
     supported = ", ".join(capability.adapter_names())
-    console.print(f"[red]✗[/red] Adapter inconnu: [bold]{adapter}[/bold]. Valeurs: {supported}.")
+    console.print(
+        f"[red]✗[/red] Adapter inconnu: [bold]{adapter}[/bold]. Valeurs: {supported}."
+    )
     raise typer.Exit(1)
 
 
 # ── Step 2 : entity selection ─────────────────────────────────────────────────
 
+
 def _prompt_entities(project_dir: Path) -> list[EntityInfo]:
     entities = scan_entities(project_dir)
     if not entities:
-        console.print("[red]✗[/red] Aucune entité trouvée dans [bold]src/<package>/domain/models/[/bold].")
+        console.print(
+            "[red]✗[/red] Aucune entité trouvée dans [bold]src/<package>/domain/models/[/bold]."
+        )
         raise typer.Exit(1)
 
     console.print("\n[bold]② Entité(s) cible(s)[/bold]")
     for i, e in enumerate(entities, 1):
-        console.print(f"   [bold cyan]{i}[/bold cyan]  {e.pascal} [dim]({e.snake})[/dim]")
-    console.print(f"   [bold cyan]{len(entities) + 1}[/bold cyan]  [italic]toutes[/italic]")
+        console.print(
+            f"   [bold cyan]{i}[/bold cyan]  {e.pascal} [dim]({e.snake})[/dim]"
+        )
+    console.print(
+        f"   [bold cyan]{len(entities) + 1}[/bold cyan]  [italic]toutes[/italic]"
+    )
 
     while True:
-        raw = Prompt.ask("\n  Votre choix [dim](numéro(s) séparés par virgule, ou nom)[/dim]").strip()
+        raw = Prompt.ask(
+            "\n  Votre choix [dim](numéro(s) séparés par virgule, ou nom)[/dim]"
+        ).strip()
         selected = _parse_entity_choice(raw, entities)
         if selected is not None:
             return selected
@@ -187,7 +242,9 @@ def _resolve_entities(
 
     entities = scan_entities(project_dir)
     if not entities:
-        console.print("[red]✗[/red] Aucune entité trouvée dans [bold]src/<package>/domain/models/[/bold].")
+        console.print(
+            "[red]✗[/red] Aucune entité trouvée dans [bold]src/<package>/domain/models/[/bold]."
+        )
         raise typer.Exit(1)
 
     if all_entities:
@@ -213,7 +270,9 @@ def _resolve_entities(
     return _prompt_entities(project_dir)
 
 
-def _parse_entity_choice(raw: str, entities: list[EntityInfo]) -> list[EntityInfo] | None:
+def _parse_entity_choice(
+    raw: str, entities: list[EntityInfo]
+) -> list[EntityInfo] | None:
     all_idx = len(entities) + 1
     parts = [p.strip() for p in raw.split(",") if p.strip()]
     result: list[EntityInfo] = []
@@ -239,6 +298,7 @@ def _parse_entity_choice(raw: str, entities: list[EntityInfo]) -> list[EntityInf
 
 
 # ── Step 3 : adapter-specific params ─────────────────────────────────────────
+
 
 def _resolve_adapter_params(
     adapter: AdapterSpec,
@@ -272,19 +332,25 @@ def _resolve_adapter_params(
 
     resolved: dict[str, Any] = {}
     for parameter in adapter.parameters:
-        value = _resolve_parameter(parameter, provided_values.get(parameter.name), project_dir, prompt_missing)
+        value = _resolve_parameter(
+            parameter, provided_values.get(parameter.name), project_dir, prompt_missing
+        )
         resolved[parameter.name] = _render_parameter_value(parameter, value)
 
     return _normalize_adapter_params(adapter, resolved)
 
 
-def _normalize_adapter_params(adapter: AdapterSpec, params: dict[str, Any]) -> dict[str, Any]:
+def _normalize_adapter_params(
+    adapter: AdapterSpec, params: dict[str, Any]
+) -> dict[str, Any]:
     if adapter.capability == "http" and adapter.name == "cache-control":
         return _normalize_cache_control_params(params)
     if adapter.capability == "command-bus" and adapter.name == "rabbitmq":
         return _normalize_rabbitmq_command_bus_params(params)
     if adapter.capability == "runtime" and adapter.name == "docker-image":
         return _normalize_docker_image_params(params)
+    if adapter.capability == "agent-persistence" and adapter.name == "langgraph":
+        return _normalize_agent_persistence_params(params)
     return params
 
 
@@ -359,7 +425,29 @@ def _normalize_docker_image_params(params: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def _assert_supported_params(adapter: AdapterSpec, extra_params: dict[str, str]) -> None:
+def _normalize_agent_persistence_params(params: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(params)
+    raw_ttl = str(normalized["ttl_seconds"]).strip()
+    if not raw_ttl:
+        normalized["ttl_seconds"] = None
+        return normalized
+    try:
+        ttl_seconds = int(raw_ttl)
+    except ValueError:
+        console.print(
+            f"[red]✗[/red] TTL entier invalide pour [bold]ttl_seconds[/bold]: {raw_ttl}."
+        )
+        raise typer.Exit(1) from None
+    if ttl_seconds <= 0:
+        console.print("[red]✗[/red] ttl_seconds doit etre strictement positif ou vide.")
+        raise typer.Exit(1)
+    normalized["ttl_seconds"] = ttl_seconds
+    return normalized
+
+
+def _assert_supported_params(
+    adapter: AdapterSpec, extra_params: dict[str, str]
+) -> None:
     supported = {parameter.name for parameter in adapter.parameters}
     unknown = sorted(name for name in extra_params if name not in supported)
     if not unknown:
@@ -406,7 +494,9 @@ def _resolve_parameter(
         resolved = Prompt.ask(f"  {parameter.prompt}", **prompt_kwargs).strip()
     resolved = resolved or string_default
     if parameter.required and not resolved:
-        console.print(f"[red]✗[/red] Paramètre requis manquant: [bold]{parameter.name}[/bold].")
+        console.print(
+            f"[red]✗[/red] Paramètre requis manquant: [bold]{parameter.name}[/bold]."
+        )
         raise typer.Exit(1)
     _assert_allowed_parameter_value(parameter, resolved)
     return resolved
@@ -475,6 +565,7 @@ def _yaml_bool(value: bool) -> str:
 
 # ── Step 4 : recap ────────────────────────────────────────────────────────────
 
+
 def _show_recap(
     project_dir: Path,
     capability: CapabilitySpec,
@@ -492,7 +583,9 @@ def _show_recap(
 
     for path, action in files:
         style = "yellow" if action == "remplacé ⚠" else "green"
-        table.add_row(str(path.relative_to(project_dir)), f"[{style}]{action}[/{style}]")
+        table.add_row(
+            str(path.relative_to(project_dir)), f"[{style}]{action}[/{style}]"
+        )
 
     if activate and capability.activation_config_key is not None:
         cfg_path = project_dir / "config" / "adapters" / "adapters.yaml"
@@ -502,7 +595,12 @@ def _show_recap(
         )
 
     console.print()
-    console.print(Panel(table, title=f"[bold]Récapitulatif — adapter [green]{adapter.name}[/green][/bold]"))
+    console.print(
+        Panel(
+            table,
+            title=f"[bold]Récapitulatif — adapter [green]{adapter.name}[/green][/bold]",
+        )
+    )
 
 
 def _list_generated_files(
@@ -564,6 +662,7 @@ def _activation_config_label(capability: CapabilitySpec) -> str:
 
 # ── Step 5 : generate ─────────────────────────────────────────────────────────
 
+
 def _generate(
     project_dir: Path,
     capability: CapabilitySpec,
@@ -577,7 +676,10 @@ def _generate(
     if adapter.name not in installed:
         installed = sorted(installed + [adapter.name])
 
-    params = {**params, **_file_template_vars(project_dir, paths, adapter, params=params)}
+    params = {
+        **params,
+        **_file_template_vars(project_dir, paths, adapter, params=params),
+    }
 
     if adapter.has_config() and adapter.config_path:
         cfg_path = project_dir / adapter.config_path
@@ -587,12 +689,18 @@ def _generate(
 
     for merge_template in adapter.merge_config_templates:
         cfg_path = project_dir / render(merge_template.path, params)
-        _merge_yaml_file(cfg_path, render(merge_template.template, params))
+        _merge_yaml_file(
+            cfg_path,
+            render(merge_template.template, params),
+            preserve_existing=merge_template.preserve_existing,
+        )
         console.print(f"[green]✓[/green] {cfg_path.relative_to(project_dir)}")
 
     if adapter.has_env() and adapter.env_path:
         env_path = project_dir / adapter.env_path
-        _merge_env_file(env_path, _parse_env_template(render(adapter.env_template, params)))
+        _merge_env_file(
+            env_path, _parse_env_template(render(adapter.env_template, params))
+        )
         _ensure_gitignore_entries(project_dir, (".env",))
         console.print(f"[green]✓[/green] {env_path.relative_to(project_dir)}")
 
@@ -614,7 +722,9 @@ def _generate(
     for file_template in adapter.file_templates:
         generated_path = project_dir / render(file_template.path, params)
         generated_path.parent.mkdir(parents=True, exist_ok=True)
-        generated_path.write_text(render(file_template.template, params), encoding="utf-8")
+        generated_path.write_text(
+            render(file_template.template, params), encoding="utf-8"
+        )
         if generated_path.name == "arclith-run":
             generated_path.chmod(0o755)
         console.print(f"[green]✓[/green] {generated_path.relative_to(project_dir)}")
@@ -650,7 +760,10 @@ def _generate(
         container = paths.containers / f"{entity.snake}_container.py"
         existed = container.exists()
         container.parent.mkdir(parents=True, exist_ok=True)
-        container.write_text(render_container(entity.pascal, entity.snake, installed, import_vars), encoding="utf-8")
+        container.write_text(
+            render_container(entity.pascal, entity.snake, installed, import_vars),
+            encoding="utf-8",
+        )
         action = "[yellow]remplacé ⚠[/yellow]" if existed else "[green]créé[/green]"
         console.print(f"{action} {container.relative_to(project_dir)}")
 
@@ -658,7 +771,13 @@ def _generate(
     if activate:
         _update_active_capability(project_dir, capability, adapter)
 
-    console.print(f"\n[bold green]✓ Adapter [cyan]{adapter.name}[/cyan] scaffoldé avec succès.[/bold green]")
+    if adapter.capability == "agent-persistence":
+        extras = _configured_agent_persistence_extras(project_dir, params)
+        _ensure_arclith_extras(project_dir, extras)
+
+    console.print(
+        f"\n[bold green]✓ Adapter [cyan]{adapter.name}[/cyan] scaffoldé avec succès.[/bold green]"
+    )
 
 
 def _import_vars(paths: ProjectPaths) -> dict[str, str]:
@@ -680,14 +799,21 @@ def _file_template_vars(
     if package_path == ".":
         langgraph_entrypoint = f"./adapters/inbound/{adapter.name}/agent.py:agent"
     else:
-        langgraph_entrypoint = f"./{package_path}/adapters/inbound/{adapter.name}/agent.py:agent"
+        langgraph_entrypoint = (
+            f"./{package_path}/adapters/inbound/{adapter.name}/agent.py:agent"
+        )
     graph_name = str(params.get("graph_name") or "agent")
     return {
         "package_path": package_path,
         "langgraph_entrypoint": langgraph_entrypoint,
         "graph_name": graph_name,
-        "stream_mode_yaml": _langgraph_stream_mode_yaml(str(params.get("stream_mode") or "updates")),
-        "secret_template_yaml": _secret_template_yaml(str(params.get("field_path") or "")),
+        "stream_mode_yaml": _langgraph_stream_mode_yaml(
+            str(params.get("stream_mode") or "updates")
+        ),
+        "persistence_config_yaml": _langgraph_persistence_yaml(params),
+        "secret_template_yaml": _secret_template_yaml(
+            str(params.get("field_path") or "")
+        ),
         "secret_chain_yaml": _secret_chain_yaml(str(params.get("resolvers") or "")),
     }
 
@@ -697,6 +823,135 @@ def _langgraph_stream_mode_yaml(stream_mode: str) -> str:
     if len(values) == 1:
         return f'"{values[0]}"'
     return yaml.safe_dump(values, default_flow_style=True, sort_keys=False).strip()
+
+
+def _langgraph_persistence_yaml(params: dict[str, Any]) -> str:
+    checkpointer_adapter = str(params.get("checkpointer") or "memory")
+    store_adapter = str(params.get("store") or "memory")
+    database = str(params.get("database") or "langgraph")
+    checkpointer: dict[str, Any] = {
+        "adapter": checkpointer_adapter,
+        "setup": _parse_boolean_param(
+            str(params.get("checkpointer_setup", "false"))
+        )
+        is True,
+        "ttl_seconds": params.get("ttl_seconds"),
+    }
+    if checkpointer_adapter == "sqlite":
+        checkpointer["path"] = str(
+            params.get("sqlite_path") or ".arclith/langgraph-checkpoints.sqlite"
+        )
+    elif checkpointer_adapter == "postgresql":
+        checkpointer.update(
+            connection_uri_env="POSTGRESQL_URL",
+            database=database,
+        )
+    elif checkpointer_adapter == "mongodb":
+        checkpointer.update(connection_uri_env="MONGODB_URI", database=database)
+    elif checkpointer_adapter == "custom" and params.get("checkpointer_factory"):
+        checkpointer["factory"] = str(params["checkpointer_factory"])
+
+    store: dict[str, Any] = {
+        "adapter": store_adapter,
+        "setup": _parse_boolean_param(str(params.get("store_setup", "false")))
+        is True,
+        "namespace_template": str(
+            params.get("namespace_template") or "{tenant_id}:{user_id}:memories"
+        ),
+        "semantic_search": {
+            "enabled": False,
+            "embed": None,
+            "dims": None,
+            "fields": ["$"],
+        },
+    }
+    if store_adapter == "postgresql":
+        store.update(connection_uri_env="POSTGRESQL_URL", database=database)
+    elif store_adapter == "mongodb":
+        store.update(
+            connection_uri_env="MONGODB_URI",
+            database=database,
+            collection="memories",
+        )
+    elif store_adapter == "redis":
+        store["connection_uri_env"] = "REDIS_URL"
+    elif store_adapter == "custom" and params.get("store_factory"):
+        store["factory"] = str(params["store_factory"])
+
+    return yaml.safe_dump(
+        {
+            "persistence": {
+                "enabled": True,
+                "mode": str(params.get("mode") or "auto"),
+                "checkpointer": checkpointer,
+                "store": store,
+            }
+        },
+        sort_keys=False,
+        allow_unicode=True,
+    ).rstrip("\n")
+
+
+def _agent_persistence_extras(params: dict[str, Any]) -> tuple[str, ...]:
+    extras = ["langgraph"]
+    by_backend = {
+        "sqlite": "langgraph-persistence-sqlite",
+        "postgresql": "langgraph-persistence-postgresql",
+        "mongodb": "langgraph-persistence-mongodb",
+        "redis": "langgraph-persistence-redis",
+    }
+    for backend in (str(params.get("checkpointer")), str(params.get("store"))):
+        extra = by_backend.get(backend)
+        if extra is not None and extra not in extras:
+            extras.append(extra)
+    return tuple(extras)
+
+
+def _configured_agent_persistence_extras(
+    project_dir: Path,
+    fallback: dict[str, Any],
+) -> tuple[str, ...]:
+    langgraph_config = _read_yaml_mapping(
+        project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml"
+    )
+    persistence = langgraph_config.get("persistence")
+    if not isinstance(persistence, dict):
+        return _agent_persistence_extras(fallback)
+    checkpointer = persistence.get("checkpointer")
+    store = persistence.get("store")
+    configured = {
+        "checkpointer": (
+            checkpointer.get("adapter") if isinstance(checkpointer, dict) else None
+        ),
+        "store": store.get("adapter") if isinstance(store, dict) else None,
+    }
+    return _agent_persistence_extras(configured)
+
+
+def _ensure_arclith_extras(project_dir: Path, required: tuple[str, ...]) -> None:
+    pyproject = project_dir / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    match = _ARCLITH_DEPENDENCY_RE.search(text)
+    if match is None:
+        raise typer.Exit(1)
+    current = [
+        extra.strip()
+        for extra in (match.group("extras") or "").split(",")
+        if extra.strip()
+    ]
+    if "all" in current:
+        return
+    merged = current + [extra for extra in required if extra not in current]
+    if merged == current:
+        return
+    quote = match.group("quote")
+    constraint = match.group("constraint")
+    replacement = f"{quote}arclith[{','.join(merged)}]{constraint}{quote}"
+    updated = text[: match.start()] + replacement + text[match.end() :]
+    pyproject.write_text(updated, encoding="utf-8")
+    console.print(
+        "[cyan]↺[/cyan] pyproject.toml → extras arclith: " + ", ".join(merged)
+    )
 
 
 def _secret_template_yaml(field_path: str) -> str:
@@ -718,7 +973,9 @@ def _secret_chain_yaml(resolvers: str) -> str:
     return "".join(f"  - {value}\n" for value in values).rstrip("\n")
 
 
-def _update_active_capability(project_dir: Path, capability: CapabilitySpec, adapter: AdapterSpec) -> None:
+def _update_active_capability(
+    project_dir: Path, capability: CapabilitySpec, adapter: AdapterSpec
+) -> None:
     if capability.activation_config_key is None:
         return
     if capability.name == "observability":
@@ -734,11 +991,15 @@ def _update_active_capability(project_dir: Path, capability: CapabilitySpec, ada
     else:
         text = cfg.read_text(encoding="utf-8")
         if re.search(rf"(?m)^{escaped_key}:", text):
-            text = re.sub(rf"(?m)^({escaped_key}:\s*).*$", rf"\g<1>{adapter.name}", text)
+            text = re.sub(
+                rf"(?m)^({escaped_key}:\s*).*$", rf"\g<1>{adapter.name}", text
+            )
         else:
             text = text.rstrip("\n") + f"\n{key}: {adapter.name}\n"
         cfg.write_text(text, encoding="utf-8")
-    console.print(f"[cyan]↺[/cyan] config/adapters/adapters.yaml → {key}: {adapter.name}")
+    console.print(
+        f"[cyan]↺[/cyan] config/adapters/adapters.yaml → {key}: {adapter.name}"
+    )
 
 
 def _enable_observability_adapter(project_dir: Path, adapter: AdapterSpec) -> None:
@@ -758,7 +1019,9 @@ def _enable_observability_adapter(project_dir: Path, adapter: AdapterSpec) -> No
 
     data["observability"] = {"enabled": enabled}
     cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    cfg.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
     console.print(
         f"[cyan]↺[/cyan] config/adapters/adapters.yaml → observability.enabled += {adapter.name}"
     )
@@ -778,7 +1041,9 @@ def _parse_env_template(rendered: str) -> dict[str, str]:
 
 def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    existing_lines = (
+        env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    )
     merged_lines: list[str] = []
     seen: set[str] = set()
 
@@ -805,15 +1070,28 @@ def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
     env_path.write_text("\n".join(merged_lines).rstrip("\n") + "\n", encoding="utf-8")
 
 
-def _merge_yaml_file(path: Path, rendered_yaml: str) -> None:
+def _merge_yaml_file(
+    path: Path,
+    rendered_yaml: str,
+    *,
+    preserve_existing: bool = False,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     existing = _read_yaml_mapping(path)
     update = yaml.safe_load(rendered_yaml) or {}
     if not isinstance(update, dict):
-        console.print("[red]✗[/red] La configuration YAML générée doit être un mapping.")
+        console.print(
+            "[red]✗[/red] La configuration YAML générée doit être un mapping."
+        )
         raise typer.Exit(1)
-    merged = _deep_merge_mapping(existing, update)
-    path.write_text(yaml.safe_dump(merged, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    merged = (
+        {**update, **existing}
+        if preserve_existing
+        else _deep_merge_mapping(existing, update)
+    )
+    path.write_text(
+        yaml.safe_dump(merged, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
 
 
 def _merge_secrets_file(
@@ -837,7 +1115,9 @@ def _merge_secrets_file(
         rendered_config = render(config_template, render_params)
         config_data = yaml.safe_load(rendered_config) or {}
         if not isinstance(config_data, dict):
-            console.print("[red]✗[/red] La configuration de secrets générée doit être un mapping YAML.")
+            console.print(
+                "[red]✗[/red] La configuration de secrets générée doit être un mapping YAML."
+            )
             raise typer.Exit(1)
         data = _deep_merge_mapping(data, config_data)
 
@@ -850,7 +1130,9 @@ def _merge_secrets_file(
         field_path = render(mapping.field_path, render_params).strip()
         secret_key = render(mapping.secret_key, render_params).strip()
         if not field_path:
-            console.print("[red]✗[/red] Un mapping de secret doit cibler un champ non vide.")
+            console.print(
+                "[red]✗[/red] Un mapping de secret doit cibler un champ non vide."
+            )
             raise typer.Exit(1)
         merged_mappings[field_path] = secret_key
     data["mappings"] = merged_mappings
@@ -859,7 +1141,9 @@ def _merge_secrets_file(
     secrets_path.write_text(rendered, encoding="utf-8")
 
 
-def _deep_merge_mapping(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+def _deep_merge_mapping(
+    base: dict[str, Any], override: dict[str, Any]
+) -> dict[str, Any]:
     result = dict(base)
     for key, value in override.items():
         current = result.get(key)

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -48,10 +48,12 @@ class ParameterSpec:
 class FileTemplateSpec:
     path: str
     template: str
+    preserve_existing: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "path": self.path,
+            "preserve_existing": self.preserve_existing,
         }
 
 
@@ -1651,6 +1653,116 @@ agent = arclith.langgraph(AgentState, register_agent, name="{graph_name}")
     ),
 )
 
+
+AGENT_PERSISTENCE_CAPABILITY = CapabilitySpec(
+    name="agent-persistence",
+    layer="inbound",
+    description="Checkpoints de threads et memoire cross-thread pour LangGraph.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="langgraph",
+            capability="agent-persistence",
+            layer="inbound",
+            description="Persistance LangGraph optionnelle, configurable et extensible.",
+            merge_config_templates=(
+                FileTemplateSpec(
+                    path="config/adapters/inbound/langgraph.yaml",
+                    template="{persistence_config_yaml}\n",
+                    preserve_existing=True,
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="mode",
+                    kind="string",
+                    prompt="Mode de persistance LangGraph",
+                    default="auto",
+                    choices=("auto", "embedded", "agent_server"),
+                ),
+                ParameterSpec(
+                    name="checkpointer",
+                    kind="string",
+                    prompt="Backend de checkpoints",
+                    default="memory",
+                    choices=(
+                        "none",
+                        "memory",
+                        "sqlite",
+                        "postgresql",
+                        "mongodb",
+                        "custom",
+                    ),
+                ),
+                ParameterSpec(
+                    name="store",
+                    kind="string",
+                    prompt="Backend de memoire cross-thread",
+                    default="memory",
+                    choices=(
+                        "none",
+                        "memory",
+                        "postgresql",
+                        "mongodb",
+                        "redis",
+                        "custom",
+                    ),
+                ),
+                ParameterSpec(
+                    name="checkpointer_setup",
+                    kind="boolean",
+                    prompt="Executer setup() pour le checkpointer",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="store_setup",
+                    kind="boolean",
+                    prompt="Executer setup() pour le store",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="ttl_seconds",
+                    kind="string",
+                    prompt="TTL des checkpoints en secondes (vide = illimite)",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="sqlite_path",
+                    kind="string",
+                    prompt="Fichier SQLite des checkpoints",
+                    default=".arclith/langgraph-checkpoints.sqlite",
+                ),
+                ParameterSpec(
+                    name="database",
+                    kind="string",
+                    prompt="Base de persistance LangGraph",
+                    default="langgraph",
+                ),
+                ParameterSpec(
+                    name="namespace_template",
+                    kind="string",
+                    prompt="Template de namespace long-term memory",
+                    default="{tenant_id}:{user_id}:memories",
+                ),
+                ParameterSpec(
+                    name="checkpointer_factory",
+                    kind="string",
+                    prompt="Import path de la factory custom checkpointer",
+                    default="",
+                ),
+                ParameterSpec(
+                    name="store_factory",
+                    kind="string",
+                    prompt="Import path de la factory custom store",
+                    default="",
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
+
 OBSERVABILITY_CAPABILITY = CapabilitySpec(
     name="observability",
     layer="outbound",
@@ -1818,6 +1930,7 @@ CAPABILITY_CATALOG = (
     LICENSE_CAPABILITY,
     LLM_CAPABILITY,
     AGENT_CAPABILITY,
+    AGENT_PERSISTENCE_CAPABILITY,
     OBSERVABILITY_CAPABILITY,
 )
 

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -19,7 +19,11 @@ from .core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_useca
 from .export_config import export_config_cmd
 from .init_project import init_project_cmd
 from .rename import EntityNames, apply_rename
-from .runtime_templates import DOCKERIGNORE_TEMPLATE, render_arclith_run, render_dockerfile
+from .runtime_templates import (
+    DOCKERIGNORE_TEMPLATE,
+    render_arclith_run,
+    render_dockerfile,
+)
 from .scaffold import download_and_extract
 from .updater import run_update
 
@@ -47,7 +51,9 @@ def init(
     ] = Path("."),
 ) -> None:
     """Initialiser un projet arclith minimal sans entité métier."""
-    init_project_cmd(project_name=project_name or _prompt_project(), directory=directory)
+    init_project_cmd(
+        project_name=project_name or _prompt_project(), directory=directory
+    )
 
 
 @app.command()
@@ -60,7 +66,9 @@ def new(
     ] = None,
     project_name: Annotated[
         str | None,
-        typer.Argument(help="Nom du répertoire du projet. Exemple : [dim]my-recipe-service[/dim]"),
+        typer.Argument(
+            help="Nom du répertoire du projet. Exemple : [dim]my-recipe-service[/dim]"
+        ),
     ] = None,
     directory: Annotated[
         Path,
@@ -76,7 +84,9 @@ def new(
     ] = "main",
     template_dir: Annotated[
         Path | None,
-        typer.Option("--template-dir", help="Répertoire local du template _sample", hidden=True),
+        typer.Option(
+            "--template-dir", help="Répertoire local du template _sample", hidden=True
+        ),
     ] = None,
 ) -> None:
     """Créer un nouveau projet [bold]arclith[/bold] scaffoldé depuis le template officiel [dim]_sample[/dim]."""
@@ -88,7 +98,9 @@ def new(
     target_dir = directory.resolve() / project_name
 
     if target_dir.exists():
-        console.print(f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]")
+        console.print(
+            f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]"
+        )
         raise typer.Exit(1)
 
     console.print(
@@ -145,7 +157,8 @@ def add_adapter(
             "--capability",
             help=(
                 "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, http, "
-                "command-bus, runtime, auth, tenant, license, llm, agent ou observability"
+                "command-bus, runtime, auth, tenant, license, llm, agent, agent-persistence "
+                "ou observability"
             ),
         ),
     ] = "repository",
@@ -155,11 +168,15 @@ def add_adapter(
     ] = None,
     entity: Annotated[
         str | None,
-        typer.Option("--entity", "-e", help="Entité cible. Liste séparée par virgule acceptée."),
+        typer.Option(
+            "--entity", "-e", help="Entité cible. Liste séparée par virgule acceptée."
+        ),
     ] = None,
     all_entities: Annotated[
         bool,
-        typer.Option("--all-entities", help="Générer l'adapter pour toutes les entités détectées"),
+        typer.Option(
+            "--all-entities", help="Générer l'adapter pour toutes les entités détectées"
+        ),
     ] = False,
     activate: Annotated[
         bool,
@@ -182,11 +199,18 @@ def add_adapter(
     ] = None,
     param: Annotated[
         list[str] | None,
-        typer.Option("--param", help="Paramètre adapter key=value, répétable pour les adapters du catalogue"),
+        typer.Option(
+            "--param",
+            help="Paramètre adapter key=value, répétable pour les adapters du catalogue",
+        ),
     ] = None,
     yes: Annotated[
         bool,
-        typer.Option("--yes", "-y", help="Utiliser les valeurs fournies ou par défaut sans confirmation"),
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Utiliser les valeurs fournies ou par défaut sans confirmation",
+        ),
     ] = False,
 ) -> None:
     """Wizard ou mode direct pour scaffolder un nouvel [bold]adapter[/bold] dans le projet courant."""
@@ -288,6 +312,7 @@ def export_config(
 
 # ── Prompts interactifs ───────────────────────────────────────────────────────
 
+
 def _prompt_entity() -> str:
     console.print(
         "\n[bold]Entité[/bold] — utilisez le [yellow]singulier[/yellow] "
@@ -307,7 +332,9 @@ def _prompt_entity() -> str:
 
 
 def _prompt_project() -> str:
-    console.print("\n[bold]Projet[/bold] [dim](ex : my-recipe-service, meal-planner)[/dim]")
+    console.print(
+        "\n[bold]Projet[/bold] [dim](ex : my-recipe-service, meal-planner)[/dim]"
+    )
     while True:
         value = Prompt.ask("  [bold green]Nom du projet[/bold green]").strip()
         if not value:
@@ -322,7 +349,9 @@ def _prompt_project() -> str:
 
 
 def _prompt_usecase() -> str:
-    console.print("\n[bold]Cas d'usage[/bold] [dim](ex : PlanShoppingList, find_by_name)[/dim]")
+    console.print(
+        "\n[bold]Cas d'usage[/bold] [dim](ex : PlanShoppingList, find_by_name)[/dim]"
+    )
     while True:
         value = Prompt.ask("  [bold green]Nom du cas d'usage[/bold green]").strip()
         if not value:
@@ -337,7 +366,9 @@ def _prompt_usecase() -> str:
 
 
 def _prompt_intent_interpreter() -> str:
-    console.print("\n[bold]Interpréteur d'intention[/bold] [dim](ex : IngredientIntent, todo_intent)[/dim]")
+    console.print(
+        "\n[bold]Interpréteur d'intention[/bold] [dim](ex : IngredientIntent, todo_intent)[/dim]"
+    )
     while True:
         value = Prompt.ask("  [bold green]Nom de l'interpréteur[/bold green]").strip()
         if not value:
@@ -353,6 +384,7 @@ def _prompt_intent_interpreter() -> str:
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+
 def _split_entity_option(value: str | None) -> list[str] | None:
     if value is None:
         return None
@@ -366,7 +398,9 @@ def _parse_param_options(values: list[str] | None) -> dict[str, str]:
         key, separator, value = raw.partition("=")
         key = key.strip()
         if separator != "=" or not key:
-            console.print(f"[red]✗[/red] Paramètre invalide: [bold]{raw}[/bold]. Format attendu: key=value.")
+            console.print(
+                f"[red]✗[/red] Paramètre invalide: [bold]{raw}[/bold]. Format attendu: key=value."
+            )
             raise typer.Exit(1)
         result[key] = value.strip()
     return result

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1497,6 +1497,101 @@ def test_add_langgraph_agent_adapter_generates_runtime_entrypoint(
     assert not (package_root / "adapters" / "outbound" / "langgraph").exists()
 
 
+def test_add_langgraph_persistence_enriches_config_and_dependency_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / "pyproject.toml").write_text(
+        """[project]
+name = "demo-service"
+dependencies = ["arclith[fastapi,mcp]>=0.18.0"]
+""",
+        encoding="utf-8",
+    )
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="agent",
+        adapter="langgraph",
+        adapter_params={"graph_name": "support_agent", "stream_mode": "updates,custom"},
+        yes=True,
+    )
+    langgraph_path = project_dir / "config" / "adapters" / "inbound" / "langgraph.yaml"
+    existing = yaml.safe_load(langgraph_path.read_text(encoding="utf-8"))
+    existing["project_field"] = {"preserved": True}
+    langgraph_path.write_text(
+        yaml.safe_dump(existing, sort_keys=False), encoding="utf-8"
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="agent-persistence",
+        adapter="langgraph",
+        adapter_params={
+            "checkpointer": "mongodb",
+            "store": "mongodb",
+            "database": "agent_memory",
+            "ttl_seconds": "3600",
+        },
+        yes=True,
+    )
+
+    generated = yaml.safe_load(langgraph_path.read_text(encoding="utf-8"))
+    assert generated["name"] == "support_agent"
+    assert generated["stream_mode"] == ["updates", "custom"]
+    assert generated["project_field"] == {"preserved": True}
+    assert generated["persistence"]["enabled"] is True
+    assert generated["persistence"]["mode"] == "auto"
+    assert generated["persistence"]["checkpointer"] == {
+        "adapter": "mongodb",
+        "setup": False,
+        "ttl_seconds": 3600,
+        "connection_uri_env": "MONGODB_URI",
+        "database": "agent_memory",
+    }
+    assert generated["persistence"]["store"]["adapter"] == "mongodb"
+    assert generated["persistence"]["store"]["database"] == "agent_memory"
+    assert (
+        generated["persistence"]["store"]["namespace_template"]
+        == "{tenant_id}:{user_id}:memories"
+    )
+    pyproject = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
+    assert (
+        "arclith[fastapi,mcp,langgraph,langgraph-persistence-mongodb]>=0.18.0"
+        in pyproject
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="agent-persistence",
+        adapter="langgraph",
+        adapter_params={"checkpointer": "sqlite", "store": "redis"},
+        yes=True,
+    )
+    regenerated = yaml.safe_load(langgraph_path.read_text(encoding="utf-8"))
+    assert regenerated == generated
+    assert (project_dir / "pyproject.toml").read_text(encoding="utf-8") == pyproject
+
+
+def test_add_langgraph_persistence_requires_agent_capability(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["arclith>=0.18.0"]\n', encoding="utf-8"
+    )
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="agent-persistence",
+            adapter="langgraph",
+            yes=True,
+        )
+
+    assert "Generez d'abord" in capsys.readouterr().out
+
+
 @pytest.mark.asyncio
 async def test_add_langgraph_agent_adapter_generates_compilable_minimal_agent(
     tmp_path: Path,

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -487,6 +487,36 @@ def test_agent_capability_catalog_declares_langgraph() -> None:
     ]
 
 
+def test_agent_persistence_capability_catalog_declares_langgraph_backends() -> None:
+    capability = get_capability("agent-persistence")
+
+    assert capability is not None
+    assert capability.layer == "inbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("langgraph",)
+    langgraph = capability.get_adapter("langgraph")
+    assert langgraph is not None
+    assert langgraph.config_path is None
+    assert langgraph.entity_scoped is False
+    assert [template.path for template in langgraph.merge_config_templates] == [
+        "config/adapters/inbound/langgraph.yaml"
+    ]
+    assert langgraph.merge_config_templates[0].preserve_existing is True
+    assert [parameter.name for parameter in langgraph.parameters] == [
+        "mode",
+        "checkpointer",
+        "store",
+        "checkpointer_setup",
+        "store_setup",
+        "ttl_seconds",
+        "sqlite_path",
+        "database",
+        "namespace_template",
+        "checkpointer_factory",
+        "store_factory",
+    ]
+
+
 def test_repository_adapter_specs_include_config_and_parameters() -> None:
     capability = get_capability("repository")
     assert capability is not None

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -89,8 +89,18 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.8" },
     { name = "langgraph-api", marker = "extra == 'all'", specifier = ">=0.11.0" },
     { name = "langgraph-api", marker = "extra == 'langgraph'", specifier = ">=0.11.0" },
+    { name = "langgraph-checkpoint-mongodb", marker = "extra == 'all'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "langgraph-checkpoint-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-redis", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-checkpoint-redis", marker = "extra == 'langgraph-persistence-redis'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-checkpoint-sqlite", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-sqlite", marker = "extra == 'langgraph-persistence-sqlite'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'all'", specifier = ">=0.4.31" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'langgraph'", specifier = ">=0.4.31" },
+    { name = "langgraph-store-mongodb", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-store-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "langsmith", marker = "extra == 'langgraph'", specifier = ">=0.4.0" },
     { name = "loguru", specifier = "==0.7.3" },
@@ -106,6 +116,8 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", marker = "extra == 'opentelemetry'", specifier = ">=0.51b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.30.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'all'", specifier = ">=3.2.0,<4.0.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'all'", specifier = ">=2.24.0,<3.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'langgraph'", specifier = ">=2.24.0,<3.0.0" },
@@ -123,7 +135,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -24,6 +24,7 @@ arclith-cli capabilities --json
 | [api](capabilities/api.md) | inbound | `fastapi` | exposer des endpoints HTTP |
 | [mcp](capabilities/mcp.md) | inbound | `fastmcp` | exposer des tools MCP |
 | [agent](capabilities/agent.md) | inbound | `langgraph` | exposer un agent LangGraph |
+| [agent-persistence](capabilities/agent-persistence.md) | inbound | `langgraph` | conserver threads et mémoire cross-thread |
 | [auth](capabilities/auth.md) | inbound | `keycloak` | sécuriser API ou MCP |
 | [tenant](capabilities/tenant.md) | inbound | `vault` | résoudre un contexte tenant |
 | [license](capabilities/license.md) | inbound | `role` | contrôler un droit d'accès |
@@ -46,7 +47,7 @@ arclith-cli capabilities --json
 | API minimale | [Quickstart API](quickstarts/api.md), [formation API](tutorials/todo-list/04-api.md), puis [api/fastapi](capabilities/api.md) |
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
-| Agent local | [Quickstart Agent](quickstarts/agent.md), [formation agent](tutorials/todo-list/06-agent.md), puis [agent/langgraph](capabilities/agent.md) |
+| Agent local | [Quickstart Agent](quickstarts/agent.md), [formation agent](tutorials/todo-list/06-agent.md), puis [agent/langgraph](capabilities/agent.md) et [persistance](capabilities/agent-persistence.md) |
 | Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |
 | Déploiement | [Runtime Docker](runtime-docker.md), puis [Docker Compose](runtime-docker/docker-compose.md) |

--- a/docs/capabilities/agent-persistence.md
+++ b/docs/capabilities/agent-persistence.md
@@ -1,0 +1,230 @@
+# Capability Agent Persistence
+
+## Intention
+
+`agent-persistence` ajoute la persistance LangGraph sans coupler le domaine Arclith à LangGraph :
+
+- le **checkpointer** conserve l'état d'un thread entre plusieurs runs ;
+- le **store** conserve des mémoires partagées entre plusieurs threads.
+
+La capability complète [agent/langgraph](agent.md). Elle ne remplace ni un repository métier ni une
+base de données applicative.
+
+## Position Hexagonale
+
+La configuration appartient à l'adapter inbound LangGraph. Les nodes continuent d'appeler des ports
+inbound ou des use cases ; ils ne reçoivent jamais un repository concret par cette capability.
+
+## Quickstart
+
+Créer d'abord le graphe, puis enrichir sa configuration :
+
+```bash
+arclith-cli add-adapter --capability agent --adapter langgraph --yes
+arclith-cli add-adapter \
+  --capability agent-persistence \
+  --adapter langgraph \
+  --param checkpointer=memory \
+  --param store=memory \
+  --yes
+uv sync
+```
+
+Le CLI conserve les champs déjà présents dans `config/adapters/inbound/langgraph.yaml` et ajoute les
+extras requis à la dépendance `arclith[...]` du projet. `memory` est réservé au développement et aux
+tests : son contenu disparaît avec le processus.
+
+## Formation
+
+Le [quickstart Agent](../quickstarts/agent.md) construit le premier graphe. La page
+[Validation IA locale](../learning/local-ai-validation.md) montre ensuite comment reprendre et
+inspecter un thread par l'API Agent Server.
+
+## Contrat
+
+Configuration complète :
+
+```yaml
+# config/adapters/inbound/langgraph.yaml
+persistence:
+  enabled: true
+  mode: auto # auto | embedded | agent_server
+  checkpointer:
+    adapter: memory # none | memory | sqlite | postgresql | mongodb | custom
+    setup: false
+    ttl_seconds: null
+  store:
+    adapter: memory # none | memory | postgresql | mongodb | redis | custom
+    setup: false
+    namespace_template: "{tenant_id}:{user_id}:memories"
+    semantic_search:
+      enabled: false
+      embed: null
+      dims: null
+      fields: ["$"]
+```
+
+Le graphe peut activer explicitement le wiring :
+
+```python
+agent = arclith.langgraph(
+    AgentState,
+    register_agent,
+    name="support_agent",
+    persistence=True,
+)
+```
+
+Si `persistence` est omis, `persistence.enabled: true` active aussi le wiring. Les priorités sont :
+
+1. `checkpointer=...` et `store=...` explicites ;
+2. configuration Arclith si la persistence est active ;
+3. `None`, soit le comportement historique sans capability.
+
+`persistence=False` désactive toute injection du framework, sans supprimer les objets fournis
+explicitement. Fermer les connexions embedded à l'arrêt du processus :
+
+```python
+arclith.close_langgraph_persistence()
+```
+
+Construire un namespace store sans recopier le template :
+
+```python
+namespace = arclith.langgraph_memory_namespace(
+    tenant_id=tenant_id,
+    user_id=user_id,
+)
+# (tenant_id, user_id, "memories")
+```
+
+## Adapters
+
+| Rôle | Adapter | Extra | Usage |
+|---|---|---|---|
+| checkpointer | `memory` | `langgraph` | dev/test volatile |
+| checkpointer | `sqlite` | `langgraph-persistence-sqlite` | debug local reproductible |
+| checkpointer + store | `postgresql` | `langgraph-persistence-postgresql` | production relationnelle |
+| checkpointer + store | `mongodb` | `langgraph-persistence-mongodb` | production documentaire |
+| store | `redis` | `langgraph-persistence-redis` | mémoire partagée Redis |
+| les deux | `custom` | dépend du projet | factory importée ou registry |
+
+Exemple SQLite :
+
+```yaml
+checkpointer:
+  adapter: sqlite
+  path: .arclith/langgraph-checkpoints.sqlite
+```
+
+Exemple PostgreSQL, sans credential dans Git :
+
+```yaml
+checkpointer:
+  adapter: postgresql
+  connection_uri_env: POSTGRESQL_URL
+  setup: true
+store:
+  adapter: postgresql
+  connection_uri_env: POSTGRESQL_URL
+  setup: true
+```
+
+`setup: true` applique les tables/indexes fournis par l'intégration LangGraph. En production, les
+migrations peuvent être exécutées séparément puis `setup` laissé à `false`.
+
+## Extension Custom
+
+Une factory importée reçoit les settings de son rôle et retourne un objet ou un context manager
+synchrone :
+
+```yaml
+checkpointer:
+  adapter: custom
+  factory: "app.infrastructure.agent_memory:build_checkpointer"
+```
+
+Une registry permet aussi un nom de backend propre au projet :
+
+```python
+from arclith import LangGraphPersistenceRegistry
+
+registry = LangGraphPersistenceRegistry().register_store("dynamodb", build_store)
+
+agent = arclith.langgraph(
+    AgentState,
+    register_agent,
+    persistence=True,
+    persistence_registry=registry,
+)
+```
+
+Les context managers asynchrones sont destinés à l'Agent Server, qui en gère le cycle de vie via
+`langgraph.json`. Le mode embedded attend des composants synchrones.
+
+## Production
+
+`mode: auto` laisse l'Agent Server gérer checkpointer et store quand son runtime est détecté ; sinon,
+Arclith construit les composants embedded. Forcer le choix avec `mode` ou, au runtime,
+`ARCLITH_LANGGRAPH_PERSISTENCE_MODE=embedded|agent_server`.
+
+Points à respecter :
+
+- Agent Server injecte lui-même ses backends : ne pas compiler le graphe avec une seconde connexion ;
+- MongoDB Agent Server exige un replica set ou un `mongos`, jamais un `mongod` standalone ;
+- PostgreSQL utilise `thread_id` comme clé fréquente : préférer un UUID ou un hash court et stable ;
+- les URI restent dans l'environnement runtime, `.env` non commité ou la capability `secrets` ;
+- activer `LANGGRAPH_STRICT_MSGPACK=true` quand les checkpoints peuvent être compromis ;
+- la recherche sémantique nécessite `embed`, `dims` et un backend/index compatible.
+
+Pour l'Agent Server, PostgreSQL est le backend géré par défaut. MongoDB se configure dans
+`langgraph.json` avec `checkpointer.backend: mongo` et `LS_MONGODB_URI` au runtime. Un checkpointer ou
+store custom Agent Server est un async context manager référencé par `checkpointer.path` ou
+`store.path`.
+
+## Validation
+
+En embedded, deux appels avec le même `thread_id` doivent reprendre le même état :
+
+```python
+config = {"configurable": {"thread_id": "018f-stable-thread"}}
+agent.invoke({"messages": ["premier message"]}, config)
+agent.invoke({"messages": ["suite"]}, config)
+```
+
+Avec l'Agent Server :
+
+```bash
+THREAD_ID=$(curl -fsS -X POST http://127.0.0.1:2024/threads \
+  -H 'Content-Type: application/json' -d '{}' \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["thread_id"])')
+
+curl -fsS "http://127.0.0.1:2024/threads/$THREAD_ID/state" | python -m json.tool
+```
+
+Un test store doit écrire une mémoire sous `(tenant_id, user_id, "memories")`, puis la relire depuis
+un second `thread_id`.
+
+## Troubleshooting
+
+| Erreur | Action |
+|---|---|
+| `Backend ... non installe` | installer l'extra indiqué puis exécuter `uv sync` |
+| variable `POSTGRESQL_URL`, `MONGODB_URI` ou `REDIS_URL` requise | injecter le secret au runtime |
+| état absent au second run | vérifier `configurable.thread_id` et sa stabilité |
+| aucun objet injecté sous Agent Server | comportement attendu : le serveur fournit ses backends |
+| `setup()` asynchrone en embedded | utiliser une implémentation sync ou le mode Agent Server |
+
+## Projet
+
+Lire [agent/langgraph](agent.md), [Lancement local Agent](../runtime-docker/local-agent.md), puis le
+[parcours Todo agent](../tutorials/todo-list/06-agent.md).
+
+## Sources
+
+- [Persistence LangGraph](https://docs.langchain.com/oss/python/langgraph/persistence)
+- [Checkpointer integrations](https://docs.langchain.com/oss/python/integrations/checkpointers)
+- [Store integrations](https://docs.langchain.com/oss/python/integrations/long-term-memory)
+- [Agent Server](https://docs.langchain.com/langsmith/agent-server)
+- [Custom checkpointer](https://docs.langchain.com/langsmith/custom-checkpointer)
+- [Custom store](https://docs.langchain.com/langsmith/custom-store)

--- a/docs/capabilities/agent.md
+++ b/docs/capabilities/agent.md
@@ -84,6 +84,24 @@ agent = arclith.langgraph(AgentState, register_agent, name="agent")
 Le template généré est volontairement minimal. Le projet remplace ensuite
 `AgentState`, les nodes et les edges par son propre parcours.
 
+## Threads Et Mémoire Durable
+
+La capability optionnelle [agent-persistence](agent-persistence.md) câble les checkpointers de
+threads et les stores cross-thread sans boilerplate projet :
+
+```bash
+arclith-cli add-adapter \
+  --capability agent-persistence \
+  --adapter langgraph \
+  --param checkpointer=memory \
+  --param store=memory \
+  --yes
+uv sync
+```
+
+`memory` convient aux tests. SQLite permet un debug local reproductible ; PostgreSQL, MongoDB et
+Redis sont disponibles via des extras séparés pour la production.
+
 ## Streaming Et Progression
 
 `config/adapters/inbound/langgraph.yaml` peut fixer le mode de streaming par
@@ -250,5 +268,5 @@ tools MCP. Il ne lit pas directement leurs repositories ou bases.
 
 ## Suite
 
-Lire [llm](llm.md), [observability](observability.md), [Validation IA locale](../learning/local-ai-validation.md),
+Lire [agent-persistence](agent-persistence.md), [llm](llm.md), [observability](observability.md), [Validation IA locale](../learning/local-ai-validation.md),
 puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).

--- a/docs/learning/local-ai-validation.md
+++ b/docs/learning/local-ai-validation.md
@@ -156,6 +156,11 @@ Le `assistant_id` doit correspondre au nom déclaré dans `langgraph.json`.
 
 Pour pouvoir relire l'état final, créer un thread explicite:
 
+Sous Agent Server, la persistance est gérée par le serveur. Pour reproduire le même test avec un
+graphe embedded, activer d'abord `agent-persistence` et invoquer le graphe avec
+`{"configurable": {"thread_id": "<id-stable>"}}`. Voir la
+[capability dédiée](../capabilities/agent-persistence.md).
+
 ```bash
 THREAD_ID=$(curl -fsS -X POST "http://127.0.0.1:2024/threads" \
   -H "Content-Type: application/json" \
@@ -252,6 +257,7 @@ propriétaires de leur métier.
 - `langgraph dev --no-browser --allow-blocking --port 2024` démarre.
 - un run `values` répond via `/runs/stream`.
 - un thread explicite peut être relu via `/threads/{thread_id}/state`.
+- une mémoire store écrite pour un utilisateur est relue depuis un autre thread.
 - les tests unitaires importants utilisent un fake LLM.
 
 ## Sources

--- a/docs/quickstarts/agent.md
+++ b/docs/quickstarts/agent.md
@@ -24,6 +24,14 @@ uvx --from arclith-cli arclith-cli add-adapter \
   --capability agent \
   --adapter langgraph \
   --yes
+
+uvx --from arclith-cli arclith-cli add-adapter \
+  --capability agent-persistence \
+  --adapter langgraph \
+  --param checkpointer=memory \
+  --param store=memory \
+  --yes
+uv sync
 ```
 
 Pour un LLM local :
@@ -93,5 +101,5 @@ transitions pour appeler ses use cases.
 
 ## Suite
 
-Lire [agent/langgraph](../capabilities/agent.md), [Validation IA locale](../learning/local-ai-validation.md),
+Lire [agent/langgraph](../capabilities/agent.md), [persistance agent](../capabilities/agent-persistence.md), [Validation IA locale](../learning/local-ai-validation.md),
 puis le [parcours Todo agent](../tutorials/todo-list/06-agent.md).

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -24,6 +24,25 @@ arclith-cli add-adapter \
   --yes
 ```
 
+Pour un debug embedded hors Agent Server, utiliser par exemple SQLite :
+
+```bash
+arclith-cli add-adapter \
+  --capability agent-persistence \
+  --adapter langgraph \
+  --param mode=embedded \
+  --param checkpointer=sqlite \
+  --param store=memory \
+  --yes
+uv sync
+```
+
+Ce profil s'applique aux appels directs à `arclith.langgraph(...)`, pas à la commande Agent Server
+ci-dessous. Pour `arclith-run agent`, conserver `mode=auto` ou choisir `mode=agent_server` : le
+serveur gère sa propre persistance et Arclith n'ouvre pas une seconde connexion. Pour MongoDB Agent
+Server, utiliser un replica set ou un `mongos`, configurer `checkpointer.backend: mongo` dans
+`langgraph.json` et injecter `LS_MONGODB_URI`. PostgreSQL est le backend Agent Server par défaut.
+
 Si le projet utilise LM Studio ou un endpoint OpenAI-compatible lancé sur le poste, ne pas utiliser
 `localhost` depuis le conteneur. Sur Docker Desktop, utiliser souvent:
 
@@ -113,6 +132,8 @@ OPENAI_API_KEY
 ANTHROPIC_API_KEY
 LANGSMITH_API_KEY
 MONGODB_URI
+POSTGRESQL_URL
+REDIS_URL
 VAULT_TOKEN
 ```
 
@@ -136,6 +157,7 @@ docker run --rm --env-file .env.local my-service:local agent
 - `host.docker.internal` utilisé quand le modèle tourne sur le poste hôte.
 - API locale `:2024` testée même sans LangSmith.
 - Traces LangSmith/OpenTelemetry activées par configuration, pas par code métier.
+- Checkpointer/store gérés une seule fois : par Arclith embedded ou par l'Agent Server.
 - En production, remplacer `langgraph dev` par la commande serveur validée du projet via
   `ARCLITH_AGENT_COMMAND` si nécessaire.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - API: capabilities/api.md
       - MCP: capabilities/mcp.md
       - Agent: capabilities/agent.md
+      - Persistance Agent: capabilities/agent-persistence.md
       - Command Bus: capabilities/command-bus.md
       - Probe: capabilities/probe.md
       - Runtime: capabilities/runtime.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ cache   = ["redis>=5.0.0"]
 auth    = ["PyJWT[crypto]>=2.8.0", "httpx>=0.27.0"]
 rabbitmq = ["aio-pika>=10.0.1,<11.0.0"]
 langgraph = ["langgraph>=1.0.8", "langgraph-api>=0.11.0", "langgraph-cli[inmem]>=0.4.31", "langsmith>=0.4.0", "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"]
+langgraph-persistence-sqlite = ["langgraph-checkpoint-sqlite>=3.0.0,<4.0.0"]
+langgraph-persistence-postgresql = ["langgraph-checkpoint-postgres>=3.0.0,<4.0.0", "psycopg[binary,pool]>=3.2.0,<4.0.0"]
+langgraph-persistence-mongodb = ["langgraph-checkpoint-mongodb>=0.3.0,<1.0.0", "langgraph-store-mongodb>=0.2.0,<1.0.0"]
+langgraph-persistence-redis = ["langgraph-checkpoint-redis>=0.2.0,<1.0.0"]
 opentelemetry = ["opentelemetry-api>=1.30.0", "opentelemetry-sdk>=1.30.0", "opentelemetry-exporter-otlp>=1.30.0", "opentelemetry-instrumentation-fastapi>=0.51b0", "opentelemetry-instrumentation-logging>=0.51b0"]
 all     = [
     "motor==3.7.1",
@@ -67,6 +71,12 @@ all     = [
     "langgraph-cli[inmem]>=0.4.31",
     "langsmith>=0.4.0",
     "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0",
+    "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
+    "langgraph-checkpoint-postgres>=3.0.0,<4.0.0",
+    "psycopg[binary,pool]>=3.2.0,<4.0.0",
+    "langgraph-checkpoint-mongodb>=0.3.0,<1.0.0",
+    "langgraph-store-mongodb>=0.2.0,<1.0.0",
+    "langgraph-checkpoint-redis>=0.2.0,<1.0.0",
     "opentelemetry-api>=1.30.0",
     "opentelemetry-sdk>=1.30.0",
     "opentelemetry-exporter-otlp>=1.30.0",

--- a/tests/units/infrastructure/test_langgraph_persistence_config.py
+++ b/tests/units/infrastructure/test_langgraph_persistence_config.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from arclith.infrastructure.config import AppConfig, load_config_dir
+
+
+def test_loads_langgraph_persistence_from_inbound_yaml(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    langgraph_file = config_dir / "adapters" / "inbound" / "langgraph.yaml"
+    langgraph_file.parent.mkdir(parents=True)
+    langgraph_file.write_text(
+        """entrypoint: "./src/app/agent.py:agent"
+persistence:
+  enabled: true
+  mode: embedded
+  checkpointer:
+    adapter: sqlite
+    path: data/checkpoints.sqlite
+    setup: false
+    ttl_seconds: null
+  store:
+    adapter: memory
+    namespace_template: "{tenant_id}:{user_id}:memories"
+    semantic_search:
+      enabled: false
+      embed: null
+      dims: null
+      fields: ["$"]
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config_dir(config_dir)
+
+    assert config.langgraph is not None
+    assert config.langgraph.persistence is not None
+    assert config.langgraph.persistence.enabled is True
+    assert config.langgraph.persistence.checkpointer.adapter == "sqlite"
+    assert config.langgraph.persistence.checkpointer.path == "data/checkpoints.sqlite"
+    assert config.langgraph.persistence.store.adapter == "memory"
+
+
+def test_missing_persistence_keeps_existing_langgraph_behavior() -> None:
+    config = AppConfig.model_validate(
+        {"langgraph": {"entrypoint": "./src/app/agent.py:agent"}}
+    )
+
+    assert config.langgraph is not None
+    assert config.langgraph.persistence is None
+
+
+@pytest.mark.parametrize(
+    "persistence",
+    [
+        {"checkpointer": {"ttl_seconds": 0}},
+        {
+            "store": {
+                "semantic_search": {
+                    "enabled": True,
+                    "embed": None,
+                    "dims": None,
+                }
+            }
+        },
+        {"store": {"namespace_template": "{tenant_id}::memories"}},
+    ],
+)
+def test_rejects_invalid_langgraph_persistence_config(
+    persistence: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {
+                "langgraph": {
+                    "entrypoint": "./src/app/agent.py:agent",
+                    "persistence": persistence,
+                }
+            }
+        )

--- a/tests/units/infrastructure/test_langgraph_persistence_config.py
+++ b/tests/units/infrastructure/test_langgraph_persistence_config.py
@@ -16,12 +16,12 @@ persistence:
   enabled: true
   mode: embedded
   checkpointer:
-    adapter: sqlite
+    adapter: SQLite
     path: data/checkpoints.sqlite
     setup: false
     ttl_seconds: null
   store:
-    adapter: memory
+    adapter: Memory
     namespace_template: "{tenant_id}:{user_id}:memories"
     semantic_search:
       enabled: false

--- a/tests/units/infrastructure/test_langgraph_persistence_factory.py
+++ b/tests/units/infrastructure/test_langgraph_persistence_factory.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from arclith.infrastructure.config import LangGraphPersistenceSettings
+from arclith.infrastructure.langgraph_persistence_factory import (
+    LangGraphPersistenceRegistry,
+    build_langgraph_persistence,
+    render_langgraph_namespace,
+    resolve_langgraph_persistence_mode,
+)
+
+
+def test_builds_memory_components_without_optional_backend_dependencies() -> None:
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": "memory"},
+            "store": {"adapter": "memory"},
+        }
+    )
+
+    components = build_langgraph_persistence(settings)
+
+    assert components.mode == "embedded"
+    assert components.checkpointer.__class__.__name__ == "InMemorySaver"
+    assert components.store.__class__.__name__ == "InMemoryStore"
+    components.close()
+
+
+def test_agent_server_mode_does_not_build_embedded_components() -> None:
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "agent_server",
+            "checkpointer": {"adapter": "sqlite"},
+            "store": {"adapter": "postgresql"},
+        }
+    )
+
+    components = build_langgraph_persistence(settings)
+
+    assert components.mode == "agent_server"
+    assert components.checkpointer is None
+    assert components.store is None
+
+
+def test_auto_mode_detects_agent_server_and_supports_explicit_override() -> None:
+    settings = LangGraphPersistenceSettings(enabled=True, mode="auto")
+
+    assert (
+        resolve_langgraph_persistence_mode(
+            settings, environ={"LANGSERVE_GRAPHS": '{"agent":"graph.py:agent"}'}
+        )
+        == "agent_server"
+    )
+    assert (
+        resolve_langgraph_persistence_mode(
+            settings, environ={"LANGSMITH_LANGGRAPH_API_VARIANT": "local_dev"}
+        )
+        == "agent_server"
+    )
+    assert (
+        resolve_langgraph_persistence_mode(
+            settings,
+            environ={"ARCLITH_LANGGRAPH_PERSISTENCE_MODE": "embedded"},
+        )
+        == "embedded"
+    )
+
+
+def test_registry_supports_custom_backend_and_closes_its_context() -> None:
+    events: list[str] = []
+    resource = object()
+
+    @contextmanager
+    def custom_checkpointer(_settings):
+        events.append("open")
+        try:
+            yield resource
+        finally:
+            events.append("close")
+
+    registry = LangGraphPersistenceRegistry().register_checkpointer(
+        "dynamodb", custom_checkpointer
+    )
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": "dynamodb"},
+            "store": {"adapter": "none"},
+        }
+    )
+
+    components = build_langgraph_persistence(settings, registry=registry)
+
+    assert components.checkpointer is resource
+    assert events == ["open"]
+    components.close()
+    assert events == ["open", "close"]
+
+
+def test_missing_backend_dependency_names_the_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import arclith.infrastructure.langgraph_persistence_factory as factory_module
+
+    real_import = factory_module.importlib.import_module
+
+    def import_module(name: str):
+        if name == "langgraph.checkpoint.sqlite":
+            raise ModuleNotFoundError(name)
+        return real_import(name)
+
+    monkeypatch.setattr(factory_module.importlib, "import_module", import_module)
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": "sqlite"},
+            "store": {"adapter": "none"},
+        }
+    )
+
+    with pytest.raises(RuntimeError, match=r"arclith\[langgraph-persistence-sqlite\]"):
+        build_langgraph_persistence(settings)
+
+
+def test_namespace_template_is_rendered_as_explicit_segments() -> None:
+    namespace = render_langgraph_namespace(
+        "{tenant_id}:{user_id}:memories",
+        {"tenant_id": "tenant-a", "user_id": "user-42"},
+    )
+
+    assert namespace == ("tenant-a", "user-42", "memories")
+
+    with pytest.raises(ValueError, match="user_id"):
+        render_langgraph_namespace(
+            "{tenant_id}:{user_id}:memories", {"tenant_id": "tenant-a"}
+        )
+
+
+def test_invalid_auto_mode_override_is_rejected() -> None:
+    settings = LangGraphPersistenceSettings(enabled=True, mode="auto")
+
+    with pytest.raises(ValueError, match="embedded ou agent_server"):
+        resolve_langgraph_persistence_mode(
+            settings,
+            environ={"ARCLITH_LANGGRAPH_PERSISTENCE_MODE": "invalid"},
+        )
+
+
+def test_custom_import_factories_run_setup_and_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import arclith.infrastructure.langgraph_persistence_factory as factory_module
+
+    events: list[str] = []
+
+    class Resource:
+        def setup(self) -> None:
+            events.append("setup")
+
+        def close(self) -> None:
+            events.append("close")
+
+    module = SimpleNamespace(
+        build_checkpointer=lambda _settings: Resource(),
+        build_store=lambda _settings: Resource(),
+    )
+    real_import = factory_module.importlib.import_module
+
+    def import_module(name: str):
+        if name == "project.persistence":
+            return module
+        return real_import(name)
+
+    monkeypatch.setattr(factory_module.importlib, "import_module", import_module)
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {
+                "adapter": "custom",
+                "factory": "project.persistence:build_checkpointer",
+                "setup": True,
+            },
+            "store": {
+                "adapter": "custom",
+                "factory": "project.persistence:build_store",
+                "setup": True,
+            },
+        }
+    )
+
+    components = build_langgraph_persistence(settings)
+
+    assert events == ["setup", "setup"]
+    components.close()
+    assert events == ["setup", "setup", "close", "close"]
+
+
+def test_builtin_database_factories_receive_connection_and_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import arclith.infrastructure.langgraph_persistence_factory as factory_module
+
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    class Resource:
+        def setup(self) -> None:
+            calls.append(("setup", "", {}))
+
+    def resource_factory(name: str):
+        @contextmanager
+        def from_conn_string(uri: str, **options: object):
+            calls.append((name, uri, options))
+            yield Resource()
+
+        return SimpleNamespace(from_conn_string=from_conn_string)
+
+    modules = {
+        "langgraph.checkpoint.postgres": SimpleNamespace(
+            PostgresSaver=resource_factory("postgres-checkpointer")
+        ),
+        "langgraph.store.postgres": SimpleNamespace(
+            PostgresStore=resource_factory("postgres-store")
+        ),
+        "langgraph.checkpoint.mongodb": SimpleNamespace(
+            MongoDBSaver=resource_factory("mongodb-checkpointer")
+        ),
+        "langgraph.store.mongodb": SimpleNamespace(
+            MongoDBStore=resource_factory("mongodb-store"),
+            create_vector_index_config=lambda **options: {"vector": options},
+        ),
+        "langgraph.store.redis": SimpleNamespace(
+            RedisStore=resource_factory("redis-store")
+        ),
+    }
+    real_import = factory_module.importlib.import_module
+
+    def import_module(name: str):
+        return modules.get(name) or real_import(name)
+
+    monkeypatch.setattr(factory_module.importlib, "import_module", import_module)
+    monkeypatch.setenv("POSTGRESQL_URL", "postgresql://runtime")
+    monkeypatch.setenv("MONGODB_URI", "mongodb://runtime")
+    monkeypatch.setenv("REDIS_URL", "redis://runtime")
+
+    postgres = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": "postgresql", "setup": True},
+            "store": {"adapter": "postgresql", "setup": True},
+        }
+    )
+    build_langgraph_persistence(postgres).close()
+    mongodb = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {
+                "adapter": "mongodb",
+                "database": "agents",
+                "ttl_seconds": 60,
+            },
+            "store": {
+                "adapter": "mongodb",
+                "database": "agents",
+                "collection": "memory",
+                "semantic_search": {
+                    "enabled": True,
+                    "embed": "openai:text-embedding-3-small",
+                    "dims": 1536,
+                },
+            },
+        }
+    )
+    build_langgraph_persistence(mongodb).close()
+    redis = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": "none"},
+            "store": {"adapter": "redis"},
+        }
+    )
+    build_langgraph_persistence(redis).close()
+
+    assert ("postgres-checkpointer", "postgresql://runtime", {}) in calls
+    assert ("postgres-store", "postgresql://runtime", {}) in calls
+    assert (
+        "mongodb-checkpointer",
+        "mongodb://runtime",
+        {"db_name": "agents", "ttl": 60},
+    ) in calls
+    mongodb_store = next(call for call in calls if call[0] == "mongodb-store")
+    assert mongodb_store[1] == "mongodb://runtime"
+    assert mongodb_store[2]["db_name"] == "agents"
+    assert mongodb_store[2]["collection_name"] == "memory"
+    assert "index_config" in mongodb_store[2]
+    assert ("redis-store", "redis://runtime", {}) in calls
+
+
+@pytest.mark.parametrize("adapter", ["memory", "sqlite", "postgresql"])
+def test_rejects_ttl_for_backends_without_embedded_ttl_support(
+    adapter: str,
+) -> None:
+    settings = LangGraphPersistenceSettings.model_validate(
+        {
+            "enabled": True,
+            "mode": "embedded",
+            "checkpointer": {"adapter": adapter, "ttl_seconds": 60},
+            "store": {"adapter": "none"},
+        }
+    )
+
+    with pytest.raises(ValueError, match="ttl_seconds n'est pas supporte"):
+        build_langgraph_persistence(settings)

--- a/tests/units/infrastructure/test_langgraph_persistence_factory.py
+++ b/tests/units/infrastructure/test_langgraph_persistence_factory.py
@@ -5,13 +5,13 @@ from types import SimpleNamespace
 
 import pytest
 
+import arclith.infrastructure.langgraph_persistence_factory as factory_module
 from arclith.infrastructure.config import LangGraphPersistenceSettings
-from arclith.infrastructure.langgraph_persistence_factory import (
-    LangGraphPersistenceRegistry,
-    build_langgraph_persistence,
-    render_langgraph_namespace,
-    resolve_langgraph_persistence_mode,
-)
+
+LangGraphPersistenceRegistry = factory_module.LangGraphPersistenceRegistry
+build_langgraph_persistence = factory_module.build_langgraph_persistence
+render_langgraph_namespace = factory_module.render_langgraph_namespace
+resolve_langgraph_persistence_mode = factory_module.resolve_langgraph_persistence_mode
 
 
 def test_builds_memory_components_without_optional_backend_dependencies() -> None:
@@ -108,8 +108,6 @@ def test_registry_supports_custom_backend_and_closes_its_context() -> None:
 def test_missing_backend_dependency_names_the_extra(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import arclith.infrastructure.langgraph_persistence_factory as factory_module
-
     real_import = factory_module.importlib.import_module
 
     def import_module(name: str):
@@ -158,8 +156,6 @@ def test_invalid_auto_mode_override_is_rejected() -> None:
 def test_custom_import_factories_run_setup_and_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import arclith.infrastructure.langgraph_persistence_factory as factory_module
-
     events: list[str] = []
 
     class Resource:
@@ -208,8 +204,6 @@ def test_custom_import_factories_run_setup_and_close(
 def test_builtin_database_factories_receive_connection_and_options(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import arclith.infrastructure.langgraph_persistence_factory as factory_module
-
     calls: list[tuple[str, str, dict[str, object]]] = []
 
     class Resource:

--- a/tests/units/test_arclith_langgraph_persistence.py
+++ b/tests/units/test_arclith_langgraph_persistence.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from operator import add
+from pathlib import Path
+from typing import Annotated, Any, TypedDict
+
+import pytest
+
+from arclith import Arclith
+
+langgraph_graph = pytest.importorskip("langgraph.graph")
+langgraph_memory = pytest.importorskip("langgraph.checkpoint.memory")
+langgraph_store = pytest.importorskip("langgraph.store.memory")
+END = langgraph_graph.END
+START = langgraph_graph.START
+InMemorySaver = langgraph_memory.InMemorySaver
+InMemoryStore = langgraph_store.InMemoryStore
+
+
+class ConversationState(TypedDict):
+    messages: Annotated[list[str], add]
+
+
+def _write_config(tmp_path: Path, *, mode: str = "embedded") -> Path:
+    config_dir = tmp_path / "config"
+    langgraph_config = config_dir / "adapters" / "inbound" / "langgraph.yaml"
+    langgraph_config.parent.mkdir(parents=True)
+    langgraph_config.write_text(
+        f"""entrypoint: "./src/app/adapters/inbound/langgraph/agent.py:agent"
+persistence:
+  enabled: true
+  mode: {mode}
+  checkpointer:
+    adapter: memory
+  store:
+    adapter: memory
+    namespace_template: "{{tenant_id}}:{{user_id}}:memories"
+""",
+        encoding="utf-8",
+    )
+    return config_dir
+
+
+def _register_graph(builder: Any, _arclith: Arclith) -> None:
+    builder.add_node("pass_through", lambda _state: {})
+    builder.add_edge(START, "pass_through")
+    builder.add_edge("pass_through", END)
+
+
+def test_memory_checkpointer_keeps_state_for_same_thread(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path))
+    agent = arclith.langgraph(ConversationState, _register_graph)
+    config = {"configurable": {"thread_id": "thread-stable-1"}}
+
+    first = agent.invoke({"messages": ["first"]}, config)
+    second = agent.invoke({"messages": ["second"]}, config)
+
+    assert first["messages"] == ["first"]
+    assert second["messages"] == ["first", "second"]
+    arclith.close_langgraph_persistence()
+
+
+def test_sqlite_checkpointer_recovers_thread_after_graph_rebuild(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("langgraph.checkpoint.sqlite")
+    config_dir = tmp_path / "config"
+    checkpoint_path = tmp_path / "state" / "checkpoints.sqlite"
+    langgraph_config = config_dir / "adapters" / "inbound" / "langgraph.yaml"
+    langgraph_config.parent.mkdir(parents=True)
+    langgraph_config.write_text(
+        f'''entrypoint: "./src/app/adapters/inbound/langgraph/agent.py:agent"
+persistence:
+  enabled: true
+  mode: embedded
+  checkpointer:
+    adapter: sqlite
+    path: "{checkpoint_path}"
+    setup: true
+  store:
+    adapter: none
+''',
+        encoding="utf-8",
+    )
+    thread_config = {"configurable": {"thread_id": "stable-local-thread"}}
+
+    first_arclith = Arclith(config_dir)
+    first_agent = first_arclith.langgraph(ConversationState, _register_graph)
+    first_agent.invoke({"messages": ["first"]}, thread_config)
+    first_arclith.close_langgraph_persistence()
+
+    second_arclith = Arclith(config_dir)
+    second_agent = second_arclith.langgraph(ConversationState, _register_graph)
+    recovered = second_agent.invoke({"messages": ["second"]}, thread_config)
+
+    assert recovered["messages"] == ["first", "second"]
+    second_arclith.close_langgraph_persistence()
+
+
+def test_memory_store_is_shared_across_threads(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path))
+    agent = arclith.langgraph(ConversationState, _register_graph, persistence=True)
+    namespace = arclith.langgraph_memory_namespace(
+        tenant_id="tenant-a", user_id="user-42"
+    )
+
+    agent.invoke(
+        {"messages": ["remember dark mode"]},
+        {"configurable": {"thread_id": "thread-a"}},
+    )
+    agent.store.put(namespace, "theme", {"value": "dark"})
+    agent.invoke(
+        {"messages": ["new conversation"]},
+        {"configurable": {"thread_id": "thread-b"}},
+    )
+
+    assert agent.store.get(namespace, "theme").value == {"value": "dark"}
+    arclith.close_langgraph_persistence()
+
+
+def test_explicit_checkpointer_and_store_override_yaml(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path))
+    explicit_checkpointer = InMemorySaver()
+    explicit_store = InMemoryStore()
+
+    agent = arclith.langgraph(
+        ConversationState,
+        _register_graph,
+        persistence=True,
+        checkpointer=explicit_checkpointer,
+        store=explicit_store,
+    )
+
+    assert agent.checkpointer is explicit_checkpointer
+    assert agent.store is explicit_store
+    assert "_langgraph_persistence_resources" not in arclith.__dict__
+
+
+def test_explicit_component_only_overrides_its_configured_role(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path))
+    explicit_checkpointer = InMemorySaver()
+
+    agent = arclith.langgraph(
+        ConversationState,
+        _register_graph,
+        persistence=True,
+        checkpointer=explicit_checkpointer,
+    )
+
+    assert agent.checkpointer is explicit_checkpointer
+    assert agent.store.__class__.__name__ == "InMemoryStore"
+    arclith.close_langgraph_persistence()
+
+
+def test_persistence_false_disables_framework_injection(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path))
+
+    agent = arclith.langgraph(
+        ConversationState,
+        _register_graph,
+        persistence=False,
+    )
+
+    assert agent.checkpointer is None
+    assert agent.store is None
+
+
+def test_agent_server_mode_leaves_persistence_to_server(tmp_path: Path) -> None:
+    arclith = Arclith(_write_config(tmp_path, mode="agent_server"))
+
+    agent = arclith.langgraph(
+        ConversationState,
+        _register_graph,
+        persistence=True,
+    )
+
+    assert agent.checkpointer is None
+    assert agent.store is None
+    assert "_langgraph_persistence_resources" not in arclith.__dict__
+
+
+def test_persistence_true_requires_enabled_configuration(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    arclith = Arclith(config_dir)
+
+    with pytest.raises(RuntimeError, match="persistence.enabled=true"):
+        arclith.langgraph(
+            ConversationState,
+            _register_graph,
+            persistence=True,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -122,7 +131,12 @@ all = [
     { name = "hvac" },
     { name = "langgraph" },
     { name = "langgraph-api" },
+    { name = "langgraph-checkpoint-mongodb" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "langgraph-checkpoint-redis" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "langgraph-cli", extra = ["inmem"] },
+    { name = "langgraph-store-mongodb" },
     { name = "langsmith" },
     { name = "motor" },
     { name = "opentelemetry-api" },
@@ -130,6 +144,7 @@ all = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pytz" },
@@ -165,6 +180,20 @@ langgraph = [
     { name = "langgraph-cli", extra = ["inmem"] },
     { name = "langsmith" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
+]
+langgraph-persistence-mongodb = [
+    { name = "langgraph-checkpoint-mongodb" },
+    { name = "langgraph-store-mongodb" },
+]
+langgraph-persistence-postgresql = [
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "psycopg", extra = ["binary", "pool"] },
+]
+langgraph-persistence-redis = [
+    { name = "langgraph-checkpoint-redis" },
+]
+langgraph-persistence-sqlite = [
+    { name = "langgraph-checkpoint-sqlite" },
 ]
 mariadb = [
     { name = "asyncmy" },
@@ -247,8 +276,18 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.8" },
     { name = "langgraph-api", marker = "extra == 'all'", specifier = ">=0.11.0" },
     { name = "langgraph-api", marker = "extra == 'langgraph'", specifier = ">=0.11.0" },
+    { name = "langgraph-checkpoint-mongodb", marker = "extra == 'all'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "langgraph-checkpoint-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-redis", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-checkpoint-redis", marker = "extra == 'langgraph-persistence-redis'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-checkpoint-sqlite", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-sqlite", marker = "extra == 'langgraph-persistence-sqlite'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'all'", specifier = ">=0.4.31" },
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'langgraph'", specifier = ">=0.4.31" },
+    { name = "langgraph-store-mongodb", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "langgraph-store-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "langsmith", marker = "extra == 'langgraph'", specifier = ">=0.4.0" },
     { name = "loguru", specifier = "==0.7.3" },
@@ -264,6 +303,8 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", marker = "extra == 'opentelemetry'", specifier = ">=0.51b0" },
     { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.30.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'all'", specifier = ">=3.2.0,<4.0.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'all'", specifier = ">=2.24.0,<3.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'langgraph'", specifier = ">=2.24.0,<3.0.0" },
@@ -281,7 +322,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1506,6 +1547,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
+]
+
+[[package]]
 name = "jsonpointer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1613,6 +1663,38 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "1.3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
+]
+
+[[package]]
+name = "langchain-classic"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "langsmith" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/65/6b5e8a7ff2f2968652c88a67dcecb925b9d8f0a0ce9458c76cd5a0dbd138/langchain_classic-1.0.8.tar.gz", hash = "sha256:ada0cc341a8a5b80fb24d73bdfaaeb849056ee2d8a41cc468355163fd3667484", size = 10557071, upload-time = "2026-06-10T21:27:54.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/9a/b8f5cb7490fdbf233088031fc69c9c747439d4097f67f196c1eb4869916d/langchain_classic-1.0.8-py3-none-any.whl", hash = "sha256:1a11ea7fbe630c4f2af2f3873d27718ceac9488cf32d0821030be7cf039a6213", size = 1041536, upload-time = "2026-06-10T21:27:52.767Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1633,6 +1715,25 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-mongodb"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-classic" },
+    { name = "langchain-core" },
+    { name = "langchain-text-splitters" },
+    { name = "lark" },
+    { name = "numpy" },
+    { name = "pymongo" },
+    { name = "pymongo-search-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0e/03027bbf0ae3ee71d00e32f5c64395cbee05393e6e5dc56e2d88320db542/langchain_mongodb-0.11.0.tar.gz", hash = "sha256:db483f12e8a4fdbbcfb0594881962fd1f0afcb38a3d42ee0d5fe8a2be20e1e86", size = 356447, upload-time = "2026-01-15T17:00:37.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/a1/a4ef0c7027166540a4aced056b1fd7194e4519932d2a846fd2cfd9f057cb/langchain_mongodb-0.11.0-py3-none-any.whl", hash = "sha256:7e1f43684c907d1f1fee4dbc480dd4909b3ebf03b5d3dad105ed9f4a4280d49f", size = 62037, upload-time = "2026-01-15T17:00:36.258Z" },
+]
+
+[[package]]
 name = "langchain-protocol"
 version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1642,6 +1743,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
+name = "langchain-text-splitters"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
 
 [[package]]
@@ -1720,6 +1833,64 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph-checkpoint-mongodb"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-mongodb" },
+    { name = "langgraph-checkpoint" },
+    { name = "pymongo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/6d/0d4d03cd849fbf191f5440a1048360c6877ce651488ad943643a00071597/langgraph_checkpoint_mongodb-0.4.0.tar.gz", hash = "sha256:21833db58637993b2e4f989d96093cd23f41d13f17b697a12a17f87ad6d987a4", size = 144440, upload-time = "2026-05-12T17:07:24.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/26/ab8f68ba99377b65252adff18e3a973c292b86743a3ba197bbb948f551fd/langgraph_checkpoint_mongodb-0.4.0-py3-none-any.whl", hash = "sha256:f7da2d48cf6adac7c169d88bd70f94358f9f7debdc0cb53b93c417250f589823", size = 8361, upload-time = "2026-05-12T17:07:23.004Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-postgres"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+    { name = "orjson" },
+    { name = "psycopg" },
+    { name = "psycopg-pool" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/52/6e732f7bf702ef4918b64ea4107e7da21d4276b808f9a651fe34be9b0abe/langgraph_checkpoint_postgres-3.1.2.tar.gz", hash = "sha256:1cd404803ff895a2b79f3ac04ce92b775e6b999715f8333fce674c6d927bba95", size = 155091, upload-time = "2026-08-07T20:40:00.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/62/8899c9f4d9b97d5b3eb0c07c13cdf5f63342f15f5ef93eaf3477958df602/langgraph_checkpoint_postgres-3.1.2-py3-none-any.whl", hash = "sha256:6a7e38ef16985b54e356cba7bdaf447943aae33d5aaf290026c593bb6b4a6264", size = 52084, upload-time = "2026-08-07T20:39:58.994Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-redis"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+    { name = "orjson" },
+    { name = "redis" },
+    { name = "redisvl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/40/8eb4cc6d4aeda603783e8abc7695c0791ffcea52dacc2b58b063f02ceb18/langgraph_checkpoint_redis-0.5.2.tar.gz", hash = "sha256:be67fd850b0799e99b10d2c3a2be2b0bda35c45ad0269e1414da30d9a9f97752", size = 120928, upload-time = "2026-08-20T09:05:20.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4c/4b9524c4f451760765be72bac67c45bc3be25dfd126184fa101dffee1c33/langgraph_checkpoint_redis-0.5.2-py3-none-any.whl", hash = "sha256:9347b8806065377fdb72ab3fd94bae97b5c62d092807c0e3633796195a0d333a", size = 132614, upload-time = "2026-08-20T09:05:18.892Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/b1/26fef7572c4fce0322740ef3fcee471510028355d4d4c1d800f0fd432d73/langgraph_checkpoint_sqlite-3.1.1.tar.gz", hash = "sha256:6fcb20db4c37ef7aad52f29b539eb98c38e2dad6fab7c2446a2a9db24f37a70e", size = 146805, upload-time = "2026-07-30T19:19:37.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b9/e458601a1718337839bcfeec9d1b27b8b16ce135be2bd50ed0395d33a878/langgraph_checkpoint_sqlite-3.1.1-py3-none-any.whl", hash = "sha256:8505c54c94a658080525d7e6780fdd4e0c078ff2566b30d399c02cc9f9af1c63", size = 40785, upload-time = "2026-07-30T19:19:36.424Z" },
+]
+
+[[package]]
 name = "langgraph-cli"
 version = "0.4.31"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +1960,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langgraph-store-mongodb"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-mongodb" },
+    { name = "langgraph-checkpoint" },
+    { name = "pymongo-search-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/5d/75fe61110b2644355d21bd85a6b12498ca49bb18be858e4aacd6aa95c917/langgraph_store_mongodb-0.3.0.tar.gz", hash = "sha256:87d1e809f3b317c55c3106c30922246c1336c335d7ebc37d670e00f810c03ae5", size = 110456, upload-time = "2026-05-12T17:18:49.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/8c/e803901b5bb366ed7366b270c8c1b01a294b020297fff818a0de79f00f01/langgraph_store_mongodb-0.3.0-py3-none-any.whl", hash = "sha256:3629892932362d7f43e53bcd0e8ae9bbea01a558fd92a2d5e960c039ff54e65f", size = 10983, upload-time = "2026-05-12T17:18:48.124Z" },
+]
+
+[[package]]
 name = "langsmith"
 version = "0.10.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1818,6 +2003,15 @@ otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -2087,6 +2281,42 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/72/307d7c4bd0600601c7133fba5cb78af7db968152951c1cd473abb1cda782/ml_dtypes-0.6.0.tar.gz", hash = "sha256:5e60251d32ced5598972e4d5e06a2f044341f9291402551a3f6f0ec44f9299b0", size = 3032327, upload-time = "2026-08-13T14:14:40.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/51/fd1582b8f5ed8a9e7be0e161a6ea0dff70cb280479a12178df0b3a72700e/ml_dtypes-0.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:084dfe51a7ad58b171f05115f8226ed4233a454a1611371947e806e76f0c638d", size = 565468, upload-time = "2026-08-13T14:14:08.5Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/22/20fd70ca6ed12446cb92d5b2a7745bd185f9d8b8cdeeadad976574398e6b/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28d676428b104bb9717b0928bc5c5129f2d6b51b6727587cc4289e7bf8713cb5", size = 360232, upload-time = "2026-08-13T14:14:09.873Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a5/da8ae6c6f1babe4b68e3e55d43d39b529e29774f10e0910671a6b8c86eb8/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26b1f1fa4f0435a2946859823f6e2bf06796f1e9f10f5a05b08a5e3c8f46ff69", size = 410169, upload-time = "2026-08-13T14:14:11.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/55/4561acefa00fa4bcbfb82ca6a48578b41f372cd7dd7cdd6eb4720abc2e5f/ml_dtypes-0.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:fb87f46b4f7ad7b5d3ad8f4b452b024bd4229d44c8ff934798c1fe656210387a", size = 439357, upload-time = "2026-08-13T14:14:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5d/6a01538e507ef0ed5e879985b13a92467bf8960696fb1131f8b8cadc60ff/ml_dtypes-0.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:57ed0d6b4ac5e7868361303a9c57fbcf63b768236ee14456f585dfcf260d0292", size = 552278, upload-time = "2026-08-13T14:14:13.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7a/97dc35667b7c9db33c5344c673cd27f87e34771875ea7100138726132ac9/ml_dtypes-0.6.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:84fa136b8602c8c39e3b6cb24918960cd6f36cade7a70376f56770729cd56510", size = 562551, upload-time = "2026-08-13T14:14:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/77f0ede10558d0d935da2e3276ed7e9c8cc2bad3463b9a0b66b03fc60be2/ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:317be9967fb84b0ce4e80e6b1bf71213d21971621cf6f1e501a63602a95297bf", size = 360334, upload-time = "2026-08-13T14:14:16.079Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b1/1831dd8c9b06c013085d31a2ac4f03392d43bd36bfc6ff591a08bcedc1cf/ml_dtypes-0.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f490c003369ce60e514a0c3b12374f05274c101fee1bead6740ec8a564032b0", size = 409966, upload-time = "2026-08-13T14:14:17.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ad/9c32c53f823dda3742df19a79c10bc198365937873ea125ba65747440c23/ml_dtypes-0.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:d574c2b28921dc72e869df248f1a278f6eee176a1f237c8642e1a71eb15f3977", size = 457224, upload-time = "2026-08-13T14:14:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/dd98205418a13353d41c52bf5326d8cbec515aace46174e23c6ea01c2978/ml_dtypes-0.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:f4adb4af61516510d786cf8c01851a66f6d3ddfa79e1144deaa5b40d8507231e", size = 568378, upload-time = "2026-08-13T14:14:19.843Z" },
+    { url = "https://files.pythonhosted.org/packages/65/36/32e7beef3281fed74883451477ad976364323206dbfaa95e948ba788dac7/ml_dtypes-0.6.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3e169214e0d80ff1c038e1b3017e33c23e43bdf948d42d31de8283111c7e2fa3", size = 590177, upload-time = "2026-08-13T14:14:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/99b3d9b3c984b3bd1e81d8244f1fa2f812e44060d853205b2df6271aa17c/ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:573b11f3c327e17ef3826d266e676cf1149a1f3016f822a05f2306c55d8246bf", size = 363142, upload-time = "2026-08-13T14:14:22.463Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fb/8091c0aee7f2712de99c7fd4b1642382644dec6a4962effe4f5b9d16a973/ml_dtypes-0.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b76fa1d3f92967d58289ac47ab7458ede66e6f3527fff3e59142aee57d9307cd", size = 430645, upload-time = "2026-08-13T14:14:23.737Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/962d2c589513b5930d05b6eae5fbd22ad8bbcf26bb763449f3d8f912360f/ml_dtypes-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3be9911d953f97cddded4b9961d7b650473b7e55806d20f6176f8356dfe7b38e", size = 465667, upload-time = "2026-08-13T14:14:25.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/bcb25e246edd19af5fa1cf6267040bd9977a7afca846e6cfd4a52078b44f/ml_dtypes-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e74266ca8e97874a937b7646378c178025650a236584f7474d10d8086a6edea3", size = 572706, upload-time = "2026-08-13T14:14:26.296Z" },
+    { url = "https://files.pythonhosted.org/packages/12/42/46cb442648e3c774d8cb25f2e1e41d496cdcc91fbe9c2a6f75c0b8df7af6/ml_dtypes-0.6.0-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b1b503864fada3f74fabf8d9fee7b4c1cbe956301e6fdece975d5f77c2fce958", size = 562550, upload-time = "2026-08-13T14:14:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/07/56/844eff5af7a2d1a09d75df12c70225c3a6b6a771f95876b2bf5f7d10ad44/ml_dtypes-0.6.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c6ad60af4102789a5c09824004beade2f7f28cd1cd581ee5c170d9dc2fbb00e", size = 360332, upload-time = "2026-08-13T14:14:28.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/29/b7165a3a76364a5baa6aa4ee82a0adf73a3c014b8cd126120b62cc087992/ml_dtypes-0.6.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4f1b9329a251e4affe3bb58f4d3e2db22a714396fd7ffb40d0b5db423c24d17", size = 409964, upload-time = "2026-08-13T14:14:30.023Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2e/f61c54a0544b6a170ac1bb89bcf406af53fb2deffc5476b6d2d3df5ba13e/ml_dtypes-0.6.0-cp315-cp315-win_amd64.whl", hash = "sha256:488c99ab181a2f59d9ec3b12c5fa11ec904e92be2c4ba18cded54dd7501208fe", size = 457249, upload-time = "2026-08-13T14:14:31.213Z" },
+    { url = "https://files.pythonhosted.org/packages/63/00/bee1bc9faa02a46e7a851019fd23f47ca1f906609edbec8b6ba5decc3cc3/ml_dtypes-0.6.0-cp315-cp315-win_arm64.whl", hash = "sha256:de9d14748dbf3968951436ef514a29c9d1fe438aa680d110134ee2f7a9f9df18", size = 568381, upload-time = "2026-08-13T14:14:32.548Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/9a5edede28f73185fd51d75030ef7f11d76997bab3a92427d986e54fe2eb/ml_dtypes-0.6.0-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e25bb3b0ad1217b60626e4ed45b10ca170c41d99fbe44a12bebc1e07ec4aad55", size = 589877, upload-time = "2026-08-13T14:14:33.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/81/d5924a141b850b606eb027493c9c3ca3c665cca5163af3f5b6e5e3345503/ml_dtypes-0.6.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31f1ce979d31a357e95aa81812f20412c8c954fa43c44ee3ead1e1c8a78575ef", size = 362788, upload-time = "2026-08-13T14:14:34.996Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8f/3298e3f334832bc28dd144af6b99cdc93502a8687e71922ea68b0a319929/ml_dtypes-0.6.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2d6149f3a57f405bcad5fb41e03218b8373936253f23e1ca84c0108abbc3392", size = 430823, upload-time = "2026-08-13T14:14:36.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d2/f2dbf118f42ce4c325a139c9236737f436b7f8e00cd18701c99ef2405e6f/ml_dtypes-0.6.0-cp315-cp315t-win_amd64.whl", hash = "sha256:ce7563e0b1a4482cbc1b4a6272145e54e4489e54fe7428f94908c3d87103abfa", size = 465119, upload-time = "2026-08-13T14:14:37.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/bda40387b5c5c64254595f4d81a12351770856acc5de4e6d43606a31f161/ml_dtypes-0.6.0-cp315-cp315t-win_arm64.whl", hash = "sha256:f6cb525101b6b903779188c1e9e9490c343b455ab822883e02cf01e5547338d2", size = 572666, upload-time = "2026-08-13T14:14:38.993Z" },
+]
+
+[[package]]
 name = "more-itertools"
 version = "10.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2248,6 +2478,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
 ]
 
 [[package]]
@@ -2722,6 +3014,67 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2985,6 +3338,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pymongo-search-utils"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymongo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/aa/3eb266ffc74ec52bbf6dd92d311ab4fc3225c2ac8f1a2e6abe98f7288867/pymongo_search_utils-0.3.0.tar.gz", hash = "sha256:56148987ce9ff191eb1cd0f56c01d3dae497a3cb6d7b7db75ec894a9afcbe418", size = 13728, upload-time = "2026-02-03T22:18:24.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/ed/87d3ed0e45b9230bacb9edcb913d515e6756bc2df3384e5f192662c38ce8/pymongo_search_utils-0.3.0-py3-none-any.whl", hash = "sha256:9b9ef8dfbd57da530ce7c2bde10aec8f462605080a9ed4e9a41679170c8742bf", size = 19467, upload-time = "2026-02-03T22:18:23.398Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3063,6 +3428,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/41/65079023c81491a21799c0120bce5925366b6913596bf797806f19973290/python_ulid-4.0.1.tar.gz", hash = "sha256:bbeec02556190bb9dc3401faa7268696acbfbe7b6db9908c155dc3548629f20c", size = 101683, upload-time = "2026-07-20T15:21:41.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/15/8b39b36f55b6618ec4ca9b55134dcfd9c04cecbc72709f5d8e6bdebed9cd/python_ulid-4.0.1-py3-none-any.whl", hash = "sha256:6f1d69ceb97e99fe542df8476ebcd7a668284bf53ee14b3106bcc6a341a95ed9", size = 14609, upload-time = "2026-07-20T15:21:40.214Z" },
 ]
 
 [[package]]
@@ -3164,6 +3538,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
+name = "redisvl"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpath-ng" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "python-ulid" },
+    { name = "pyyaml" },
+    { name = "redis" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/23/7ffb5e1575e414fb324d3f64ac2ed6de70f2eea9d9381909547dd2305719/redisvl-0.26.0.tar.gz", hash = "sha256:db87fba908f33ab43b6d0dae5c9b3df59eb6b65166ee9e69b646a355a7bd86ed", size = 1273455, upload-time = "2026-08-19T15:54:07.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/91392718021582b5599b96787203cfb77a3db1244bcf08c855e1d748cdf5/redisvl-0.26.0-py3-none-any.whl", hash = "sha256:c3738695c4af0c46ff1ae96503f490c4e921936cbe66c5bbd61b689011a4332b", size = 396624, upload-time = "2026-08-19T15:54:06.062Z" },
 ]
 
 [[package]]
@@ -3487,6 +3880,18 @@ asyncio = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3627,6 +4032,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Résumé

- ajoute la configuration optionnelle `langgraph.persistence` et une factory lazy/extensible pour checkpointers et stores
- fournit les backends memory, SQLite, PostgreSQL, MongoDB et Redis via des extras granulaires, avec registry et import path custom
- câble `Arclith.langgraph(..., persistence=True)` en respectant la priorité des objets explicites et en laissant l'Agent Server gérer sa propre persistance
- ajoute la capability CLI `agent-persistence`, fusionnée sans écraser la configuration LangGraph existante, avec mise à jour idempotente des extras
- documente les profils embedded/Agent Server, les namespaces, le lifecycle, les secrets, MongoDB replica set et l'inspection `/threads/{id}/state`

## Validation

- `make quality` : 575 tests réussis, 1 intégration RabbitMQ ignorée, couverture 91,30 %
- suite CLI : 111 tests réussis, 1 test conditionnel ignoré dans l'environnement CLI seul
- `make docs` : build MkDocs strict réussi
- wheel installé sans extras : `import arclith` réussi et backends LangGraph absents

Les backends PostgreSQL, MongoDB et Redis sont validés au niveau factory sans connexion live ni credentials externes.

Closes #182
