### PR TITLE
feat(observability): add optional LangSmith runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@
 - **Persistance agent LangGraph** — capability optionnelle `agent-persistence`, configuration
   checkpointer/store, registry custom, wiring embedded/Agent Server et extras SQLite, PostgreSQL,
   MongoDB et Redis granulaires.
+- **Runtime LangSmith optionnel** — port `TracePort` provider-neutral, tracer no-op, configuration
+  programmatique du client, contexte conditionnel, sampling, confidentialité, propagation
+  FastAPI/FastMCP/RabbitMQ, cycle de vie flush/close et escape hatch `langsmith_client()`.
+- **Instrumentation agents** — `Arclith.langgraph()` initialise le contexte LangSmith et
+  `Arclith.pydantic_ai_llm()` injecte l'instrumentation OpenTelemetry dans les seuls agents Pydantic
+  AI construits par Arclith.
+- **Profils CLI LangSmith** — profils `development` et `production`, génération de `.env.example`
+  sans secret et ajout idempotent de l'extra `arclith[langsmith]`.
+
+### Changed
+
+- **Extra LangSmith dédié** — `langsmith[otel]>=0.10,<1` quitte la déclaration directe de l'extra
+  `langgraph`. Les projets utilisant explicitement LangSmith doivent ajouter
+  `arclith[langsmith]`; `arclith[all]` continue de l'inclure.
+- **Coexistence OpenTelemetry** — lorsque les deux adapters sont actifs, LangSmith utilise
+  obligatoirement le mode `otel` et ajoute un processor au provider partagé afin d'éviter les spans
+  dupliqués.
+
+### Security
+
+- **Capture sûre par défaut** — inputs, outputs, prompts, réponses, binaires et paramètres modèle
+  sont masqués; le baggage est vide sans allowlist et la CLI refuse toute clé LangSmith en argument.
 
 ---
 

--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -33,6 +33,11 @@ from arclith.domain.ports.outbound.file_storage import (
     normalize_storage_key,
 )
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
+from arclith.domain.ports.outbound.observability import (
+    TraceAnonymizer,
+    TracePort,
+    TraceSpan,
+)
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.adapter_registry import AdapterRegistry
 from arclith.infrastructure.config import (
@@ -66,7 +71,7 @@ from arclith.infrastructure.repository_factory import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
-    from arclith.adapters.outbound.console.logger import ConsoleLogger as _ConsoleLogger, ConsoleLogger  # noqa: F401
+    from arclith.adapters.outbound.console.logger import ConsoleLogger  # noqa: F401
 
 __all__ = [
     "Entity",
@@ -92,6 +97,9 @@ __all__ = [
     "GCSStorageConfig",
     "Logger",
     "LogLevel",
+    "TracePort",
+    "TraceSpan",
+    "TraceAnonymizer",
     "BaseService",
     "CommandDispatcher",
     "CommandEnvelope",

--- a/arclith/adapters/bidirectional/rabbitmq/command_bus.py
+++ b/arclith/adapters/bidirectional/rabbitmq/command_bus.py
@@ -15,6 +15,7 @@ from arclith.application.command_bus import (
 )
 from arclith.domain.ports.outbound.command_bus import CommandPublisher
 from arclith.domain.ports.outbound.logger import Logger
+from arclith.domain.ports.outbound.observability import TracePort
 from arclith.infrastructure.config import RabbitMQCommandBusSettings
 
 type AioPikaModule = Any
@@ -29,11 +30,17 @@ class RabbitMQCommandBus(CommandPublisher):
         settings: RabbitMQCommandBusSettings,
         logger: Logger,
         *,
+        tracer: TracePort | None = None,
         connector: Connector | None = None,
         aio_pika_module: AioPikaModule | None = None,
     ) -> None:
         self._settings = settings
         self._logger = logger
+        if tracer is None:
+            from arclith.adapters.outbound.noop.observability import NoOpTraceAdapter
+
+            tracer = NoOpTraceAdapter()
+        self._tracer = tracer
         self._connector = connector
         self._aio_pika = aio_pika_module
         self._connection: Any | None = None
@@ -92,25 +99,39 @@ class RabbitMQCommandBus(CommandPublisher):
             raise RuntimeError("RabbitMQ exchange non initialise")
 
         aio_pika = self._load_aio_pika()
-        message_headers = self._message_headers(
-            command_type,
-            headers=headers,
-            correlation_id=correlation_id,
-        )
-        message = aio_pika.Message(
-            body=encode_command_message(
-                CommandEnvelope(
-                    command_type=command_type,
-                    payload=dict(payload),
-                    headers=message_headers,
-                )
-            ),
-            content_type="application/json",
-            delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
-            headers=message_headers,
-            correlation_id=message_headers["correlation_id"],
-        )
-        await self._exchange.publish(message, routing_key=routing_key or self._settings.routing_key)
+        with self._tracer.span(
+            "rabbitmq.publish",
+            kind="tool",
+            metadata={
+                "messaging.system": "rabbitmq",
+                "messaging.destination.name": self._settings.exchange,
+                "messaging.operation.name": "publish",
+                "messaging.command.type": command_type,
+            },
+        ) as span:
+            message_headers = self._message_headers(
+                command_type,
+                headers=headers,
+                correlation_id=correlation_id,
+            )
+            message = aio_pika.Message(
+                body=encode_command_message(
+                    CommandEnvelope(
+                        command_type=command_type,
+                        payload=dict(payload),
+                        headers=message_headers,
+                    )
+                ),
+                content_type="application/json",
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                headers=message_headers,
+                correlation_id=message_headers["correlation_id"],
+            )
+            await self._exchange.publish(
+                message,
+                routing_key=routing_key or self._settings.routing_key,
+            )
+            span.set_outputs({"status": "published"})
 
     async def handle_message(self, message: Any, dispatcher: CommandDispatcher) -> None:
         headers = self._headers_from_message(message)
@@ -135,25 +156,47 @@ class RabbitMQCommandBus(CommandPublisher):
             )
             return
 
-        try:
-            await dispatcher.dispatch(envelope)
-        except Exception as exc:
-            await message.nack(requeue=self._settings.retry_enabled and self._settings.retry_requeue)
-            self._logger.error(
-                "RabbitMQ command rejected",
-                command_type=fallback_command_type,
-                correlation_id=headers.get("correlation_id"),
-                retry_requeue=self._settings.retry_requeue,
-                error=str(exc),
-            )
-            return
+        with self._tracer.context(
+            parent=headers,
+            metadata={"correlation.id": headers.get("correlation_id", "")},
+        ):
+            with self._tracer.span(
+                "rabbitmq.process",
+                kind="chain",
+                metadata={
+                    "messaging.system": "rabbitmq",
+                    "messaging.destination.name": self._settings.queue,
+                    "messaging.operation.name": "process",
+                    "messaging.command.type": fallback_command_type,
+                },
+            ) as span:
+                try:
+                    await dispatcher.dispatch(envelope)
+                except Exception as exc:
+                    await message.nack(
+                        requeue=(
+                            self._settings.retry_enabled
+                            and self._settings.retry_requeue
+                        )
+                    )
+                    self._logger.error(
+                        "RabbitMQ command rejected",
+                        command_type=fallback_command_type,
+                        correlation_id=headers.get("correlation_id"),
+                        retry_requeue=self._settings.retry_requeue,
+                        error=str(exc),
+                    )
+                    span.set_metadata({"error.type": type(exc).__name__})
+                    span.set_outputs({"status": "rejected"})
+                    return
 
-        await message.ack()
-        self._logger.info(
-            "RabbitMQ command acknowledged",
-            command_type=fallback_command_type,
-            correlation_id=headers.get("correlation_id"),
-        )
+                await message.ack()
+                span.set_outputs({"status": "acknowledged"})
+                self._logger.info(
+                    "RabbitMQ command acknowledged",
+                    command_type=fallback_command_type,
+                    correlation_id=headers.get("correlation_id"),
+                )
 
     async def run(self, dispatcher: CommandDispatcher) -> None:
         await self.connect()
@@ -163,10 +206,14 @@ class RabbitMQCommandBus(CommandPublisher):
         semaphore = asyncio.Semaphore(self._settings.concurrency)
         tasks: set[asyncio.Task[None]] = set()
 
-        async with self._queue.iterator(consumer_tag=self._settings.consumer_name) as queue_iter:
+        async with self._queue.iterator(
+            consumer_tag=self._settings.consumer_name
+        ) as queue_iter:
             async for message in queue_iter:
                 await semaphore.acquire()
-                task = asyncio.create_task(self._handle_with_semaphore(message, dispatcher, semaphore))
+                task = asyncio.create_task(
+                    self._handle_with_semaphore(message, dispatcher, semaphore)
+                )
                 tasks.add(task)
                 task.add_done_callback(tasks.discard)
 
@@ -197,6 +244,7 @@ class RabbitMQCommandBus(CommandPublisher):
         traceparent = self._current_traceparent()
         if traceparent:
             normalized.setdefault("traceparent", traceparent)
+        self._tracer.inject(normalized)
         return normalized
 
     @staticmethod

--- a/arclith/adapters/outbound/langsmith/__init__.py
+++ b/arclith/adapters/outbound/langsmith/__init__.py
@@ -1,0 +1,3 @@
+from arclith.adapters.outbound.langsmith.runtime import LangSmithRuntime
+
+__all__ = ["LangSmithRuntime"]

--- a/arclith/adapters/outbound/langsmith/config.py
+++ b/arclith/adapters/outbound/langsmith/config.py
@@ -36,9 +36,9 @@ def resolve_langsmith_config(settings: LangSmithSettings) -> ResolvedLangSmithCo
             "LANGSMITH_TRACING_SAMPLING_RATE doit etre compris entre 0.0 et 1.0"
         )
 
-    tracing_mode_raw = (
-        os.getenv("LANGSMITH_TRACING_MODE", settings.tracing.mode).strip().lower()
-    )
+    tracing_mode_raw = _env_string(
+        "LANGSMITH_TRACING_MODE", settings.tracing.mode
+    ).lower()
     if tracing_mode_raw not in _TRACING_MODES:
         allowed = ", ".join(sorted(_TRACING_MODES))
         raise RuntimeError(f"LANGSMITH_TRACING_MODE invalide. Valeurs: {allowed}")
@@ -68,8 +68,8 @@ def resolve_langsmith_config(settings: LangSmithSettings) -> ResolvedLangSmithCo
         workspace_id = os.getenv(settings.workspace_id_env, "").strip()
 
     return ResolvedLangSmithConfig(
-        project=os.getenv("LANGSMITH_PROJECT", settings.project).strip(),
-        endpoint=os.getenv("LANGSMITH_ENDPOINT", settings.endpoint).strip(),
+        project=_env_string("LANGSMITH_PROJECT", settings.project),
+        endpoint=_env_string("LANGSMITH_ENDPOINT", settings.endpoint),
         api_key=api_key,
         workspace_id=workspace_id or None,
         tracing_enabled=tracing_enabled,
@@ -88,6 +88,13 @@ def resolve_langsmith_config(settings: LangSmithSettings) -> ResolvedLangSmithCo
             not settings.capture.metadata,
         ),
     )
+
+
+def _env_string(name: str, default: str) -> str:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip()
 
 
 def _env_bool(name: str, default: bool) -> bool:

--- a/arclith/adapters/outbound/langsmith/config.py
+++ b/arclith/adapters/outbound/langsmith/config.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+from arclith.infrastructure.config import LangSmithSettings
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_TRACING_MODES = frozenset({"langsmith", "otel", "hybrid"})
+
+
+@dataclass(frozen=True)
+class ResolvedLangSmithConfig:
+    project: str
+    endpoint: str
+    api_key: str = field(repr=False)
+    workspace_id: str | None = None
+    tracing_enabled: bool = True
+    tracing_mode: Literal["langsmith", "otel", "hybrid"] = "otel"
+    sampling_rate: float = 1.0
+    capture_inputs: bool = False
+    capture_outputs: bool = False
+    capture_metadata: bool = True
+
+
+def resolve_langsmith_config(settings: LangSmithSettings) -> ResolvedLangSmithConfig:
+    tracing_enabled = _env_bool("LANGSMITH_TRACING", settings.tracing.enabled)
+    sampling_rate = _env_float(
+        "LANGSMITH_TRACING_SAMPLING_RATE",
+        settings.tracing.sampling_rate,
+    )
+    if not 0.0 <= sampling_rate <= 1.0:
+        raise RuntimeError(
+            "LANGSMITH_TRACING_SAMPLING_RATE doit etre compris entre 0.0 et 1.0"
+        )
+
+    tracing_mode_raw = (
+        os.getenv("LANGSMITH_TRACING_MODE", settings.tracing.mode).strip().lower()
+    )
+    if tracing_mode_raw not in _TRACING_MODES:
+        allowed = ", ".join(sorted(_TRACING_MODES))
+        raise RuntimeError(f"LANGSMITH_TRACING_MODE invalide. Valeurs: {allowed}")
+    tracing_mode: Literal["langsmith", "otel", "hybrid"]
+    if tracing_mode_raw == "otel":
+        tracing_mode = "otel"
+    elif tracing_mode_raw == "hybrid":
+        tracing_mode = "hybrid"
+    else:
+        tracing_mode = "langsmith"
+
+    api_key = os.getenv("LANGSMITH_API_KEY", "").strip()
+    if not api_key:
+        api_key = os.getenv(settings.api_key_env, "").strip()
+    if not api_key:
+        key_hint = "LANGSMITH_API_KEY"
+        if settings.api_key_env != key_hint:
+            key_hint = f"{key_hint} ou {settings.api_key_env}"
+        raise RuntimeError(
+            "LangSmith est active mais aucune cle API n'est disponible. "
+            f"Definissez {key_hint}, "
+            "ou retirez langsmith de adapters.observability.enabled."
+        )
+
+    workspace_id = os.getenv("LANGSMITH_WORKSPACE_ID", "").strip()
+    if not workspace_id:
+        workspace_id = os.getenv(settings.workspace_id_env, "").strip()
+
+    return ResolvedLangSmithConfig(
+        project=os.getenv("LANGSMITH_PROJECT", settings.project).strip(),
+        endpoint=os.getenv("LANGSMITH_ENDPOINT", settings.endpoint).strip(),
+        api_key=api_key,
+        workspace_id=workspace_id or None,
+        tracing_enabled=tracing_enabled,
+        tracing_mode=tracing_mode,
+        sampling_rate=sampling_rate,
+        capture_inputs=not _env_bool(
+            "LANGSMITH_HIDE_INPUTS",
+            not settings.capture.inputs,
+        ),
+        capture_outputs=not _env_bool(
+            "LANGSMITH_HIDE_OUTPUTS",
+            not settings.capture.outputs,
+        ),
+        capture_metadata=not _env_bool(
+            "LANGSMITH_HIDE_METADATA",
+            not settings.capture.metadata,
+        ),
+    )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise RuntimeError(f"{name} doit etre un booleen (true/false)")
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise RuntimeError(f"{name} doit etre un nombre") from None

--- a/arclith/adapters/outbound/langsmith/fastapi.py
+++ b/arclith/adapters/outbound/langsmith/fastapi.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from arclith.domain.ports.outbound.observability import TracePort
+
+
+def instrument_fastapi_app(app: "FastAPI", tracer: "TracePort") -> None:
+    try:
+        from starlette.middleware.base import BaseHTTPMiddleware
+    except ImportError as exc:
+        raise RuntimeError(
+            'L\'instrumentation FastAPI LangSmith requiert "arclith[fastapi,langsmith]".'
+        ) from exc
+
+    class LangSmithTracingMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Any, call_next: Any) -> Any:
+            parent = {
+                key.lower(): value
+                for key, value in request.headers.items()
+                if key.lower() in {"langsmith-trace", "traceparent", "baggage"}
+            }
+            with tracer.context(parent=parent):
+                with tracer.span(
+                    "http.server.request",
+                    kind="chain",
+                    metadata={
+                        "http.request.method": request.method,
+                        "url.scheme": request.url.scheme,
+                    },
+                ) as span:
+                    response = await call_next(request)
+                    route = request.scope.get("route")
+                    route_path = getattr(route, "path", None)
+                    metadata: dict[str, object] = {
+                        "http.response.status_code": response.status_code,
+                    }
+                    if route_path:
+                        metadata["http.route"] = route_path
+                    span.set_metadata(metadata)
+                    span.set_outputs({"status_code": response.status_code})
+                    return response
+
+    app.add_middleware(LangSmithTracingMiddleware)

--- a/arclith/adapters/outbound/langsmith/privacy.py
+++ b/arclith/adapters/outbound/langsmith/privacy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+
+def trace_payload(value: object | None, *, enabled: bool) -> dict[str, Any]:
+    if not enabled or value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return {str(key): _safe_value(item) for key, item in value.items()}
+    return {"value": _safe_value(value)}
+
+
+def trace_metadata(
+    value: Mapping[str, object] | None,
+    *,
+    enabled: bool,
+) -> dict[str, Any]:
+    if not enabled or value is None:
+        return {}
+    return {str(key): _safe_value(item) for key, item in value.items()}
+
+
+def _safe_value(value: object) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, bytes | bytearray | memoryview):
+        return "<binary omitted>"
+    if isinstance(value, Mapping):
+        return {str(key): _safe_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_safe_value(item) for item in value]
+    return _safe_object(value)
+
+
+def _safe_object(value: object) -> Any:
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _safe_value(model_dump(mode="json"))
+    if is_dataclass(value) and not isinstance(value, type):
+        return _safe_value(asdict(value))
+    return str(value)

--- a/arclith/adapters/outbound/langsmith/propagation.py
+++ b/arclith/adapters/outbound/langsmith/propagation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+from collections.abc import Mapping
+
+_LANGSMITH_TRACE = "langsmith-trace"
+_BAGGAGE = "baggage"
+_TRACEPARENT = "traceparent"
+
+
+def normalized_parent_headers(
+    headers: Mapping[str, str] | None,
+    *,
+    allowlist: set[str],
+    langsmith_headers: bool,
+    traceparent: bool,
+) -> dict[str, str]:
+    if not headers:
+        return {}
+    normalized = {str(key).lower(): str(value) for key, value in headers.items()}
+    result: dict[str, str] = {}
+    if langsmith_headers and normalized.get(_LANGSMITH_TRACE):
+        result[_LANGSMITH_TRACE] = normalized[_LANGSMITH_TRACE]
+    if traceparent and normalized.get(_TRACEPARENT):
+        result[_TRACEPARENT] = normalized[_TRACEPARENT]
+    baggage = filter_baggage(normalized.get(_BAGGAGE, ""), allowlist=allowlist)
+    if baggage:
+        result[_BAGGAGE] = baggage
+    return result
+
+
+def filter_baggage(value: str, *, allowlist: set[str]) -> str:
+    if not value or not allowlist:
+        return ""
+    filtered: list[str] = []
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        safe_item = _filtered_baggage_item(item, allowlist=allowlist)
+        if safe_item:
+            filtered.append(safe_item)
+    return ",".join(filtered)
+
+
+def _filtered_baggage_item(item: str, *, allowlist: set[str]) -> str | None:
+    key, separator, encoded = item.partition("=")
+    if separator != "=" or not key:
+        return None
+    if key == "langsmith-metadata":
+        metadata = _filtered_metadata(encoded, allowlist=allowlist)
+        if not metadata:
+            return None
+        serialized = json.dumps(metadata, separators=(",", ":"), sort_keys=True)
+        return f"{key}={urllib.parse.quote(serialized)}"
+    aliases = {"langsmith-tags": "tags", "langsmith-project": "project"}
+    allowed_key = aliases.get(key, key)
+    return item if allowed_key in allowlist else None
+
+
+def merge_baggage(*values: str) -> str:
+    items: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for raw_item in value.split(","):
+            item = raw_item.strip()
+            key = item.partition("=")[0]
+            if item and key not in seen:
+                seen.add(key)
+                items.append(item)
+    return ",".join(items)
+
+
+def _filtered_metadata(encoded: str, *, allowlist: set[str]) -> dict[str, object]:
+    try:
+        loaded = json.loads(urllib.parse.unquote(encoded))
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(key): value for key, value in loaded.items() if str(key) in allowlist}

--- a/arclith/adapters/outbound/langsmith/runtime.py
+++ b/arclith/adapters/outbound/langsmith/runtime.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
+from contextlib import ExitStack, contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+from arclith.adapters.outbound.langsmith.config import (
+    ResolvedLangSmithConfig,
+    resolve_langsmith_config,
+)
+from arclith.adapters.outbound.langsmith.privacy import trace_metadata, trace_payload
+from arclith.adapters.outbound.langsmith.propagation import (
+    filter_baggage,
+    merge_baggage,
+    normalized_parent_headers,
+)
+from arclith.adapters.outbound.noop.observability import NoOpTraceSpan
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.domain.ports.outbound.observability import (
+    TraceAnonymizer,
+    TracePort,
+    TraceSpan,
+)
+from arclith.infrastructure.config import LangSmithSettings
+
+_RUN_TYPES = frozenset(
+    {"chain", "llm", "tool", "retriever", "embedding", "prompt", "parser"}
+)
+
+
+class LangSmithTraceSpan(TraceSpan):
+    def __init__(self, run_tree: Any, resolved: ResolvedLangSmithConfig) -> None:
+        self._run_tree = run_tree
+        self._resolved = resolved
+
+    def set_outputs(self, outputs: object | None) -> None:
+        self._run_tree.end(
+            outputs=trace_payload(outputs, enabled=self._resolved.capture_outputs)
+        )
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        if not self._resolved.capture_metadata:
+            return
+        self._run_tree.metadata.update(trace_metadata(metadata, enabled=True))
+
+
+class LangSmithRuntime(TracePort):
+    """Lazy LangSmith runtime. LangSmith imports remain confined to this adapter."""
+
+    def __init__(
+        self,
+        settings: LangSmithSettings,
+        logger: Logger,
+        *,
+        service_metadata: Mapping[str, object] | None = None,
+        opentelemetry_enabled: bool = False,
+        anonymizer: TraceAnonymizer | None = None,
+        before_start: Callable[[], None] | None = None,
+    ) -> None:
+        self.settings = settings
+        self._logger = logger
+        self._service_metadata = dict(service_metadata or {})
+        self._opentelemetry_enabled = opentelemetry_enabled
+        self._anonymizer = anonymizer
+        self._before_start = before_start
+        self._lock = threading.RLock()
+        self._started = False
+        self._closed = False
+        self._client: Any | None = None
+        self._langsmith: Any | None = None
+        self._resolved: ResolvedLangSmithConfig | None = None
+        self._otel_provider: Any | None = None
+        self._otel_processor: Any | None = None
+        self._owns_otel_provider = False
+        self._reported_errors: set[str] = set()
+        self._enabled_override: ContextVar[bool | None] = ContextVar(
+            "arclith_langsmith_enabled",
+            default=None,
+        )
+
+    def start(self) -> None:
+        with self._lock:
+            if self._started:
+                return
+            if self._closed:
+                raise RuntimeError("Le runtime LangSmith est deja ferme")
+            resolved = resolve_langsmith_config(self.settings)
+            try:
+                import langsmith
+            except ImportError as exc:
+                raise RuntimeError(
+                    "observability.enabled contient langsmith; installez l'extra "
+                    '"arclith[langsmith]".'
+                ) from exc
+
+            if self._before_start is not None:
+                self._before_start()
+
+            self._langsmith = langsmith
+            self._resolved = resolved
+            self._client = langsmith.Client(
+                api_url=resolved.endpoint,
+                api_key=resolved.api_key,
+                workspace_id=resolved.workspace_id,
+                anonymizer=self._anonymizer,
+                hide_inputs=not resolved.capture_inputs,
+                hide_outputs=not resolved.capture_outputs,
+                hide_metadata=not resolved.capture_metadata,
+                tracing_mode=resolved.tracing_mode,
+                tracing_sampling_rate=resolved.sampling_rate,
+                tracing_error_callback=self._on_export_error,
+            )
+            langsmith.configure(
+                client=self._client,
+                enabled=(
+                    resolved.tracing_enabled
+                    and resolved.sampling_rate > 0
+                    and self.settings.instrumentation.langgraph
+                ),
+                project_name=resolved.project,
+                tags=list(self.settings.tags),
+                metadata=self._default_metadata(),
+            )
+            self._started = True
+            if self._opentelemetry_enabled and resolved.tracing_mode == "otel":
+                self._attach_to_current_otel_provider()
+            self._diagnostic(
+                "LangSmith runtime initialise",
+                project=resolved.project,
+                endpoint=resolved.endpoint,
+                tracing=resolved.tracing_enabled,
+                tracing_mode=resolved.tracing_mode,
+                sampling_rate=resolved.sampling_rate,
+            )
+
+    def client(self) -> Any:
+        self.start()
+        return self._client
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        self.start()
+        resolved = self._require_resolved()
+        override = self._enabled_override.get()
+        if override is False or (override is None and not resolved.tracing_enabled):
+            yield NoOpTraceSpan()
+            return
+
+        opened = self._open_span(name, kind, inputs, tags, metadata)
+        if opened is None:
+            yield NoOpTraceSpan()
+            return
+
+        trace_context, run_tree = opened
+        span = LangSmithTraceSpan(run_tree, resolved)
+        try:
+            yield span
+        except BaseException as exc:
+            self._finish_span(trace_context, exc)
+            raise
+        else:
+            self._finish_span(trace_context)
+
+    def _open_span(
+        self,
+        name: str,
+        kind: str,
+        inputs: object | None,
+        tags: Sequence[str],
+        metadata: Mapping[str, object] | None,
+    ) -> tuple[Any, Any] | None:
+        resolved = self._require_resolved()
+        combined_metadata = {**self._default_metadata(), **dict(metadata or {})}
+        stack = ExitStack()
+        try:
+            stack.enter_context(
+                self._require_langsmith().tracing_context(
+                    enabled=True,
+                    client=self._client,
+                )
+            )
+            run_tree = stack.enter_context(
+                self._require_langsmith().trace(
+                    name,
+                    run_type=kind if kind in _RUN_TYPES else "chain",
+                    inputs=trace_payload(inputs, enabled=resolved.capture_inputs),
+                    project_name=None,
+                    tags=[*self.settings.tags, *tags],
+                    metadata=trace_metadata(
+                        combined_metadata,
+                        enabled=resolved.capture_metadata,
+                    ),
+                    client=self._client,
+                )
+            )
+            return stack, run_tree
+        except Exception as exc:
+            self._close_failed_stack(stack, "span.start.cleanup")
+            self._handle_runtime_error("span.start", exc)
+            return None
+
+    def _close_failed_stack(self, stack: ExitStack, operation: str) -> None:
+        try:
+            stack.close()
+        except Exception as exc:
+            self._handle_runtime_error(operation, exc)
+
+    def _finish_span(
+        self, trace_context: Any, error: BaseException | None = None
+    ) -> None:
+        exc_info = (
+            (type(error), error, error.__traceback__)
+            if error is not None
+            else (None, None, None)
+        )
+        operation = "span.error.close" if error is not None else "span.close"
+        try:
+            trace_context.__exit__(*exc_info)
+        except Exception as exc:
+            self._handle_runtime_error(operation, exc)
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        self.start()
+        resolved = self._require_resolved()
+        safe_parent = normalized_parent_headers(
+            parent,
+            allowlist=set(self.settings.propagation.baggage_allowlist),
+            langsmith_headers=self.settings.propagation.langsmith_headers,
+            traceparent=self.settings.propagation.traceparent,
+        )
+        token = self._enabled_override.set(enabled)
+        stack = ExitStack()
+        try:
+            try:
+                stack.enter_context(self._otel_parent_context(safe_parent))
+                stack.enter_context(
+                    self._require_langsmith().tracing_context(
+                        enabled=enabled,
+                        project_name=project or resolved.project,
+                        tags=[*self.settings.tags, *tags],
+                        metadata=trace_metadata(
+                            {**self._default_metadata(), **dict(metadata or {})},
+                            enabled=resolved.capture_metadata,
+                        ),
+                        parent=safe_parent or None,
+                        client=self._client,
+                    )
+                )
+            except Exception as exc:
+                self._close_failed_stack(stack, "context.start.cleanup")
+                self._handle_runtime_error("context.start", exc)
+                yield
+                return
+            try:
+                yield
+            except BaseException:
+                try:
+                    stack.close()
+                except Exception as exc:
+                    self._handle_runtime_error("context.error.close", exc)
+                raise
+            else:
+                try:
+                    stack.close()
+                except Exception as exc:
+                    self._handle_runtime_error("context.close", exc)
+        finally:
+            self._enabled_override.reset(token)
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        if not self.settings.propagation.enabled:
+            return
+        self.start()
+        allowlist = set(self.settings.propagation.baggage_allowlist)
+        native_baggage = self._inject_langsmith_context(headers, allowlist)
+        otel_baggage = self._inject_otel_context(headers, allowlist)
+        baggage = merge_baggage(native_baggage, otel_baggage)
+        if baggage:
+            headers.setdefault("baggage", baggage)
+
+    def _inject_langsmith_context(
+        self,
+        headers: MutableMapping[str, str],
+        allowlist: set[str],
+    ) -> str:
+        if not self.settings.propagation.langsmith_headers:
+            return ""
+        try:
+            from langsmith.run_helpers import get_current_run_tree
+
+            run_tree = get_current_run_tree()
+            if run_tree is None:
+                return ""
+            native_headers = run_tree.to_headers()
+            trace_header = native_headers.get("langsmith-trace")
+            if trace_header:
+                headers.setdefault("langsmith-trace", trace_header)
+            return filter_baggage(
+                native_headers.get("baggage", ""),
+                allowlist=allowlist,
+            )
+        except Exception as exc:
+            self._handle_runtime_error("propagation.inject.langsmith", exc)
+            return ""
+
+    def _inject_otel_context(
+        self,
+        headers: MutableMapping[str, str],
+        allowlist: set[str],
+    ) -> str:
+        if not self.settings.propagation.traceparent:
+            return ""
+        try:
+            from opentelemetry import propagate
+
+            carrier: dict[str, str] = {}
+            propagate.inject(carrier)
+            traceparent = carrier.get("traceparent")
+            if traceparent:
+                headers.setdefault("traceparent", traceparent)
+            return filter_baggage(carrier.get("baggage", ""), allowlist=allowlist)
+        except ImportError:
+            return ""
+        except Exception as exc:
+            self._handle_runtime_error("propagation.inject.otel", exc)
+            return ""
+
+    def pydantic_ai_capability(self) -> Any | None:
+        if not self.settings.instrumentation.pydantic_ai:
+            return None
+        self.start()
+        resolved = self._require_resolved()
+        if not resolved.tracing_enabled or resolved.sampling_rate == 0:
+            return None
+        try:
+            from pydantic_ai.capabilities.instrumentation import Instrumentation
+            from pydantic_ai.models.instrumented import InstrumentationSettings
+        except ImportError as exc:
+            raise RuntimeError(
+                "L'instrumentation LangSmith de Pydantic AI requiert "
+                'les extras "arclith[langgraph,langsmith]".'
+            ) from exc
+
+        provider = self._ensure_pydantic_otel_provider()
+        return Instrumentation(
+            InstrumentationSettings(
+                tracer_provider=provider,
+                include_content=self.settings.capture.model_content,
+                include_binary_content=self.settings.capture.binary_content,
+                include_model_request_parameters=(
+                    self.settings.capture.model_request_parameters
+                ),
+            )
+        )
+
+    def attach_to_current_opentelemetry(self) -> None:
+        """Fan out the shared provider to LangSmith without replacing it."""
+        self.start()
+        resolved = self._require_resolved()
+        if resolved.tracing_mode != "otel" or self._otel_processor is not None:
+            return
+        self._attach_to_current_otel_provider()
+
+    def _attach_to_current_otel_provider(self) -> None:
+        try:
+            from opentelemetry import trace
+        except ImportError as exc:
+            raise RuntimeError(
+                'Le mode LangSmith "otel" requiert "arclith[langsmith]".'
+            ) from exc
+        provider = trace.get_tracer_provider()
+        if not hasattr(provider, "add_span_processor"):
+            raise RuntimeError(
+                "Aucun TracerProvider OpenTelemetry configurable n'est disponible "
+                "pour composer LangSmith et OpenTelemetry"
+            )
+        self._attach_langsmith_processor(provider)
+
+    def flush(self, timeout: float | None = None) -> None:
+        if not self._started or self._closed:
+            return
+        resolved_timeout = timeout or self.settings.lifecycle.flush_timeout_seconds
+        self._flush_otel(resolved_timeout)
+        self._flush_client(resolved_timeout)
+
+    def _flush_otel(self, timeout: float) -> None:
+        if self._otel_processor is None:
+            return
+        try:
+            self._otel_processor.force_flush(timeout_millis=max(1, int(timeout * 1000)))
+        except Exception as exc:
+            self._handle_runtime_error("otel.flush", exc)
+
+    def _flush_client(self, timeout: float) -> None:
+        if self._client is None:
+            return
+        try:
+            self._client.flush(timeout=timeout)
+        except Exception as exc:
+            self._handle_runtime_error("client.flush", exc)
+
+    def close(self, timeout: float | None = None) -> None:
+        with self._lock:
+            if not self._started or self._closed:
+                return
+            resolved_timeout = timeout or self.settings.lifecycle.flush_timeout_seconds
+            self.flush(resolved_timeout)
+            self._close_otel()
+            self._close_client(resolved_timeout)
+            self._reset_langsmith_configuration()
+            self._closed = True
+
+    def _close_otel(self) -> None:
+        try:
+            if self._owns_otel_provider and self._otel_provider is not None:
+                self._otel_provider.shutdown()
+            elif self._otel_processor is not None:
+                self._otel_processor.shutdown()
+        except Exception as exc:
+            self._handle_runtime_error("otel.close", exc)
+
+    def _close_client(self, timeout: float) -> None:
+        if self._client is None:
+            return
+        try:
+            self._client.close(timeout=timeout)
+        except Exception as exc:
+            self._handle_runtime_error("client.close", exc)
+
+    def _reset_langsmith_configuration(self) -> None:
+        if self._langsmith is None:
+            return
+        try:
+            self._langsmith.configure(
+                client=None,
+                enabled=None,
+                project_name=None,
+                tags=None,
+                metadata=None,
+            )
+        except Exception as exc:
+            self._handle_runtime_error("configuration.reset", exc)
+
+    def diagnostics(self) -> Mapping[str, object]:
+        resolved = self._resolved
+        return {
+            "backend": "langsmith",
+            "started": self._started,
+            "closed": self._closed,
+            "tracing": resolved.tracing_enabled
+            if resolved
+            else self.settings.tracing.enabled,
+            "mode": resolved.tracing_mode if resolved else self.settings.tracing.mode,
+            "project": resolved.project if resolved else self.settings.project,
+            "sampling_rate": (
+                resolved.sampling_rate
+                if resolved
+                else self.settings.tracing.sampling_rate
+            ),
+            "capture": {
+                "inputs": resolved.capture_inputs
+                if resolved
+                else self.settings.capture.inputs,
+                "outputs": resolved.capture_outputs
+                if resolved
+                else self.settings.capture.outputs,
+                "metadata": (
+                    resolved.capture_metadata
+                    if resolved
+                    else self.settings.capture.metadata
+                ),
+                "model_content": self.settings.capture.model_content,
+                "binary_content": self.settings.capture.binary_content,
+            },
+        }
+
+    def _ensure_pydantic_otel_provider(self) -> Any:
+        if self._otel_provider is not None:
+            return self._otel_provider
+        try:
+            from langsmith.integrations.otel.processor import OtelSpanProcessor
+            from opentelemetry import trace
+            from opentelemetry.sdk.trace import TracerProvider
+        except ImportError as exc:
+            raise RuntimeError(
+                "L'instrumentation Pydantic AI requiert OpenTelemetry. "
+                'Installez "arclith[langsmith]".'
+            ) from exc
+
+        resolved = self._require_resolved()
+        provider: Any = None
+        if self._opentelemetry_enabled:
+            candidate = trace.get_tracer_provider()
+            if hasattr(candidate, "add_span_processor"):
+                provider = candidate
+        elif resolved.tracing_mode in {"otel", "hybrid"}:
+            candidate = trace.get_tracer_provider()
+            if hasattr(candidate, "add_span_processor"):
+                self._otel_provider = candidate
+                return candidate
+        if provider is None:
+            provider = TracerProvider()
+            self._owns_otel_provider = True
+
+        self._attach_langsmith_processor(provider, processor_class=OtelSpanProcessor)
+        return provider
+
+    def _attach_langsmith_processor(
+        self,
+        provider: Any,
+        *,
+        processor_class: Any | None = None,
+    ) -> None:
+        if self._otel_processor is not None:
+            return
+        if processor_class is None:
+            from langsmith.integrations.otel.processor import OtelSpanProcessor
+
+            processor_class = OtelSpanProcessor
+        resolved = self._require_resolved()
+        processor = processor_class(
+            api_key=resolved.api_key,
+            project=resolved.project,
+            url=resolved.endpoint,
+        )
+        provider.add_span_processor(processor)
+        self._otel_provider = provider
+        self._otel_processor = processor
+
+    @contextmanager
+    def _otel_parent_context(self, headers: Mapping[str, str]) -> Iterator[None]:
+        if not (self.settings.propagation.traceparent and headers.get("traceparent")):
+            yield
+            return
+        try:
+            from opentelemetry import context as otel_context
+            from opentelemetry import propagate
+        except ImportError:
+            yield
+            return
+        token = otel_context.attach(propagate.extract(dict(headers)))
+        try:
+            yield
+        finally:
+            otel_context.detach(token)
+
+    def _default_metadata(self) -> dict[str, object]:
+        return {**self._service_metadata, **self.settings.metadata}
+
+    def _require_resolved(self) -> ResolvedLangSmithConfig:
+        if self._resolved is None:
+            raise RuntimeError("Le runtime LangSmith n'est pas initialise")
+        return self._resolved
+
+    def _require_langsmith(self) -> Any:
+        if self._langsmith is None:
+            raise RuntimeError("Le runtime LangSmith n'est pas initialise")
+        return self._langsmith
+
+    def _on_export_error(self, exc: Exception) -> None:
+        self._handle_runtime_error("export", exc)
+
+    def _handle_runtime_error(self, operation: str, exc: Exception) -> None:
+        key = f"{operation}:{type(exc).__name__}"
+        if key not in self._reported_errors:
+            self._reported_errors.add(key)
+            self._logger.warning(
+                "LangSmith telemetry failure (fail-open)",
+                operation=operation,
+                error_type=type(exc).__name__,
+            )
+        if self.settings.failure_mode == "raise":
+            raise exc
+
+    def _diagnostic(self, message: str, **metadata: object) -> None:
+        if not self.settings.diagnostics.enabled:
+            return
+        log = getattr(self._logger, self.settings.diagnostics.log_level)
+        log(message, **metadata)

--- a/arclith/adapters/outbound/noop/__init__.py
+++ b/arclith/adapters/outbound/noop/__init__.py
@@ -1,0 +1,3 @@
+from arclith.adapters.outbound.noop.observability import NoOpTraceAdapter, NoOpTraceSpan
+
+__all__ = ["NoOpTraceAdapter", "NoOpTraceSpan"]

--- a/arclith/adapters/outbound/noop/observability.py
+++ b/arclith/adapters/outbound/noop/observability.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+
+from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
+
+
+class NoOpTraceSpan(TraceSpan):
+    def set_outputs(self, outputs: object | None) -> None:
+        return None
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        return None
+
+
+class NoOpTraceAdapter(TracePort):
+    """Zero-cost tracer used when no observability backend is selected."""
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        yield NoOpTraceSpan()
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        yield
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        return None
+
+    def flush(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self, timeout: float | None = None) -> None:
+        return None
+
+    def diagnostics(self) -> Mapping[str, object]:
+        return {"backend": "noop", "tracing": False}

--- a/arclith/adapters/outbound/opentelemetry/fastapi.py
+++ b/arclith/adapters/outbound/opentelemetry/fastapi.py
@@ -204,7 +204,3 @@ def _headers_from_env(env_name: str) -> dict[str, str] | None:
         if separator == "=" and key:
             headers[key] = value.strip()
     return headers or None
-
-
-# Backward-compatible private alias kept for integrations written against <= 0.18.
-_configure_opentelemetry = configure_opentelemetry

--- a/arclith/adapters/outbound/opentelemetry/fastapi.py
+++ b/arclith/adapters/outbound/opentelemetry/fastapi.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
     from arclith.infrastructure.config import OpenTelemetrySettings
 
+
 @dataclass
 class _ConfigurationState:
     configured: bool = False
@@ -25,7 +26,11 @@ def instrument_fastapi_app(
     if not (settings.traces or settings.metrics):
         return
 
-    _configure_opentelemetry(settings, service_name=service_name, service_version=service_version)
+    configure_opentelemetry(
+        settings,
+        service_name=service_name,
+        service_version=service_version,
+    )
     if not (settings.instrument_fastapi and settings.traces):
         return
 
@@ -39,7 +44,7 @@ def instrument_fastapi_app(
     FastAPIInstrumentor.instrument_app(app)
 
 
-def _configure_opentelemetry(
+def configure_opentelemetry(
     settings: "OpenTelemetrySettings",
     *,
     service_name: str,
@@ -48,7 +53,9 @@ def _configure_opentelemetry(
     if _CONFIGURATION_STATE.configured or not (settings.traces or settings.metrics):
         return
 
-    resource = _build_resource(settings, service_name=service_name, service_version=service_version)
+    resource = _build_resource(
+        settings, service_name=service_name, service_version=service_version
+    )
 
     if settings.traces:
         _configure_traces(settings, resource)
@@ -72,10 +79,12 @@ def _build_resource(
             'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
         ) from exc
 
-    return Resource.create({
-        SERVICE_NAME: settings.service_name or service_name,
-        SERVICE_VERSION: service_version,
-    })
+    return Resource.create(
+        {
+            SERVICE_NAME: settings.service_name or service_name,
+            SERVICE_VERSION: service_version,
+        }
+    )
 
 
 def _instrument_logging_correlation() -> None:
@@ -86,7 +95,9 @@ def _instrument_logging_correlation() -> None:
             'observability.enabled contient opentelemetry; installez l\'extra "arclith[opentelemetry]".'
         ) from exc
 
-    LoggingInstrumentor().instrument(set_logging_format=False, inject_trace_context=True)
+    LoggingInstrumentor().instrument(
+        set_logging_format=False, inject_trace_context=True
+    )
 
 
 def _configure_traces(settings: "OpenTelemetrySettings", resource: Any) -> None:
@@ -118,20 +129,31 @@ def _configure_metrics(settings: "OpenTelemetrySettings", resource: Any) -> None
         _build_metric_exporter(settings),
         export_interval_millis=settings.metrics_export_interval_millis,
     )
-    metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[reader]))
+    metrics.set_meter_provider(
+        MeterProvider(resource=resource, metric_readers=[reader])
+    )
 
 
 def _build_span_exporter(settings: "OpenTelemetrySettings") -> Any:
     headers = _headers_from_env(settings.headers_env)
     if settings.protocol == "grpc":
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as GrpcSpanExporter
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter as GrpcSpanExporter,
+        )
 
-        return GrpcSpanExporter(endpoint=_resolve_endpoint(settings.traces_endpoint, settings.endpoint), headers=headers)
+        return GrpcSpanExporter(
+            endpoint=_resolve_endpoint(settings.traces_endpoint, settings.endpoint),
+            headers=headers,
+        )
 
-    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as HttpSpanExporter
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as HttpSpanExporter,
+    )
 
     return HttpSpanExporter(
-        endpoint=_resolve_endpoint(settings.traces_endpoint, settings.endpoint, suffix="v1/traces"),
+        endpoint=_resolve_endpoint(
+            settings.traces_endpoint, settings.endpoint, suffix="v1/traces"
+        ),
         headers=headers,
     )
 
@@ -139,19 +161,30 @@ def _build_span_exporter(settings: "OpenTelemetrySettings") -> Any:
 def _build_metric_exporter(settings: "OpenTelemetrySettings") -> Any:
     headers = _headers_from_env(settings.headers_env)
     if settings.protocol == "grpc":
-        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GrpcMetricExporter
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter as GrpcMetricExporter,
+        )
 
-        return GrpcMetricExporter(endpoint=_resolve_endpoint(settings.metrics_endpoint, settings.endpoint), headers=headers)
+        return GrpcMetricExporter(
+            endpoint=_resolve_endpoint(settings.metrics_endpoint, settings.endpoint),
+            headers=headers,
+        )
 
-    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as HttpMetricExporter
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+        OTLPMetricExporter as HttpMetricExporter,
+    )
 
     return HttpMetricExporter(
-        endpoint=_resolve_endpoint(settings.metrics_endpoint, settings.endpoint, suffix="v1/metrics"),
+        endpoint=_resolve_endpoint(
+            settings.metrics_endpoint, settings.endpoint, suffix="v1/metrics"
+        ),
         headers=headers,
     )
 
 
-def _resolve_endpoint(explicit: str | None, base: str, suffix: str | None = None) -> str:
+def _resolve_endpoint(
+    explicit: str | None, base: str, suffix: str | None = None
+) -> str:
     if explicit:
         return explicit
     if suffix is None:
@@ -171,3 +204,7 @@ def _headers_from_env(env_name: str) -> dict[str, str] | None:
         if separator == "=" and key:
             headers[key] = value.strip()
     return headers or None
+
+
+# Backward-compatible private alias kept for integrations written against <= 0.18.
+_configure_opentelemetry = configure_opentelemetry

--- a/arclith/adapters/outbound/pydantic_ai/llm.py
+++ b/arclith/adapters/outbound/pydantic_ai/llm.py
@@ -17,8 +17,11 @@ T = TypeVar("T")
 
 
 class PydanticAILLMAdapter(LLMPort):
-    def __init__(self, settings: LMSettings) -> None:
+    def __init__(
+        self, settings: LMSettings, *, instrumentation: Any | None = None
+    ) -> None:
         self._settings = settings
+        self._instrumentation = instrumentation
 
     async def complete_structured(
         self,
@@ -83,8 +86,10 @@ class PydanticAILLMAdapter(LLMPort):
     ) -> Any:
         from pydantic_ai import Agent
 
-        return Agent(
-            build_pydantic_ai_model(self._settings),
-            output_type=output_type,
-            instructions=instructions,
-        )
+        kwargs: dict[str, Any] = {
+            "output_type": output_type,
+            "instructions": instructions,
+        }
+        if self._instrumentation is not None:
+            kwargs["capabilities"] = [self._instrumentation]
+        return Agent(build_pydantic_ai_model(self._settings), **kwargs)

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import threading
 import traceback
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
-from functools import cached_property
+from functools import cached_property, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, TypeVar, overload
 
@@ -16,6 +17,7 @@ from arclith.adapters.outbound.opentelemetry.correlation import (
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
+from arclith.domain.ports.outbound.observability import TraceAnonymizer, TracePort
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.config import (
     AppConfig,
@@ -121,7 +123,12 @@ class _UvicornLogInterceptHandler(logging.Handler):
 
 
 class Arclith:
-    def __init__(self, config_path: str | Path) -> None:
+    def __init__(
+        self,
+        config_path: str | Path,
+        *,
+        trace_anonymizer: TraceAnonymizer | None = None,
+    ) -> None:
         p = Path(config_path)
         if p.is_dir():
             self.config: AppConfig = load_config_dir(p)
@@ -129,6 +136,7 @@ class Arclith:
             self.config = load_config_file(p)
         else:
             raise ValueError(f"Config path not found: {p}")
+        self._trace_anonymizer = trace_anonymizer
 
     @cached_property
     def logger(self) -> Logger:
@@ -188,7 +196,19 @@ class Arclith:
             )
         from arclith.adapters.bidirectional.rabbitmq import RabbitMQCommandBus
 
-        return RabbitMQCommandBus(self.config.command_bus.rabbitmq, self.logger)
+        tracer: TracePort | None = None
+        langsmith = self.config.adapters.langsmith
+        if (
+            self.config.adapters.observability.is_enabled("langsmith")
+            and langsmith is not None
+            and langsmith.instrumentation.command_bus
+        ):
+            tracer = self.tracer()
+        return RabbitMQCommandBus(
+            self.config.command_bus.rabbitmq,
+            self.logger,
+            tracer=tracer,
+        )
 
     def run_command_bus(self, dispatcher: "CommandDispatcher") -> None:
         async def _run() -> None:
@@ -197,6 +217,7 @@ class Arclith:
                 await bus.run(dispatcher)
             finally:
                 await bus.close()
+                self.close_observability()
 
         asyncio.run(_run())
 
@@ -209,16 +230,22 @@ class Arclith:
         @asynccontextmanager
         async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             self._setup_uvicorn_logging()
-            if user_lifespan is not None:
-                async with AsyncExitStack() as stack:
-                    await stack.enter_async_context(user_lifespan(app))
+            self._start_observability()
+            try:
+                if user_lifespan is not None:
+                    async with AsyncExitStack() as stack:
+                        await stack.enter_async_context(user_lifespan(app))
+                        yield
+                else:
                     yield
-            else:
-                yield
+            finally:
+                self.close_observability()
 
         app = FastAPI(lifespan=_lifespan, **kwargs)
         self._add_fastapi_observability(app)
         self._add_fastapi_http_middlewares(app)
+        if self.config.adapters.observability.is_enabled("langsmith"):
+            self._instrument_fastapi_langsmith(app)
         if self.config.adapters.observability.is_enabled("opentelemetry"):
             self._instrument_fastapi_opentelemetry(app)
 
@@ -275,6 +302,22 @@ class Arclith:
             service_name=self.config.app.name,
             service_version=self.config.app.version,
         )
+
+    def _instrument_fastapi_langsmith(self, app: "FastAPI") -> None:
+        settings = self.config.adapters.langsmith
+        if settings is None or not settings.instrumentation.fastapi:
+            return
+        otel = self.config.adapters.opentelemetry
+        if (
+            self.config.adapters.observability.is_enabled("opentelemetry")
+            and otel is not None
+            and otel.traces
+            and otel.instrument_fastapi
+        ):
+            return
+        from arclith.adapters.outbound.langsmith.fastapi import instrument_fastapi_app
+
+        instrument_fastapi_app(app, self.tracer())
 
     def _add_fastapi_http_middlewares(self, app: "FastAPI") -> None:
         # Order matters: Starlette applies the last registered middleware first.
@@ -435,32 +478,90 @@ class Arclith:
         self._probe_server.add_readiness_check(fn)
 
     def instrument_mcp(self, mcp: "_fastmcp.FastMCP") -> None:
-        """Wrap all registered FastMCP tools with McpMetricsCollector (Option B).
+        """Wrap registered FastMCP tools with metrics and optional tracing.
 
         Call AFTER all tools are registered::
 
             IngredientMCP(service, logger, mcp)
             arclith.instrument_mcp(mcp)
         """
-        if not self.config.probe.enabled:
+        collector = self._mcp_collector if self.config.probe.enabled else None
+        tracer = self._selected_mcp_tracer()
+        if collector is None and tracer is None:
             return
-        collector = self._mcp_collector
+        components = self._mcp_components(mcp)
+        if components is None:
+            return
+        count = sum(
+            self._instrument_mcp_component(component, collector, tracer)
+            for component in components.values()
+        )
+        self.logger.info("🔬 MCP tools instrumented", count=count)
+
+    def _selected_mcp_tracer(self) -> TracePort | None:
+        settings = self.config.adapters.langsmith
+        if not self.config.adapters.observability.is_enabled("langsmith"):
+            return None
+        if settings is None or not settings.instrumentation.fastmcp:
+            return None
+        return self.tracer()
+
+    def _mcp_components(self, mcp: "_fastmcp.FastMCP") -> dict[str, Any] | None:
         try:
-            # fastmcp 3.x: tools live in _local_provider._components as FunctionTool objects
-            components: dict[str, Any] = mcp._local_provider._components  # type: ignore[attr-defined]
+            # fastmcp 3.x: FunctionTool objects are kept on the local provider.
+            return mcp._local_provider._components  # type: ignore[attr-defined,no-any-return]
         except AttributeError:
             self.logger.warning(
                 "⚠️ instrument_mcp: cannot access FastMCP components (API changed?)"
             )
-            return
-        count = 0
-        for component in components.values():
-            fn = getattr(component, "fn", None)
-            if fn is None or not callable(fn):
-                continue
-            component.fn = collector.wrap(component.name, fn)
-            count += 1
-        self.logger.info("🔬 MCP tools instrumented", count=count)
+            return None
+
+    def _instrument_mcp_component(
+        self,
+        component: Any,
+        collector: Any | None,
+        tracer: TracePort | None,
+    ) -> int:
+        fn = getattr(component, "fn", None)
+        if fn is None or not callable(fn):
+            return 0
+        if getattr(fn, "__arclith_instrumented__", False):
+            return 0
+        wrapped = collector.wrap(component.name, fn) if collector is not None else fn
+        if tracer is not None and not getattr(wrapped, "__arclith_traced__", False):
+            wrapped = self._wrap_mcp_trace(component.name, wrapped, tracer)
+        setattr(wrapped, "__arclith_instrumented__", True)
+        component.fn = wrapped
+        return 1
+
+    @staticmethod
+    def _wrap_mcp_trace(name: str, fn: Callable, tracer: TracePort) -> Callable:
+        metadata = {"mcp.method.name": name, "mcp.operation.name": "tools/call"}
+        if inspect.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def _async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                with tracer.span(name, kind="tool", metadata=metadata) as span:
+                    result = await fn(*args, **kwargs)
+                    span.set_outputs(
+                        {"status": "success", "result_type": type(result).__name__}
+                    )
+                    return result
+
+            setattr(_async_wrapped, "__arclith_traced__", True)
+            return _async_wrapped
+
+        @wraps(fn)
+        def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            with tracer.span(name, kind="tool", metadata=metadata) as span:
+                result = fn(*args, **kwargs)
+                span.set_outputs(
+                    {"status": "success", "result_type": type(result).__name__}
+                )
+                return result
+
+        setattr(_wrapped, "__arclith_traced__", True)
+        return _wrapped
 
     def run_with_probes(
         self,
@@ -503,6 +604,45 @@ class Arclith:
 
         return fastmcp.FastMCP(name, **kwargs)
 
+    def tracer(self) -> TracePort:
+        """Return the configured provider-neutral tracer (a no-op by default)."""
+        return self._trace_adapter
+
+    def langsmith_client(self) -> Any:
+        """Return the configured native LangSmith client for advanced operations."""
+        if not self.config.adapters.observability.is_enabled("langsmith"):
+            raise RuntimeError(
+                "LangSmith n'est pas active dans adapters.observability.enabled"
+            )
+        client = getattr(self._trace_adapter, "client", None)
+        if not callable(client):
+            raise RuntimeError("Le runtime LangSmith ne fournit pas de client")
+        return client()
+
+    def pydantic_ai_llm(self) -> Any:
+        """Build the configured Pydantic AI adapter with optional tracing."""
+        settings = self.config.adapters.lm
+        if settings is None:
+            raise RuntimeError(
+                "config.adapters.lm est requis pour utiliser pydantic_ai_llm()"
+            )
+        from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
+
+        instrumentation = None
+        capability = getattr(self._trace_adapter, "pydantic_ai_capability", None)
+        if callable(capability):
+            instrumentation = capability()
+        return PydanticAILLMAdapter(settings, instrumentation=instrumentation)
+
+    def flush_observability(self, timeout: float | None = None) -> None:
+        self._trace_adapter.flush(timeout)
+
+    def close_observability(self, timeout: float | None = None) -> None:
+        self._trace_adapter.close(timeout)
+
+    def observability_diagnostics(self) -> Mapping[str, Any]:
+        return self._trace_adapter.diagnostics()
+
     def langgraph(
         self,
         state_schema: type[Any],
@@ -523,6 +663,13 @@ class Arclith:
         persistence: bool | None = None,
         persistence_registry: LangGraphPersistenceRegistry | None = None,
     ) -> Any:
+        langsmith = self.config.adapters.langsmith
+        if (
+            self.config.adapters.observability.is_enabled("langsmith")
+            and langsmith is not None
+            and langsmith.instrumentation.langgraph
+        ):
+            self._start_observability()
         from langgraph.graph import StateGraph
 
         builder = StateGraph(
@@ -650,16 +797,61 @@ class Arclith:
         )
 
     def run_mcp_sse(self, mcp: "_fastmcp.FastMCP") -> None:
-        mcp.run(transport="sse", host=self.config.mcp.host, port=self.config.mcp.port)
+        self._start_observability()
+        try:
+            mcp.run(
+                transport="sse", host=self.config.mcp.host, port=self.config.mcp.port
+            )
+        finally:
+            self.close_observability()
 
     def run_mcp_http(self, mcp: "_fastmcp.FastMCP") -> None:
-        mcp.run(
-            transport="streamable-http",
-            host=self.config.mcp.host,
-            port=self.config.mcp.port,
-        )
+        self._start_observability()
+        try:
+            mcp.run(
+                transport="streamable-http",
+                host=self.config.mcp.host,
+                port=self.config.mcp.port,
+            )
+        finally:
+            self.close_observability()
 
     # ── private cached helpers ────────────────────────────────────────────────
+
+    @cached_property
+    def _trace_adapter(self) -> TracePort:
+        from arclith.infrastructure.observability_factory import build_trace_adapter
+
+        return build_trace_adapter(
+            self.config,
+            self.logger,
+            anonymizer=self._trace_anonymizer,
+        )
+
+    def _start_observability(self) -> None:
+        if self.config.adapters.observability.is_enabled("opentelemetry"):
+            settings = self.config.adapters.opentelemetry
+            if settings is not None:
+                from arclith.adapters.outbound.opentelemetry.fastapi import (
+                    configure_opentelemetry,
+                )
+
+                configure_opentelemetry(
+                    settings,
+                    service_name=self.config.app.name,
+                    service_version=self.config.app.version,
+                )
+        start = getattr(self._trace_adapter, "start", None)
+        if callable(start):
+            start()
+        if self.config.adapters.observability.is_enabled("opentelemetry"):
+            attach = getattr(
+                self._trace_adapter,
+                "attach_to_current_opentelemetry",
+                None,
+            )
+            if callable(attach):
+                attach()
 
     @cached_property
     def _cache(self) -> Any:

--- a/arclith/domain/ports/outbound/observability.py
+++ b/arclith/domain/ports/outbound/observability.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, Callable, ContextManager
+
+TraceAnonymizer = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+class TraceSpan(ABC):
+    """Provider-neutral handle for a span created at an application boundary."""
+
+    @abstractmethod
+    def set_outputs(self, outputs: object | None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        raise NotImplementedError
+
+
+class TracePort(ABC):
+    """Outbound tracing contract with a no-op implementation available by default."""
+
+    @abstractmethod
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> ContextManager[TraceSpan]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> ContextManager[None]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def flush(self, timeout: float | None = None) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self, timeout: float | None = None) -> None:
+        raise NotImplementedError
+
+    def diagnostics(self) -> Mapping[str, Any]:
+        return {}

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -137,13 +137,120 @@ class LMSettings(BaseModel):
     base_url: str | None = None  # requis si provider="openai" (LLM local/custom)
 
 
+class LangSmithTracingSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    mode: Literal["langsmith", "otel", "hybrid"] = "otel"
+    sampling_rate: float = 1.0
+
+    @field_validator("sampling_rate")
+    @classmethod
+    def must_be_valid_sampling_rate(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("sampling_rate doit etre compris entre 0.0 et 1.0")
+        return v
+
+
+class LangSmithInstrumentationSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    langgraph: bool = True
+    pydantic_ai: bool = True
+    fastapi: bool = False
+    fastmcp: bool = True
+    command_bus: bool = True
+
+
+class LangSmithCaptureSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    inputs: bool = False
+    outputs: bool = False
+    metadata: bool = True
+    model_content: bool = False
+    binary_content: bool = False
+    model_request_parameters: bool = False
+
+
+class LangSmithPropagationSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    langsmith_headers: bool = True
+    traceparent: bool = True
+    baggage_allowlist: list[str] = Field(default_factory=list)
+
+    @field_validator("baggage_allowlist")
+    @classmethod
+    def must_not_contain_duplicate_baggage_keys(cls, v: list[str]) -> list[str]:
+        normalized = [item.strip() for item in v if item.strip()]
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("baggage_allowlist ne doit pas contenir de doublons")
+        return normalized
+
+
+class LangSmithLifecycleSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    flush_timeout_seconds: float = 5.0
+
+    @field_validator("flush_timeout_seconds")
+    @classmethod
+    def must_be_positive_timeout(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("flush_timeout_seconds doit etre > 0")
+        return v
+
+
+class LangSmithDiagnosticsSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    log_level: Literal["debug", "info", "warning", "error"] = "info"
+
+
 class LangSmithSettings(BaseModel):
-    tracing: bool = True
+    model_config = ConfigDict(extra="forbid")
+
     project: str
     endpoint: str = "https://api.smith.langchain.com"
     api_key_env: str = "LANGSMITH_API_KEY"
+    workspace_id_env: str = "LANGSMITH_WORKSPACE_ID"
+    tracing: LangSmithTracingSettings = Field(default_factory=LangSmithTracingSettings)
+    instrumentation: LangSmithInstrumentationSettings = Field(
+        default_factory=LangSmithInstrumentationSettings
+    )
+    capture: LangSmithCaptureSettings = Field(default_factory=LangSmithCaptureSettings)
+    propagation: LangSmithPropagationSettings = Field(
+        default_factory=LangSmithPropagationSettings
+    )
+    tags: list[str] = Field(default_factory=lambda: ["arclith"])
+    metadata: dict[str, str | int | float | bool] = Field(default_factory=dict)
+    lifecycle: LangSmithLifecycleSettings = Field(
+        default_factory=LangSmithLifecycleSettings
+    )
+    diagnostics: LangSmithDiagnosticsSettings = Field(
+        default_factory=LangSmithDiagnosticsSettings
+    )
+    failure_mode: Literal["log-and-continue", "raise"] = "log-and-continue"
     studio: Literal["langgraph"] = "langgraph"
     langgraph_api_min_version: str = "0.11.0"
+
+    @field_validator("tracing", mode="before")
+    @classmethod
+    def migrate_legacy_tracing_flag(cls, v: object) -> object:
+        if isinstance(v, bool):
+            return {"enabled": v}
+        return v
+
+    @field_validator("project", "endpoint", "api_key_env", "workspace_id_env")
+    @classmethod
+    def must_not_be_blank(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            raise ValueError("la valeur ne doit pas etre vide")
+        return value
 
 
 class OpenTelemetrySettings(BaseModel):
@@ -454,6 +561,16 @@ class AdaptersSettings(BaseModel):
                     f"observability.enabled contient {observability_adapter} mais aucune section "
                     f"[adapters.{observability_section}] dans config.yaml"
                 )
+        if (
+            self.observability.is_enabled("langsmith")
+            and self.observability.is_enabled("opentelemetry")
+            and self.langsmith is not None
+            and self.langsmith.tracing.mode != "otel"
+        ):
+            raise ValueError(
+                "LangSmith + OpenTelemetry requiert tracing.mode=otel afin de "
+                "partager un seul arbre de spans sans doublons"
+            )
         return self
 
 

--- a/arclith/infrastructure/observability_factory.py
+++ b/arclith/infrastructure/observability_factory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from arclith.adapters.outbound.noop.observability import NoOpTraceAdapter
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.domain.ports.outbound.observability import TraceAnonymizer, TracePort
+from arclith.infrastructure.config import AppConfig
+
+
+def build_trace_adapter(
+    config: AppConfig,
+    logger: Logger,
+    *,
+    anonymizer: TraceAnonymizer | None = None,
+) -> TracePort:
+    if not config.adapters.observability.is_enabled("langsmith"):
+        return NoOpTraceAdapter()
+
+    settings = config.adapters.langsmith
+    if settings is None:
+        raise RuntimeError(
+            "observability.enabled contient langsmith mais adapters.langsmith est absent"
+        )
+
+    from arclith.adapters.outbound.langsmith.runtime import LangSmithRuntime
+
+    return LangSmithRuntime(
+        settings,
+        logger,
+        service_metadata={
+            "service.name": config.app.name,
+            "service.version": config.app.version,
+        },
+        opentelemetry_enabled=config.adapters.observability.is_enabled("opentelemetry"),
+        anonymizer=anonymizer,
+        before_start=lambda: _configure_shared_opentelemetry(config),
+    )
+
+
+def _configure_shared_opentelemetry(config: AppConfig) -> None:
+    if not config.adapters.observability.is_enabled("opentelemetry"):
+        return
+    settings = config.adapters.opentelemetry
+    if settings is None:
+        return
+    from arclith.adapters.outbound.opentelemetry.fastapi import configure_opentelemetry
+
+    configure_opentelemetry(
+        settings,
+        service_name=config.app.name,
+        service_version=config.app.version,
+    )

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -50,6 +50,7 @@ def add_adapter_cmd(
     multitenant: bool | None = None,
     duckdb_path: str | None = None,
     adapter_params: dict[str, str] | None = None,
+    profile: str | None = None,
     yes: bool = False,
 ) -> None:
     """Wizard interactif pour scaffolder un adapter du catalogue."""
@@ -64,13 +65,14 @@ def add_adapter_cmd(
     entities = _resolve_entities(
         project_dir, entity_names, all_entities, yes=yes, adapter=adapter_spec
     )
+    profile_values = _resolve_profile(adapter_spec, profile)
     params = _resolve_adapter_params(
         adapter_spec,
         project_dir,
         db_name=db_name,
         multitenant=multitenant,
         duckdb_path=duckdb_path,
-        extra_params=adapter_params or {},
+        extra_params={**profile_values, **(adapter_params or {})},
         prompt_missing=not yes,
     )
     if capability.activation_config_key is None:
@@ -89,7 +91,16 @@ def add_adapter_cmd(
         console.print("[yellow]Annulé.[/yellow]")
         raise typer.Exit(0)
 
-    _generate(project_dir, capability, adapter_spec, entities, params, activate)
+    explicit_params = {*profile_values, *(adapter_params or {})}
+    _generate(
+        project_dir,
+        capability,
+        adapter_spec,
+        entities,
+        params,
+        activate,
+        explicit_params=explicit_params,
+    )
 
 
 # ── Validation ────────────────────────────────────────────────────────────────
@@ -189,6 +200,22 @@ def _resolve_adapter_type(
     supported = ", ".join(capability.adapter_names())
     console.print(
         f"[red]✗[/red] Adapter inconnu: [bold]{adapter}[/bold]. Valeurs: {supported}."
+    )
+    raise typer.Exit(1)
+
+
+def _resolve_profile(
+    adapter: AdapterSpec, profile: str | None
+) -> dict[str, str | bool]:
+    if profile is None:
+        return {}
+    selected = adapter.get_profile(profile)
+    if selected is not None:
+        return selected.values()
+    allowed = ", ".join(item.name for item in adapter.profiles) or "(aucun)"
+    console.print(
+        f"[red]✗[/red] Profil inconnu pour [bold]{adapter.name}[/bold]: {profile}. "
+        f"Valeurs: {allowed}."
     )
     raise typer.Exit(1)
 
@@ -307,7 +334,7 @@ def _resolve_adapter_params(
     db_name: str | None,
     multitenant: bool | None,
     duckdb_path: str | None,
-    extra_params: dict[str, str],
+    extra_params: dict[str, str | bool],
     prompt_missing: bool,
 ) -> dict[str, Any]:
     if prompt_missing:
@@ -351,7 +378,32 @@ def _normalize_adapter_params(
         return _normalize_docker_image_params(params)
     if adapter.capability == "agent-persistence" and adapter.name == "langgraph":
         return _normalize_agent_persistence_params(params)
+    if adapter.capability == "observability" and adapter.name == "langsmith":
+        return _normalize_langsmith_params(params)
     return params
+
+
+def _normalize_langsmith_params(params: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(params)
+    try:
+        sampling_rate = float(str(normalized["sampling_rate"]))
+    except ValueError:
+        console.print(
+            "[red]✗[/red] sampling_rate doit être un nombre entre 0.0 et 1.0."
+        )
+        raise typer.Exit(1) from None
+    if not 0.0 <= sampling_rate <= 1.0:
+        console.print("[red]✗[/red] sampling_rate doit être compris entre 0.0 et 1.0.")
+        raise typer.Exit(1)
+    normalized["sampling_rate"] = str(sampling_rate)
+    for capture, hide in (
+        ("capture_inputs", "hide_inputs"),
+        ("capture_outputs", "hide_outputs"),
+        ("capture_metadata", "hide_metadata"),
+    ):
+        enabled = _parse_boolean_param(str(normalized[capture])) is True
+        normalized[hide] = _yaml_bool(not enabled)
+    return normalized
 
 
 def _normalize_cache_control_params(params: dict[str, Any]) -> dict[str, Any]:
@@ -446,7 +498,8 @@ def _normalize_agent_persistence_params(params: dict[str, Any]) -> dict[str, Any
 
 
 def _assert_supported_params(
-    adapter: AdapterSpec, extra_params: dict[str, str]
+    adapter: AdapterSpec,
+    extra_params: dict[str, str | bool],
 ) -> None:
     supported = {parameter.name for parameter in adapter.parameters}
     unknown = sorted(name for name in extra_params if name not in supported)
@@ -670,6 +723,8 @@ def _generate(
     entities: list[EntityInfo],
     params: dict[str, Any],
     activate: bool,
+    *,
+    explicit_params: set[str] | None = None,
 ) -> None:
     installed = scan_installed_adapters(project_dir)
     paths = detect_project_paths(project_dir)
@@ -683,9 +738,23 @@ def _generate(
 
     if adapter.has_config() and adapter.config_path:
         cfg_path = project_dir / adapter.config_path
-        cfg_path.parent.mkdir(parents=True, exist_ok=True)
-        cfg_path.write_text(render(adapter.config_template, params), encoding="utf-8")
+        rendered_config = render(adapter.config_template, params)
+        if adapter.capability == "observability" and adapter.name == "langsmith":
+            _merge_langsmith_config(
+                cfg_path,
+                rendered_config,
+                explicit_params=explicit_params or set(),
+            )
+        else:
+            cfg_path.parent.mkdir(parents=True, exist_ok=True)
+            cfg_path.write_text(rendered_config, encoding="utf-8")
         console.print(f"[green]✓[/green] {cfg_path.relative_to(project_dir)}")
+
+    if adapter.dependency_extra:
+        _ensure_arclith_extra(project_dir / "pyproject.toml", adapter.dependency_extra)
+        console.print(
+            f"[cyan]↺[/cyan] pyproject.toml → arclith[{adapter.dependency_extra}]"
+        )
 
     for merge_template in adapter.merge_config_templates:
         cfg_path = project_dir / render(merge_template.path, params)
@@ -698,8 +767,17 @@ def _generate(
 
     if adapter.has_env() and adapter.env_path:
         env_path = project_dir / adapter.env_path
+        env_overrides: set[str] | None = None
+        if adapter.capability == "observability" and adapter.name == "langsmith":
+            env_overrides = {
+                env_name
+                for env_name, parameter in _LANGSMITH_ENV_PARAMETERS.items()
+                if parameter in (explicit_params or set())
+            }
         _merge_env_file(
-            env_path, _parse_env_template(render(adapter.env_template, params))
+            env_path,
+            _parse_env_template(render(adapter.env_template, params)),
+            overwrite_keys=env_overrides,
         )
         _ensure_gitignore_entries(project_dir, (".env",))
         console.print(f"[green]✓[/green] {env_path.relative_to(project_dir)}")
@@ -774,7 +852,6 @@ def _generate(
     if adapter.capability == "agent-persistence":
         extras = _configured_agent_persistence_extras(project_dir, params)
         _ensure_arclith_extras(project_dir, extras)
-
     console.print(
         f"\n[bold green]✓ Adapter [cyan]{adapter.name}[/cyan] scaffoldé avec succès.[/bold green]"
     )
@@ -1039,7 +1116,12 @@ def _parse_env_template(rendered: str) -> dict[str, str]:
     return values
 
 
-def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
+def _merge_env_file(
+    env_path: Path,
+    updates: dict[str, str],
+    *,
+    overwrite_keys: set[str] | None = None,
+) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
     existing_lines = (
         env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
@@ -1055,7 +1137,12 @@ def _merge_env_file(env_path: Path, updates: dict[str, str]) -> None:
         key_raw, existing_value = stripped.split("=", 1)
         key = key_raw.strip()
         if key in updates:
-            if not updates[key] and existing_value.strip():
+            preserve_existing = (
+                overwrite_keys is not None
+                and key not in overwrite_keys
+                and bool(existing_value.strip())
+            )
+            if preserve_existing or (not updates[key] and existing_value.strip()):
                 merged_lines.append(line)
             else:
                 merged_lines.append(f"{key}={updates[key]}")
@@ -1092,6 +1179,80 @@ def _merge_yaml_file(
     path.write_text(
         yaml.safe_dump(merged, sort_keys=False, allow_unicode=True), encoding="utf-8"
     )
+
+
+_LANGSMITH_PARAMETER_PATHS: dict[str, tuple[str, ...]] = {
+    "tracing_enabled": ("tracing", "enabled"),
+    "tracing_mode": ("tracing", "mode"),
+    "sampling_rate": ("tracing", "sampling_rate"),
+    "project": ("project",),
+    "endpoint": ("endpoint",),
+    "capture_inputs": ("capture", "inputs"),
+    "capture_outputs": ("capture", "outputs"),
+    "capture_metadata": ("capture", "metadata"),
+    "capture_model_content": ("capture", "model_content"),
+    "instrument_langgraph": ("instrumentation", "langgraph"),
+    "instrument_pydantic_ai": ("instrumentation", "pydantic_ai"),
+    "instrument_fastapi": ("instrumentation", "fastapi"),
+    "instrument_fastmcp": ("instrumentation", "fastmcp"),
+    "instrument_command_bus": ("instrumentation", "command_bus"),
+    "diagnostics_enabled": ("diagnostics", "enabled"),
+}
+
+_LANGSMITH_ENV_PARAMETERS: dict[str, str] = {
+    "LANGSMITH_TRACING": "tracing_enabled",
+    "LANGSMITH_PROJECT": "project",
+    "LANGSMITH_ENDPOINT": "endpoint",
+    "LANGSMITH_TRACING_MODE": "tracing_mode",
+    "LANGSMITH_TRACING_SAMPLING_RATE": "sampling_rate",
+    "LANGSMITH_HIDE_INPUTS": "capture_inputs",
+    "LANGSMITH_HIDE_OUTPUTS": "capture_outputs",
+    "LANGSMITH_HIDE_METADATA": "capture_metadata",
+}
+
+
+def _merge_langsmith_config(
+    path: Path,
+    rendered_yaml: str,
+    *,
+    explicit_params: set[str],
+) -> None:
+    """Fill missing defaults while preserving user values on later CLI runs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text(rendered_yaml, encoding="utf-8")
+        return
+    generated = yaml.safe_load(rendered_yaml) or {}
+    if not isinstance(generated, dict):
+        console.print("[red]✗[/red] La configuration LangSmith doit être un mapping.")
+        raise typer.Exit(1)
+    existing = _read_yaml_mapping(path)
+    merged = _deep_merge_mapping(generated, existing)
+    for parameter in explicit_params:
+        config_path = _LANGSMITH_PARAMETER_PATHS.get(parameter)
+        if config_path is not None:
+            _copy_nested_value(generated, merged, config_path)
+    path.write_text(
+        yaml.safe_dump(merged, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _copy_nested_value(
+    source: dict[str, Any],
+    destination: dict[str, Any],
+    path: tuple[str, ...],
+) -> None:
+    source_cursor: Any = source
+    destination_cursor: dict[str, Any] = destination
+    for key in path[:-1]:
+        source_cursor = source_cursor[key]
+        child = destination_cursor.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            destination_cursor[key] = child
+        destination_cursor = child
+    destination_cursor[path[-1]] = source_cursor[path[-1]]
 
 
 def _merge_secrets_file(
@@ -1178,3 +1339,32 @@ def _ensure_gitignore_entries(project_dir: Path, entries: tuple[str, ...]) -> No
         lines.append("")
     lines.extend(missing)
     gitignore.write_text("\n".join(lines).rstrip("\n") + "\n", encoding="utf-8")
+
+
+def _ensure_arclith_extra(pyproject: Path, extra: str) -> None:
+    if not pyproject.exists():
+        return
+    text = pyproject.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'(?P<quote>["\'])arclith(?:\[(?P<extras>[^]]*)\])?'
+        r'(?P<version>\s*(?:[<>=!~@][^"\']*)?)(?P=quote)'
+    )
+    match = pattern.search(text)
+    if match is None:
+        return
+    extras = [
+        item.strip()
+        for item in (match.group("extras") or "").split(",")
+        if item.strip()
+    ]
+    if extra in extras:
+        return
+    extras.append(extra)
+    rendered = (
+        f"{match.group('quote')}arclith[{','.join(extras)}]"
+        f"{match.group('version')}{match.group('quote')}"
+    )
+    pyproject.write_text(
+        text[: match.start()] + rendered + text[match.end() :],
+        encoding="utf-8",
+    )

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -70,6 +70,18 @@ class SecretMappingSpec:
 
 
 @dataclass(frozen=True)
+class AdapterProfileSpec:
+    name: str
+    parameters: tuple[tuple[str, str | bool], ...]
+
+    def values(self) -> dict[str, str | bool]:
+        return dict(self.parameters)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "parameters": dict(self.parameters)}
+
+
+@dataclass(frozen=True)
 class AdapterSpec:
     name: str
     capability: str
@@ -86,6 +98,8 @@ class AdapterSpec:
     secret_config_template: str = ""
     gitignore_entries: tuple[str, ...] = ()
     parameters: tuple[ParameterSpec, ...] = ()
+    profiles: tuple[AdapterProfileSpec, ...] = ()
+    dependency_extra: str | None = None
     entity_scoped: bool = True
 
     def has_config(self) -> bool:
@@ -102,6 +116,13 @@ class AdapterSpec:
 
     def has_secret_config(self) -> bool:
         return bool(self.secret_config_template)
+
+    def get_profile(self, name: str) -> AdapterProfileSpec | None:
+        normalized = name.strip().lower()
+        return next(
+            (profile for profile in self.profiles if profile.name == normalized),
+            None,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -124,6 +145,8 @@ class AdapterSpec:
             "secret_config_template": bool(self.secret_config_template),
             "gitignore_entries": list(self.gitignore_entries),
             "parameters": [parameter.to_dict() for parameter in self.parameters],
+            "profiles": [profile.to_dict() for profile in self.profiles],
+            "dependency_extra": self.dependency_extra,
             "entity_scoped": self.entity_scoped,
         }
 
@@ -1776,26 +1799,61 @@ OBSERVABILITY_CAPABILITY = CapabilitySpec(
             description="Tracing LangSmith et tests agent dans LangGraph Studio.",
             config_path="config/adapters/outbound/langsmith.yaml",
             config_template="""\
-tracing: {tracing}
 project: "{project}"
 endpoint: "{endpoint}"
 api_key_env: LANGSMITH_API_KEY
+workspace_id_env: LANGSMITH_WORKSPACE_ID
 # Définir LANGSMITH_API_KEY hors Git: .env local, env runtime ou secret manager.
+tracing:
+  enabled: {tracing_enabled}
+  mode: "{tracing_mode}"
+  sampling_rate: {sampling_rate}
+instrumentation:
+  langgraph: {instrument_langgraph}
+  pydantic_ai: {instrument_pydantic_ai}
+  fastapi: {instrument_fastapi}
+  fastmcp: {instrument_fastmcp}
+  command_bus: {instrument_command_bus}
+capture:
+  inputs: {capture_inputs}
+  outputs: {capture_outputs}
+  metadata: {capture_metadata}
+  model_content: {capture_model_content}
+  binary_content: false
+  model_request_parameters: false
+propagation:
+  enabled: true
+  langsmith_headers: true
+  traceparent: true
+  baggage_allowlist: []
+tags:
+  - arclith
+metadata: {{}}
+lifecycle:
+  flush_timeout_seconds: 5.0
+diagnostics:
+  enabled: {diagnostics_enabled}
+  log_level: info
+failure_mode: log-and-continue
 studio: langgraph
 langgraph_api_min_version: "0.11.0"
 """,
-            env_path=".env",
+            env_path=".env.example",
             env_template="""\
-LANGSMITH_TRACING={tracing}
+LANGSMITH_TRACING={tracing_enabled}
 LANGSMITH_PROJECT={project}
 LANGSMITH_ENDPOINT={endpoint}
-LANGSMITH_API_KEY={api_key}
+LANGSMITH_TRACING_MODE={tracing_mode}
+LANGSMITH_TRACING_SAMPLING_RATE={sampling_rate}
+LANGSMITH_HIDE_INPUTS={hide_inputs}
+LANGSMITH_HIDE_OUTPUTS={hide_outputs}
+LANGSMITH_HIDE_METADATA={hide_metadata}
 """,
             parameters=(
                 ParameterSpec(
-                    name="tracing",
+                    name="tracing_enabled",
                     kind="boolean",
-                    prompt="Activer LANGSMITH_TRACING",
+                    prompt="Activer le tracing LangSmith",
                     default=True,
                 ),
                 ParameterSpec(
@@ -1811,13 +1869,107 @@ LANGSMITH_API_KEY={api_key}
                     default="https://api.smith.langchain.com",
                 ),
                 ParameterSpec(
-                    name="api_key",
+                    name="tracing_mode",
                     kind="string",
-                    prompt="LANGSMITH_API_KEY",
-                    default="",
-                    secret=True,
+                    prompt="Mode de tracing LangSmith",
+                    default="otel",
+                    choices=("langsmith", "otel", "hybrid"),
+                ),
+                ParameterSpec(
+                    name="sampling_rate",
+                    kind="string",
+                    prompt="Taux d'échantillonnage (0.0-1.0)",
+                    default="1.0",
+                ),
+                ParameterSpec(
+                    name="capture_inputs",
+                    kind="boolean",
+                    prompt="Capturer les inputs",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="capture_outputs",
+                    kind="boolean",
+                    prompt="Capturer les outputs",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="capture_metadata",
+                    kind="boolean",
+                    prompt="Capturer les métadonnées",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="capture_model_content",
+                    kind="boolean",
+                    prompt="Capturer prompts et réponses modèle (sensible)",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="instrument_langgraph",
+                    kind="boolean",
+                    prompt="Instrumenter LangGraph",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="instrument_pydantic_ai",
+                    kind="boolean",
+                    prompt="Instrumenter Pydantic AI",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="instrument_fastapi",
+                    kind="boolean",
+                    prompt="Instrumenter FastAPI",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="instrument_fastmcp",
+                    kind="boolean",
+                    prompt="Instrumenter FastMCP",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="instrument_command_bus",
+                    kind="boolean",
+                    prompt="Instrumenter le command bus",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="diagnostics_enabled",
+                    kind="boolean",
+                    prompt="Activer les diagnostics locaux",
+                    default=False,
                 ),
             ),
+            profiles=(
+                AdapterProfileSpec(
+                    name="development",
+                    parameters=(
+                        ("tracing_enabled", True),
+                        ("tracing_mode", "otel"),
+                        ("sampling_rate", "1.0"),
+                        ("capture_inputs", False),
+                        ("capture_outputs", False),
+                        ("capture_model_content", False),
+                        ("diagnostics_enabled", True),
+                    ),
+                ),
+                AdapterProfileSpec(
+                    name="production",
+                    parameters=(
+                        ("tracing_enabled", True),
+                        ("tracing_mode", "otel"),
+                        ("sampling_rate", "0.1"),
+                        ("capture_inputs", False),
+                        ("capture_outputs", False),
+                        ("capture_model_content", False),
+                        ("diagnostics_enabled", False),
+                    ),
+                ),
+            ),
+            dependency_extra="langsmith",
+            gitignore_entries=(".env",),
             entity_scoped=False,
         ),
         AdapterSpec(

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -204,6 +204,13 @@ def add_adapter(
             help="Paramètre adapter key=value, répétable pour les adapters du catalogue",
         ),
     ] = None,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            help="Profil explicite de l'adapter, par exemple development ou production",
+        ),
+    ] = None,
     yes: Annotated[
         bool,
         typer.Option(
@@ -224,6 +231,7 @@ def add_adapter(
         multitenant=multitenant,
         duckdb_path=path,
         adapter_params=_parse_param_options(param),
+        profile=profile,
         yes=yes,
     )
 

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -363,10 +363,12 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
         capability_name="observability",
         adapter="langsmith",
         adapter_params={
-            "tracing": "true",
+            "tracing_enabled": "true",
             "project": "agent-tests",
             "endpoint": "https://eu.api.smith.langchain.com",
-            "api_key": "test-key",
+            "tracing_mode": "hybrid",
+            "sampling_rate": "0.5",
+            "capture_inputs": "true",
         },
         yes=True,
     )
@@ -375,7 +377,11 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     config = (
         project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml"
     ).read_text(encoding="utf-8")
-    assert "tracing: true" in config
+    assert "tracing:\n  enabled: true" in config
+    assert 'mode: "hybrid"' in config
+    assert "sampling_rate: 0.5" in config
+    assert "inputs: true" in config
+    assert "model_content: false" in config
     assert 'project: "agent-tests"' in config
     assert 'endpoint: "https://eu.api.smith.langchain.com"' in config
     assert "api_key_env: LANGSMITH_API_KEY" in config
@@ -389,14 +395,17 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
     assert adapters_config["observability"]["enabled"] == ["langsmith"]
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
-    assert "EXISTING=value" in env
-    assert "LANGSMITH_TRACING=true" in env
-    assert "LANGSMITH_PROJECT=agent-tests" in env
-    assert "LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com" in env
-    assert "LANGSMITH_API_KEY=test-key" in env
+    env_example = (project_dir / ".env.example").read_text(encoding="utf-8")
+    assert env == "EXISTING=value\nLANGSMITH_PROJECT=old\n"
+    assert "LANGSMITH_TRACING=true" in env_example
+    assert "LANGSMITH_PROJECT=agent-tests" in env_example
+    assert "LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com" in env_example
+    assert "LANGSMITH_TRACING_MODE=hybrid" in env_example
+    assert "LANGSMITH_TRACING_SAMPLING_RATE=0.5" in env_example
+    assert "LANGSMITH_API_KEY=" not in env_example
     assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
-    assert "test-key" not in cli_output.out
-    assert "test-key" not in cli_output.err
+    assert "LANGSMITH_API_KEY" not in cli_output.out
+    assert "LANGSMITH_API_KEY" not in cli_output.err
     from arclith import Arclith
 
     arclith = Arclith(project_dir / "config")
@@ -404,19 +413,20 @@ def test_add_langsmith_observability_adapter_uses_catalog_params(
 
     assert arclith.config.adapters.observability.enabled == ["langsmith"]
     assert arclith.config.adapters.langsmith is not None
-    assert arclith.config.adapters.langsmith.tracing is True
+    assert arclith.config.adapters.langsmith.tracing.enabled is True
+    assert arclith.config.adapters.langsmith.tracing.mode == "hybrid"
     assert arclith.config.adapters.langsmith.project == "agent-tests"
     assert (
         arclith.config.adapters.langsmith.endpoint
         == "https://eu.api.smith.langchain.com"
     )
-    assert "test-key" not in load_output.out
-    assert "test-key" not in load_output.err
+    assert "LANGSMITH_API_KEY" not in load_output.out
+    assert "LANGSMITH_API_KEY" not in load_output.err
     package_root = project_dir / "src" / "demo_service"
     assert not (package_root / "adapters" / "outbound" / "langsmith").exists()
 
 
-def test_add_langsmith_preserves_existing_api_key_when_missing(tmp_path: Path) -> None:
+def test_add_langsmith_never_rewrites_existing_dotenv(tmp_path: Path) -> None:
     project_dir = _minimal_project(tmp_path)
     (project_dir / ".env").write_text(
         "LANGSMITH_API_KEY=existing-key\nLANGSMITH_PROJECT = old-project\n",
@@ -435,10 +445,10 @@ def test_add_langsmith_preserves_existing_api_key_when_missing(tmp_path: Path) -
     )
 
     env = (project_dir / ".env").read_text(encoding="utf-8")
-    assert "LANGSMITH_API_KEY=existing-key" in env
-    assert "LANGSMITH_PROJECT=agent-tests" in env
-    assert "LANGSMITH_PROJECT = old-project" not in env
-    assert env.count("LANGSMITH_PROJECT") == 1
+    env_example = (project_dir / ".env.example").read_text(encoding="utf-8")
+    assert env == "LANGSMITH_API_KEY=existing-key\nLANGSMITH_PROJECT = old-project\n"
+    assert "LANGSMITH_PROJECT=agent-tests" in env_example
+    assert "existing-key" not in env_example
 
 
 def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
@@ -455,7 +465,7 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
         yes=True,
     )
 
-    env = (project_dir / ".env").read_text(encoding="utf-8")
+    env = (project_dir / ".env.example").read_text(encoding="utf-8")
     config = (
         project_dir / "config" / "adapters" / "outbound" / "langsmith.yaml"
     ).read_text(encoding="utf-8")
@@ -463,6 +473,110 @@ def test_add_langsmith_skips_missing_empty_api_key(tmp_path: Path) -> None:
     assert "LANGSMITH_PROJECT=agent-tests" in env
     assert "api_key_env: LANGSMITH_API_KEY" in config
     assert "Définir LANGSMITH_API_KEY hors Git" in config
+
+
+def test_add_langsmith_rejects_api_key_cli_parameter(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="observability",
+            adapter="langsmith",
+            adapter_params={"project": "agent-tests", "api_key": "secret"},
+            yes=True,
+        )
+
+    assert not (project_dir / ".env.example").exists()
+
+
+@pytest.mark.parametrize(
+    ("profile", "sampling_rate", "diagnostics"),
+    [("development", "1.0", "true"), ("production", "0.1", "false")],
+)
+def test_add_langsmith_profiles_are_explicit_and_safe(
+    tmp_path: Path,
+    profile: str,
+    sampling_rate: str,
+    diagnostics: str,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        profile=profile,
+        yes=True,
+    )
+
+    config = (project_dir / "config/adapters/outbound/langsmith.yaml").read_text()
+    assert f"sampling_rate: {sampling_rate}" in config
+    assert f"enabled: {diagnostics}\n  log_level: info" in config
+    assert "model_content: false" in config
+
+
+def test_add_langsmith_adds_dependency_extra_idempotently(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    pyproject = project_dir / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\ndependencies = ["arclith[fastapi,mcp]>=0.18.0"]\n',
+        encoding="utf-8",
+    )
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="observability",
+            adapter="langsmith",
+            adapter_params={"project": "agent-tests"},
+            yes=True,
+        )
+
+    assert "arclith[fastapi,mcp,langsmith]>=0.18.0" in pyproject.read_text()
+
+
+def test_add_langsmith_preserves_existing_config_values(tmp_path: Path) -> None:
+    project_dir = _minimal_project(tmp_path)
+    config_path = project_dir / "config/adapters/outbound/langsmith.yaml"
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        adapter_params={"project": "custom-project"},
+        yes=True,
+    )
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["tracing"]["sampling_rate"] = 0.33
+    config["metadata"] = {"deployment.environment": "staging"}
+    config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+    env_example = project_dir / ".env.example"
+    env_example.write_text(
+        env_example.read_text(encoding="utf-8").replace(
+            "LANGSMITH_PROJECT=custom-project",
+            "LANGSMITH_PROJECT=existing-runtime-project",
+        ),
+        encoding="utf-8",
+    )
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="observability",
+        adapter="langsmith",
+        yes=True,
+    )
+    preserved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert preserved["project"] == "custom-project"
+    assert preserved["tracing"]["sampling_rate"] == 0.33
+    assert preserved["metadata"] == {"deployment.environment": "staging"}
+    assert "LANGSMITH_PROJECT=existing-runtime-project" in env_example.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_add_fastapi_api_adapter_generates_inbound_config_only(tmp_path: Path) -> None:
@@ -1430,6 +1544,7 @@ def test_add_langsmith_preserves_existing_opentelemetry_activation(
         )
     )
     env = (project_dir / ".env").read_text(encoding="utf-8")
+    env_example = (project_dir / ".env.example").read_text(encoding="utf-8")
     opentelemetry_config = (
         project_dir / "config" / "adapters" / "outbound" / "opentelemetry.yaml"
     ).read_text(encoding="utf-8")
@@ -1439,8 +1554,8 @@ def test_add_langsmith_preserves_existing_opentelemetry_activation(
     assert adapters_config["observability"]["enabled"].count("opentelemetry") == 1
     assert "EXISTING=value" in env
     assert "OTEL_SERVICE_NAME=demo-api" in env
-    assert "LANGSMITH_PROJECT=agent-tests" in env
-    assert "LANGSMITH_API_KEY=" not in env
+    assert "LANGSMITH_PROJECT=agent-tests" in env_example
+    assert "LANGSMITH_API_KEY=" not in env_example
     assert 'service_name: "demo-api"' in opentelemetry_config
 
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -168,19 +168,30 @@ def test_observability_capability_catalog_declares_langsmith() -> None:
     langsmith = capability.get_adapter("langsmith")
     assert langsmith is not None
     assert langsmith.config_path == "config/adapters/outbound/langsmith.yaml"
-    assert langsmith.env_path == ".env"
+    assert langsmith.env_path == ".env.example"
+    assert langsmith.dependency_extra == "langsmith"
     assert langsmith.entity_scoped is False
     assert [parameter.name for parameter in langsmith.parameters] == [
-        "tracing",
+        "tracing_enabled",
         "project",
         "endpoint",
-        "api_key",
+        "tracing_mode",
+        "sampling_rate",
+        "capture_inputs",
+        "capture_outputs",
+        "capture_metadata",
+        "capture_model_content",
+        "instrument_langgraph",
+        "instrument_pydantic_ai",
+        "instrument_fastapi",
+        "instrument_fastmcp",
+        "instrument_command_bus",
+        "diagnostics_enabled",
     ]
-    langsmith_parameters = {
-        parameter.name: parameter for parameter in langsmith.parameters
-    }
-    assert langsmith_parameters["api_key"].secret is True
-    assert langsmith_parameters["api_key"].default == ""
+    assert [profile.name for profile in langsmith.profiles] == [
+        "development",
+        "production",
+    ]
 
 
 def test_api_capability_catalog_declares_fastapi() -> None:
@@ -946,8 +957,8 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "opentelemetry",
     ]
     langsmith = observability["adapters"][0]
-    langsmith_parameters = {
-        parameter["name"]: parameter for parameter in langsmith["parameters"]
-    }
-    assert langsmith_parameters["api_key"]["secret"] is True
-    assert langsmith_parameters["api_key"]["default"] == ""
+    assert langsmith["dependency_extra"] == "langsmith"
+    assert [profile["name"] for profile in langsmith["profiles"]] == [
+        "development",
+        "production",
+    ]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -101,8 +101,8 @@ requires-dist = [
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'langgraph'", specifier = ">=0.4.31" },
     { name = "langgraph-store-mongodb", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-store-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.4.0" },
-    { name = "langsmith", marker = "extra == 'langgraph'", specifier = ">=0.4.0" },
+    { name = "langsmith", extras = ["otel"], marker = "extra == 'all'", specifier = ">=0.10,<1" },
+    { name = "langsmith", extras = ["otel"], marker = "extra == 'langsmith'", specifier = ">=0.10,<1" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "motor", marker = "extra == 'all'", specifier = "==3.7.1" },
     { name = "motor", marker = "extra == 'mongodb'", specifier = "==3.7.1" },
@@ -135,7 +135,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -104,18 +104,22 @@ arclith-cli add-adapter \
   --yes
 ```
 
-Générer la configuration LangSmith:
+Générer la configuration LangSmith avec un profil explicite:
 
 ```bash
-export LANGSMITH_API_KEY="<clé-langsmith>"
-
 arclith-cli add-adapter \
   --capability observability \
   --adapter langsmith \
+  --profile development \
   --param project=pantry-agent-dev \
   --param endpoint=https://api.smith.langchain.com \
-  --param api_key="$LANGSMITH_API_KEY" \
   --yes
+```
+
+La clé n'est jamais acceptée en argument CLI. La définir uniquement dans le runtime:
+
+```bash
+export LANGSMITH_API_KEY="<clé-langsmith>"
 ```
 
 La commande ajoute `langsmith` dans `config/adapters/adapters.yaml` sous
@@ -130,11 +134,12 @@ config/adapters/outbound/lm.yaml
 config/adapters/outbound/langsmith.yaml
 src/pantry_agent/application/intent_interpreters/ingredient_intent.py
 src/pantry_agent/adapters/inbound/langgraph/agent.py
+.env.example
 .env
 ```
 
-`langgraph.json` pointe vers `.env`; le serveur LangGraph local charge donc les variables
-`LANGSMITH_TRACING`, `LANGSMITH_PROJECT`, `LANGSMITH_ENDPOINT` et `LANGSMITH_API_KEY`.
+La CLI écrit les valeurs non secrètes dans `.env.example`. Copier celles nécessaires dans le
+runtime ou `.env`; `langgraph.json` charge `.env`, qui reste ignoré par Git.
 
 ## 4. Configurer LM Studio et l'interpréteur d'intention
 
@@ -216,7 +221,6 @@ from functools import lru_cache
 from typing import Any, TypedDict
 
 from arclith import Arclith
-from arclith.adapters.outbound.pydantic_ai.llm import PydanticAILLMAdapter
 from langgraph.graph import END, START
 
 from pantry_agent.application.intent_interpreters.ingredient_intent import IngredientIntentInterpreter
@@ -241,10 +245,7 @@ def _ingredient_service() -> IngredientService:
 
 @lru_cache(maxsize=1)
 def _intent_interpreter() -> IngredientIntentInterpreter:
-    lm_settings = arclith.config.adapters.lm
-    if lm_settings is None:
-        raise RuntimeError("config/adapters/outbound/lm.yaml est requis pour l'interpréteur d'intention.")
-    return IngredientIntentInterpreter(PydanticAILLMAdapter(lm_settings))
+    return IngredientIntentInterpreter(arclith.pydantic_ai_llm())
 
 
 def _last_user_message(state: AgentState) -> str:
@@ -297,10 +298,12 @@ prompts par les noms générés par `arclith-cli new`.
 Dans un terminal dedie:
 
 ```bash
-export LANGSMITH_TRACING=false
 export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run --frozen langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+Pour ce lancement hors ligne, retirer `langsmith` de `observability.enabled`; le tracer Arclith
+devient automatiquement no-op et aucune clé n'est requise.
 
 Hors ligne, tester directement l'API locale:
 

--- a/docs/capabilities/agent.md
+++ b/docs/capabilities/agent.md
@@ -173,17 +173,18 @@ Le LLM sert à interpréter ou choisir une action. Il ne persiste pas directemen
 
 ```bash
 arclith-cli add-adapter --capability llm --adapter lmstudio --yes
-arclith-cli add-adapter --capability observability --adapter langsmith --yes
+arclith-cli add-adapter --capability observability --adapter langsmith --profile development --yes
 ```
 
 LM Studio est pratique pour le local. LangSmith est optionnel mais utile pour
 inspecter les runs, messages et erreurs.
 
-Pour un développement hors ligne:
+Construire l'adapter Pydantic AI avec `arclith.pydantic_ai_llm()` pour recevoir automatiquement la
+capability de tracing locale à cet agent, sans instrumentation globale du processus.
+
+Pour un développement hors ligne, conserver `observability.enabled: []`, puis:
 
 ```bash
-unset LANGSMITH_API_KEY LANGCHAIN_API_KEY
-export LANGSMITH_TRACING=false
 export LANGGRAPH_CLI_NO_ANALYTICS=1
 ```
 

--- a/docs/capabilities/observability.md
+++ b/docs/capabilities/observability.md
@@ -1,80 +1,278 @@
 # Capability Observability
 
-Observabilité du runtime, de l'API et des agents.
-
-## Objectif
-
-Produire les signaux nécessaires pour relier une requête, un tool MCP, une
-commande RabbitMQ et un run agent.
+Arclith fournit une observabilité optionnelle aux frontières sans introduire de SDK fournisseur
+dans le domaine ou les use cases.
 
 ## Adapters
 
 | Adapter | Usage |
 |---|---|
-| `langsmith` | traces et runs agents LangGraph |
-| `opentelemetry` | traces et métriques OTLP |
+| `langsmith` | traces agents, contexte distribué et API avancées LangSmith |
+| `opentelemetry` | traces et métriques OTLP du runtime |
 
-## Commande
+Sans adapter activé, `arclith.tracer()` retourne un tracer no-op. Le code applicatif reste donc
+identique avec ou sans backend.
+
+## Installer et activer LangSmith
+
+L'installation, l'activation et l'émission sont trois décisions indépendantes:
 
 ```bash
-arclith-cli add-adapter --capability observability --adapter opentelemetry --yes
-arclith-cli add-adapter --capability observability --adapter langsmith --yes
+uv add "arclith[langsmith]"
+
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter langsmith \
+  --profile development \
+  --yes
 ```
 
-## Activation
+La commande:
+
+- ajoute l'extra `arclith[langsmith]` idempotemment;
+- génère `config/adapters/outbound/langsmith.yaml`;
+- ajoute `langsmith` à `observability.enabled`;
+- génère uniquement les valeurs non secrètes dans `.env.example`;
+- ajoute `.env` à `.gitignore`;
+- ne demande et n'écrit jamais la clé API.
+
+Copier les valeurs utiles de `.env.example` vers le secret store du runtime, puis définir:
+
+```bash
+export LANGSMITH_API_KEY="<secret>"
+```
+
+Si LangSmith n'est pas souhaité sur un environnement, ne pas le placer dans
+`adapters.observability.enabled`. Aucun module LangSmith, client, buffer ou appel réseau n'est alors
+créé.
+
+## Configuration complète
 
 ```yaml
 # config/adapters/adapters.yaml
+observability:
+  enabled:
+    - langsmith
+```
+
+```yaml
+# config/adapters/outbound/langsmith.yaml
+project: "my-service-dev"
+endpoint: "https://api.smith.langchain.com"
+api_key_env: LANGSMITH_API_KEY
+workspace_id_env: LANGSMITH_WORKSPACE_ID
+
+tracing:
+  enabled: true
+  mode: otel
+  sampling_rate: 1.0
+
+instrumentation:
+  langgraph: true
+  pydantic_ai: true
+  fastapi: false
+  fastmcp: true
+  command_bus: true
+
+capture:
+  inputs: false
+  outputs: false
+  metadata: true
+  model_content: false
+  binary_content: false
+  model_request_parameters: false
+
+propagation:
+  enabled: true
+  langsmith_headers: true
+  traceparent: true
+  baggage_allowlist: []
+
+tags:
+  - arclith
+metadata:
+  deployment.environment: development
+
+lifecycle:
+  flush_timeout_seconds: 5.0
+
+diagnostics:
+  enabled: true
+  log_level: info
+
+failure_mode: log-and-continue
+```
+
+Les prompts, réponses, arguments/résultats de tools et contenus binaires sont masqués par défaut.
+Activer leur capture uniquement après analyse des données et de leur durée de rétention.
+
+Pour une redaction métier plus fine, le projet consommateur injecte une fonction neutre au
+composition root. Arclith la transmet au client sans connaître les champs du domaine:
+
+```python
+from typing import Any
+
+from arclith import Arclith
+
+
+def redact_trace(payload: dict[str, Any]) -> dict[str, Any]:
+    sanitized = dict(payload)
+    sanitized.pop("email", None)
+    return sanitized
+
+
+arclith = Arclith("config", trace_anonymizer=redact_trace)
+```
+
+Cette fonction complète les interrupteurs `capture.*`; elle ne doit jamais réintroduire un champ
+masqué ni journaliser le payload reçu.
+
+## Profils CLI
+
+`development` active un sampling à `1.0` et les diagnostics. `production` utilise `0.1`, désactive
+les diagnostics et conserve tous les contenus sensibles masqués. Les deux profils gardent
+`model_content: false`; une capture explicite reste nécessaire.
+
+```bash
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter langsmith \
+  --profile production \
+  --param sampling_rate=0.05 \
+  --yes
+```
+
+## Précédence
+
+La résolution est déterministe:
+
+1. contexte d'invocation;
+2. variables `LANGSMITH_*`;
+3. YAML;
+4. valeurs sûres par défaut.
+
+Overrides supportés: `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`,
+`LANGSMITH_WORKSPACE_ID`, `LANGSMITH_PROJECT`, `LANGSMITH_ENDPOINT`,
+`LANGSMITH_TRACING_SAMPLING_RATE`, `LANGSMITH_HIDE_INPUTS`,
+`LANGSMITH_HIDE_OUTPUTS`, `LANGSMITH_HIDE_METADATA` et `LANGSMITH_TRACING_MODE`.
+
+Arclith ne transforme jamais le YAML en mutations de `os.environ`.
+
+## API neutre
+
+```python
+tracer = arclith.tracer()
+
+with tracer.span(
+    "resolve-user-intent",
+    kind="chain",
+    metadata={"feature": "todo-agent"},
+) as span:
+    result = resolve_intent()
+    span.set_outputs({"status": "resolved"})
+```
+
+Désactiver une invocation sensible sans modifier la configuration globale:
+
+```python
+with tracer.context(enabled=False):
+    await process_sensitive_request()
+```
+
+Le contexte accepte aussi `project`, `tags`, `metadata` et `parent`. Seuls
+`langsmith-trace`, `traceparent` et le baggage allowlisté peuvent être propagés.
+
+## API LangSmith avancée
+
+Arclith n'encapsule pas datasets, feedbacks, évaluations ou prompts:
+
+```python
+client = arclith.langsmith_client()
+```
+
+Le client est préconfiguré avec endpoint, workspace, politique de capture, mode et sampling. Il
+permet d'utiliser directement les nouvelles fonctions du SDK LangSmith.
+
+Pour un script court:
+
+```python
+try:
+    run_job()
+finally:
+    arclith.flush_observability()
+    arclith.close_observability()
+```
+
+FastAPI, FastMCP et les runners Arclith ferment automatiquement le runtime à l'arrêt.
+
+## Instrumentation automatique
+
+- `Arclith.langgraph()` configure le client, projet, tags et métadonnées avant compilation.
+- `Arclith.pydantic_ai_llm()` injecte l'instrumentation uniquement dans les agents Pydantic AI
+  construits par Arclith; aucun `Agent.instrument_all()` global n'est utilisé.
+- `Arclith.instrument_mcp()` trace les tools sans capturer leurs arguments/résultats bruts.
+- `Arclith.rabbitmq_command_bus()` injecte le contexte à la publication et l'extrait autour du
+  handler.
+- `instrumentation.fastapi: true` ajoute un span HTTP LangSmith lorsque FastAPI n'est pas déjà
+  instrumenté par OpenTelemetry.
+
+Les metadata de transport sont bornées: méthode/route HTTP, nom du tool, type de commande,
+destination et statut. Les payloads métier ne sont jamais ajoutés automatiquement.
+
+## LangSmith et OpenTelemetry ensemble
+
+Les deux adapters partagent un seul `TracerProvider` et plusieurs processors/exporters. Lorsque les
+deux sont activés, `tracing.mode` doit être `otel`; la configuration est refusée autrement pour
+éviter deux arbres concurrents.
+
+```yaml
 observability:
   enabled:
     - opentelemetry
     - langsmith
 ```
 
-## OpenTelemetry
+L'instrumentation FastAPI et Pydantic AI n'est alors créée qu'une fois et les spans sont fan-out vers
+OTLP et LangSmith. Une panne d'export reste fail-open et ne doit pas interrompre le métier.
+
+## Hors ligne
+
+Pour exécuter LangGraph sans LangSmith et sans clé, retirer `langsmith` de
+`observability.enabled`. L'extra `langgraph` ne déclare plus directement LangSmith; une éventuelle
+dépendance transitive du runtime LangGraph n'est jamais initialisée par Arclith.
 
 ```yaml
-# config/adapters/outbound/opentelemetry.yaml
-service_name: "my-service"
-endpoint: "http://localhost:4318"
-protocol: "http/protobuf"
-traces: true
-metrics: false
-instrument_fastapi: true
+observability:
+  enabled: []
 ```
 
-## LangSmith
+Le graphe et `arclith.tracer()` continuent de fonctionner localement.
 
-```yaml
-# config/adapters/outbound/langsmith.yaml
-tracing: true
-project: "my-service-dev"
-endpoint: "https://api.smith.langchain.com"
-api_key_env: LANGSMITH_API_KEY
-```
+## Test live optionnel
 
-LangSmith est optionnel pour exécuter un agent localement. Pour un poste hors ligne:
+Le test d'intégration est désactivé par défaut. Il émet un run identifiable, force le flush puis le
+recherche via le client:
 
 ```bash
-export LANGSMITH_TRACING=false
-export LANGGRAPH_CLI_NO_ANALYTICS=1
+ARCLITH_LANGSMITH_INTEGRATION=1 \
+LANGSMITH_API_KEY="<secret>" \
+LANGSMITH_PROJECT="arclith-integration" \
+uv run --extra all pytest -q tests/integration/test_langsmith.py
 ```
 
-Le run se valide alors via l'API locale LangGraph `http://127.0.0.1:2024`, pas via Studio.
+## Dépannage
 
-## Règles
-
-- OpenTelemetry sert au runtime, API, métriques et corrélation.
-- LangSmith sert aux runs agents et aux évaluations.
-- Définir `service.name`, `service.version` et l'environnement.
-- Propager `traceparent` entre HTTP, MCP, bus et agent.
-- Ne jamais envoyer de secret dans logs, traces ou attributs.
-
-## Validation
-
-```bash
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local uv run pytest
-```
+- `clé API absente`: injecter `LANGSMITH_API_KEY` ou retirer l'adapter de
+  `observability.enabled`.
+- `trace absente`: vérifier successivement `observability.enabled`, `tracing.enabled`, le sampling,
+  `LANGSMITH_TRACING` et le projet résolu dans `arclith.observability_diagnostics()`.
+- `ancienne valeur encore utilisée`: les variables sont résolues au démarrage lazy du runtime et
+  le client est ensuite conservé. Redémarrer le worker après un changement de secret ou de
+  `LANGSMITH_*`; Arclith ne relit pas l'environnement pour chaque span.
+- `spans dupliqués`: avec OpenTelemetry actif, imposer `tracing.mode: otel` et ne conserver qu'une
+  instrumentation FastAPI.
+- `Studio local hors ligne`: retirer LangSmith de l'activation et appeler directement l'API locale
+  LangGraph.
 
 ## Suite
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -309,6 +309,38 @@ dépendances.
 
 ---
 
+## ADR-014 — Observabilité LangSmith derrière un port neutre
+
+**Date :** 2026-08-26
+
+**Contexte :** Le scaffold LangSmith d'ADR-011 générait la configuration et `.env`, mais Arclith ne
+consommait pas le YAML au runtime. Chaque projet devait réimplémenter le client, le sampling, la
+confidentialité, la propagation et le flush. Importer LangSmith dans les use cases aurait en outre
+couplé le coeur à un backend SaaS optionnel.
+
+**Décision :** le coeur expose seulement `TracePort` et `TraceSpan`. Le composition root sélectionne
+un `NoOpTraceAdapter` ou le runtime outbound LangSmith. Le runtime configure le SDK par API, sans
+muter l'environnement, et fournit contexte conditionnel, propagation filtrée, cycle de vie et accès
+explicite au client natif. Pydantic AI reçoit une capability d'instrumentation par agent; aucune
+instrumentation globale n'est appliquée.
+
+Lorsque LangSmith et OpenTelemetry sont actifs ensemble, `tracing.mode=otel` est obligatoire. Le
+provider OpenTelemetry existant reçoit un processor LangSmith; les instrumentations FastAPI et
+Pydantic AI ne sont pas créées deux fois.
+
+**Conséquences :**
+
+- `pip install arclith` n'installe pas LangSmith et le tracer reste no-op;
+- `arclith[langsmith]` porte le SDK LangSmith et son support OpenTelemetry;
+- absence de clé ou d'extra avec adapter activé provoque une erreur de démarrage actionnable;
+- les pannes d'export restent fail-open;
+- le contenu GenAI et les payloads de transport sont absents par défaut;
+- `.env.example` contient uniquement des réglages non secrets et `.env` reste ignoré;
+- les fonctions avancées restent disponibles via `Arclith.langsmith_client()` sans être recopiées
+  dans Arclith.
+
+---
+
 **Contexte :** Exposer les services via le Model Context Protocol.
 
 **Décision :** `fastmcp>=3.1.0` avec trois transports : stdio, SSE, streamable-HTTP.

--- a/docs/deep-dives/agent.md
+++ b/docs/deep-dives/agent.md
@@ -99,14 +99,17 @@ Activer LangSmith pour inspecter:
 | erreurs node | diagnostiquer un blocage |
 | sorties use case | vérifier l'action réelle |
 
-LangSmith est optionnel pour exécuter localement. Hors ligne, désactiver le tracing et utiliser
+LangSmith est optionnel pour exécuter localement. Hors ligne, retirer l'adapter de
+`observability.enabled` et utiliser
 l'API locale de l'Agent Server:
 
 ```bash
-export LANGSMITH_TRACING=false
 export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
+
+Lorsque LangSmith est actif, préférer `arclith.pydantic_ai_llm()` à une construction directe de
+`PydanticAILLMAdapter`: le runtime applique alors sampling, masquage et provider partagé.
 
 ## Validation
 

--- a/docs/production/observability.md
+++ b/docs/production/observability.md
@@ -1,54 +1,99 @@
 # Observabilité Production
 
-Cette page donne le minimum pour diagnostiquer un service Arclith en production.
+L'observabilité Arclith reste un adapter outbound optionnel. Le domaine et les use cases ne
+connaissent ni LangSmith ni OpenTelemetry.
 
-## Objectif
-
-Chaque requête API, appel MCP, message bus ou run agent doit pouvoir être relié
-à un trace id, un service et un environnement.
-
-## Stack Cible
+## Stack cible
 
 | Besoin | Choix |
 |---|---|
 | Traces runtime/API | OpenTelemetry |
-| Traces agent | LangSmith |
-| Logs | logger structuré |
+| Traces agent et GenAI | LangSmith via le provider OpenTelemetry partagé |
+| Logs | logger structuré avec corrélation |
 | Santé | probes HTTP |
-| Corrélation | `traceparent` |
+| Propagation | W3C `traceparent` et `langsmith-trace` |
 
-## Ajouter Les Adapters
+## Générer le profil production
 
 ```bash
-arclith-cli add-adapter --capability observability --adapter opentelemetry --yes
-arclith-cli add-adapter --capability observability --adapter langsmith --yes
-arclith-cli add-adapter --capability logger --adapter loguru --yes
-arclith-cli add-adapter --capability probe --adapter server --yes
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter opentelemetry \
+  --yes
+
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter langsmith \
+  --profile production \
+  --yes
 ```
 
-## Variables Minimales
+Lorsque les deux backends sont actifs, LangSmith doit utiliser `tracing.mode: otel`. Arclith refuse
+les modes natif/hybride dans cette combinaison afin d'éviter les doublons.
+
+## Secrets et variables
 
 ```bash
 export OTEL_SERVICE_NAME=my-service
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 export OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production
+export LANGSMITH_API_KEY="<secret>"
+export LANGSMITH_PROJECT=my-service-production
+export LANGSMITH_TRACING=true
+export LANGSMITH_TRACING_MODE=otel
+export LANGSMITH_TRACING_SAMPLING_RATE=0.05
+export LANGSMITH_HIDE_INPUTS=true
+export LANGSMITH_HIDE_OUTPUTS=true
+export LANGSMITH_HIDE_METADATA=false
 ```
 
-## Règles
+Une clé appartenant à plusieurs workspaces requiert aussi `LANGSMITH_WORKSPACE_ID`.
 
-- Nommer explicitement le service et l'environnement.
-- Propager `traceparent` entre API, MCP, bus et agent.
-- Ne pas logger les secrets, tokens ou payloads sensibles.
-- Exposer `/health` et `/ready` sur un port de probe dédié.
-- Garder LangSmith optionnel si aucun agent n'est lancé.
+Ne jamais mettre la clé dans le YAML, `.env.example`, un argument CLI, une image ou un manifeste
+versionné. Utiliser le secret store de la plateforme.
+
+## Politique recommandée
+
+- prompts, réponses, tools, binaires et paramètres modèle masqués;
+- sampling adapté au volume;
+- baggage vide ou allowlisté clé par clé;
+- aucune donnée tenant brute; utiliser un hash stable seulement si nécessaire;
+- diagnostics LangSmith désactivés hors incident;
+- timeouts et buffers bornés;
+- Collector OTLP recommandé pour le fan-out runtime;
+- `failure_mode: log-and-continue` pour ne jamais bloquer le métier.
+
+Les metadata stables recommandées sont `service.name`, `service.version`,
+`deployment.environment`, `release.revision`, `request.id`, `correlation.id`, `thread_id` et un
+éventuel `tenant.id_hash` non réversible.
+
+## Cycle de vie
+
+FastAPI, FastMCP et le command bus démarrent le runtime après fork et appellent flush/close à
+l'arrêt. Les scripts et workers personnalisés doivent utiliser:
+
+```python
+try:
+    run_worker()
+finally:
+    arclith.close_observability(timeout=5.0)
+```
+
+La panne du Collector ou de LangSmith ne rend pas le service indisponible. Une dépendance absente,
+une configuration incohérente ou une clé manquante lorsque LangSmith est activé provoque en revanche
+une erreur de démarrage actionnable.
 
 ## Vérifier
 
 ```bash
-OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=local uv run pytest
+uv run --extra all pytest
 curl -fsS http://127.0.0.1:9000/health
 ```
 
+Vérifier aussi qu'une requête API, un tool MCP, une commande RabbitMQ et un run agent partagent le
+même contexte, sans payload sensible ni span dupliqué.
+
 ## Suite
 
-Lire [runtime et probes](runtime.md), puis les capabilities [observability](../capabilities/observability.md) et [logger](../capabilities/logger.md).
+Lire [runtime et probes](runtime.md), [capability observability](../capabilities/observability.md) et
+[logger](../capabilities/logger.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -275,10 +275,19 @@ pour valider un run local:
 uv add "arclith[langgraph]"
 arclith-cli add-adapter --capability llm --adapter lmstudio --param "model_name=<model-id-lm-studio>" --yes
 arclith-cli add-adapter --capability agent --adapter langgraph
-arclith-cli add-adapter --capability observability --adapter langsmith
-export LANGSMITH_TRACING=false
 export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
+```
+
+Ajouter LangSmith séparément uniquement lorsque les traces distantes sont souhaitées:
+
+```bash
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter langsmith \
+  --profile development \
+  --yes
+export LANGSMITH_API_KEY="<secret>"
 ```
 
 Tester sans Studio:
@@ -301,11 +310,12 @@ Le flux attendu est: utilisateur ou canal conversationnel -> LangGraph Agent Ser
 ports et use cases applicatifs. Les nodes peuvent utiliser un `LLMPort` configuré par `llm/*` et les
 traces via `observability/*`, sans appeler les repositories directement.
 
-L'adapter `observability/langsmith` demande le projet LangSmith, l'endpoint, l'activation du tracing et
-`LANGSMITH_API_KEY`. Elle génère `config/adapters/outbound/langsmith.yaml`, ajoute `langsmith` à
-`observability.enabled`, met à jour `.env`, et ajoute `.env` au `.gitignore` si besoin.
-Si la clé n'est pas passée à la CLI, définir `LANGSMITH_API_KEY` manuellement dans `.env`,
-l'environnement runtime ou un secret manager avant de lancer `langgraph dev`.
+L'adapter `observability/langsmith` génère `config/adapters/outbound/langsmith.yaml`, ajoute
+`langsmith` à `observability.enabled`, ajoute l'extra optionnel correspondant et écrit uniquement
+les valeurs non secrètes dans `.env.example`. La CLI ne demande et n'écrit jamais la clé API.
+Définir `LANGSMITH_API_KEY` dans l'environnement runtime ou un secret manager avant de lancer un
+service avec cet adapter activé. Sans LangSmith, ne pas l'ajouter à `observability.enabled`: aucun
+client, buffer ou appel réseau n'est alors créé.
 
 L'adapter `llm/lmstudio` génère `config/adapters/outbound/lm.yaml`, chargé dans
 `AppConfig.adapters.lm`. L'interpréteur d'intention applicatif consomme ensuite un `LLMPort`;

--- a/docs/runtime-docker/kubernetes.md
+++ b/docs/runtime-docker/kubernetes.md
@@ -48,7 +48,7 @@ metadata:
 type: Opaque
 stringData:
   MONGODB_URI: mongodb://mongo:27017/my-service
-  LANGSMITH_API_KEY: change-me
+  LANGSMITH_API_KEY: <injecté-par-le-secret-manager>
 ```
 
 En vrai déploiement, générer les `Secret` depuis le gestionnaire de secrets de la plateforme, pas

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -62,7 +62,6 @@ docker build -t my-service:local .
 ```bash
 docker run --rm \
   --env-file .env.local \
-  -e LANGSMITH_TRACING=false \
   -e LANGGRAPH_CLI_NO_ANALYTICS=1 \
   -e LANGGRAPH_HOST=0.0.0.0 \
   -e LANGGRAPH_PORT=2024 \
@@ -136,6 +135,10 @@ POSTGRESQL_URL
 REDIS_URL
 VAULT_TOKEN
 ```
+
+Les réglages LangSmith non secrets sont générés dans `.env.example`. La clé reste injectée au
+runtime. Pour un conteneur hors ligne, conserver `observability.enabled: []` plutôt que d'activer un
+adapter LangSmith incomplet.
 
 Utiliser un fichier local non commité:
 

--- a/docs/tutorials/todo-list/06-agent-config.md
+++ b/docs/tutorials/todo-list/06-agent-config.md
@@ -48,16 +48,20 @@ base_url: "http://127.0.0.1:1234/v1"
 
 LangSmith est optionnel pour exécuter localement, mais utile pour inspecter les runs.
 
-Si vous travaillez hors ligne, désactiver explicitement le tracing et passer directement à la
+Si vous travaillez hors ligne, conserver `observability.enabled: []` et passer directement à la
 configuration LangGraph:
 
 ```dotenv
-LANGSMITH_TRACING=false
 LANGGRAPH_CLI_NO_ANALYTICS=1
 ```
 
+Sinon, ajouter LangSmith avec le profil de développement:
+
 ```bash
-arclith-cli add-adapter --capability observability
+arclith-cli add-adapter \
+  --capability observability \
+  --adapter langsmith \
+  --profile development
 ```
 
 Répondre:
@@ -68,10 +72,9 @@ Répondre:
    2  opentelemetry
 
   Votre choix (numéro ou nom): 1
-  Activer LANGSMITH_TRACING [y/n] (y): y
+  Activer le tracing LangSmith [y/n] (y): y
   Projet LangSmith (todo-list-service): todo-list-service-dev
   Endpoint LangSmith (https://api.smith.langchain.com):
-  LANGSMITH_API_KEY:
   Activer langsmith [y/n] (y): y
   Confirmer la génération ? [y/n] (y): y
 ```
@@ -79,15 +82,21 @@ Répondre:
 Vérifier `config/adapters/outbound/langsmith.yaml`:
 
 ```yaml
-tracing: true
 project: "todo-list-service"
 endpoint: "https://api.smith.langchain.com"
 api_key_env: LANGSMITH_API_KEY
+workspace_id_env: LANGSMITH_WORKSPACE_ID
+tracing:
+  enabled: true
+  mode: otel
+  sampling_rate: 1.0
 studio: langgraph
 langgraph_api_min_version: "0.11.0"
 ```
 
-La clé reste dans `.env`, jamais dans Git. LangSmith sert à observer l'agent:
+La CLI écrit uniquement les valeurs non secrètes dans `.env.example`. La clé est injectée dans le
+runtime via `LANGSMITH_API_KEY`, jamais via un argument CLI ou dans Git. LangSmith sert à observer
+l'agent:
 
 - LangGraph exécute le graphe localement;
 - LM Studio fournit le modèle local;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,12 @@ vault   = ["hvac==2.3.0"]
 cache   = ["redis>=5.0.0"]
 auth    = ["PyJWT[crypto]>=2.8.0", "httpx>=0.27.0"]
 rabbitmq = ["aio-pika>=10.0.1,<11.0.0"]
-langgraph = ["langgraph>=1.0.8", "langgraph-api>=0.11.0", "langgraph-cli[inmem]>=0.4.31", "langsmith>=0.4.0", "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"]
+langgraph = ["langgraph>=1.0.8", "langgraph-api>=0.11.0", "langgraph-cli[inmem]>=0.4.31", "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"]
 langgraph-persistence-sqlite = ["langgraph-checkpoint-sqlite>=3.0.0,<4.0.0"]
 langgraph-persistence-postgresql = ["langgraph-checkpoint-postgres>=3.0.0,<4.0.0", "psycopg[binary,pool]>=3.2.0,<4.0.0"]
 langgraph-persistence-mongodb = ["langgraph-checkpoint-mongodb>=0.3.0,<1.0.0", "langgraph-store-mongodb>=0.2.0,<1.0.0"]
 langgraph-persistence-redis = ["langgraph-checkpoint-redis>=0.2.0,<1.0.0"]
+langsmith = ["langsmith[otel]>=0.10,<1"]
 opentelemetry = ["opentelemetry-api>=1.30.0", "opentelemetry-sdk>=1.30.0", "opentelemetry-exporter-otlp>=1.30.0", "opentelemetry-instrumentation-fastapi>=0.51b0", "opentelemetry-instrumentation-logging>=0.51b0"]
 all     = [
     "motor==3.7.1",
@@ -69,7 +70,7 @@ all     = [
     "langgraph>=1.0.8",
     "langgraph-api>=0.11.0",
     "langgraph-cli[inmem]>=0.4.31",
-    "langsmith>=0.4.0",
+    "langsmith[otel]>=0.10,<1",
     "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
     "langgraph-checkpoint-postgres>=3.0.0,<4.0.0",

--- a/tests/integration/test_langsmith.py
+++ b/tests/integration/test_langsmith.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import time
+from uuid import uuid4
+
+import pytest
+
+from arclith.adapters.outbound.langsmith.runtime import LangSmithRuntime
+from arclith.infrastructure.config import LangSmithSettings
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("ARCLITH_LANGSMITH_INTEGRATION") != "1",
+    reason="ARCLITH_LANGSMITH_INTEGRATION=1 non configure",
+)
+
+
+def test_langsmith_live_trace_is_queryable(logger) -> None:
+    if not os.getenv("LANGSMITH_API_KEY"):
+        pytest.fail("LANGSMITH_API_KEY est requis pour le test live LangSmith")
+
+    project = os.getenv("LANGSMITH_PROJECT", "arclith-integration")
+    run_name = f"arclith-integration-{uuid4().hex}"
+    runtime = LangSmithRuntime(
+        LangSmithSettings(
+            project=project,
+            tracing={"mode": "langsmith"},
+            capture={"inputs": False, "outputs": False, "metadata": True},
+        ),
+        logger,
+        service_metadata={"service.name": "arclith-integration"},
+    )
+
+    try:
+        with runtime.span(run_name, metadata={"test.kind": "live"}) as span:
+            span.set_outputs({"status": "ok"})
+        runtime.flush(timeout=10.0)
+
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            runs = list(
+                runtime.client().list_runs(
+                    project_name=project,
+                    filter=f'eq(name, "{run_name}")',
+                    limit=1,
+                )
+            )
+            if runs:
+                assert runs[0].name == run_name
+                break
+            time.sleep(1.0)
+        else:
+            pytest.fail(f"run LangSmith introuvable apres flush: {run_name}")
+    finally:
+        runtime.close(timeout=10.0)

--- a/tests/units/adapters/bidirectional/rabbitmq/test_command_bus.py
+++ b/tests/units/adapters/bidirectional/rabbitmq/test_command_bus.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import builtins
 import json
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 
@@ -11,6 +12,7 @@ import pytest
 from arclith.adapters.bidirectional.rabbitmq import RabbitMQCommandBus
 from arclith.application.command_bus import CommandDispatcher
 from arclith.domain.ports.inbound.command_bus import CommandHandler
+from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
 from arclith.infrastructure.config import RabbitMQCommandBusSettings
 
 
@@ -34,7 +36,9 @@ class FakeExchange:
 
 
 class FakeQueue:
-    def __init__(self, name: str, durable: bool, arguments: dict[str, str] | None) -> None:
+    def __init__(
+        self, name: str, durable: bool, arguments: dict[str, str] | None
+    ) -> None:
         self.name = name
         self.durable = durable
         self.arguments = arguments
@@ -82,7 +86,9 @@ class FakeChannel:
     async def set_qos(self, *, prefetch_count: int) -> None:
         self.prefetch_count = prefetch_count
 
-    async def declare_exchange(self, name: str, exchange_type: str, *, durable: bool) -> FakeExchange:
+    async def declare_exchange(
+        self, name: str, exchange_type: str, *, durable: bool
+    ) -> FakeExchange:
         exchange = FakeExchange(name, exchange_type, durable)
         self.exchanges[name] = exchange
         return exchange
@@ -140,14 +146,18 @@ class RecordingHandler(CommandHandler):
     def __init__(self) -> None:
         self.calls: list[tuple[Mapping[str, Any], Mapping[str, str]]] = []
 
-    async def handle(self, payload: Mapping[str, Any], headers: Mapping[str, str]) -> None:
+    async def handle(
+        self, payload: Mapping[str, Any], headers: Mapping[str, str]
+    ) -> None:
         self.calls.append((payload, headers))
 
 
 class FailingHandler(CommandHandler):
     command_type = "todo.create"
 
-    async def handle(self, payload: Mapping[str, Any], headers: Mapping[str, str]) -> None:
+    async def handle(
+        self, payload: Mapping[str, Any], headers: Mapping[str, str]
+    ) -> None:
         raise RuntimeError("boom")
 
 
@@ -156,6 +166,58 @@ FakeAioPika = SimpleNamespace(
     ExchangeType=SimpleNamespace(DIRECT="direct", TOPIC="topic"),
     Message=FakePublishedMessage,
 )
+
+
+class RecordingTraceSpan(TraceSpan):
+    def set_outputs(self, outputs: object | None) -> None:
+        return None
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        return None
+
+
+class RecordingTracer(TracePort):
+    def __init__(self) -> None:
+        self.span_names: list[str] = []
+        self.parents: list[Mapping[str, str] | None] = []
+        self.events: list[str] = []
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        self.span_names.append(name)
+        self.events.append(f"span:{name}")
+        yield RecordingTraceSpan()
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        self.parents.append(parent)
+        yield
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        self.events.append("inject")
+        headers["langsmith-trace"] = "trace-value"
+
+    def flush(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self, timeout: float | None = None) -> None:
+        return None
 
 
 async def test_rabbitmq_command_bus_publish_configures_reliable_channel(logger) -> None:
@@ -268,6 +330,63 @@ async def test_rabbitmq_command_bus_publish_adds_current_traceparent(
     assert message.headers["traceparent"] == f"00-{'a' * 32}-{'b' * 16}-01"
 
 
+async def test_rabbitmq_command_bus_propagates_langsmith_context(logger) -> None:
+    connection = FakeConnection()
+
+    async def connector(url: str) -> FakeConnection:
+        return connection
+
+    tracer = RecordingTracer()
+    bus = RabbitMQCommandBus(
+        RabbitMQCommandBusSettings(url="amqp://broker/"),
+        logger,
+        tracer=tracer,
+        connector=connector,
+        aio_pika_module=FakeAioPika,
+    )
+
+    await bus.publish("todo.create", {"title": "write docs"})
+
+    channel = connection.channel_instance
+    assert channel is not None
+    message, _routing_key = channel.exchanges["arclith.commands"].published[0]
+    assert message.headers["langsmith-trace"] == "trace-value"
+    assert tracer.span_names == ["rabbitmq.publish"]
+    assert tracer.events == ["span:rabbitmq.publish", "inject"]
+
+
+async def test_rabbitmq_command_bus_extracts_context_for_handler(logger) -> None:
+    tracer = RecordingTracer()
+    handler = RecordingHandler()
+    dispatcher = CommandDispatcher([handler])
+    message = FakeIncomingMessage(
+        b'{"payload": {"title": "write docs"}}',
+        headers={
+            "command_type": "todo.create",
+            "langsmith-trace": "trace-value",
+            "baggage": "safe=yes",
+        },
+    )
+    bus = RabbitMQCommandBus(
+        RabbitMQCommandBusSettings(),
+        logger,
+        tracer=tracer,
+        aio_pika_module=FakeAioPika,
+    )
+
+    await bus.handle_message(message, dispatcher)
+
+    assert tracer.parents == [
+        {
+            "command_type": "todo.create",
+            "langsmith-trace": "trace-value",
+            "baggage": "safe=yes",
+        }
+    ]
+    assert tracer.span_names == ["rabbitmq.process"]
+    assert message.acked is True
+
+
 async def test_rabbitmq_command_bus_acks_after_dispatch_success(logger) -> None:
     handler = RecordingHandler()
     dispatcher = CommandDispatcher([handler])
@@ -276,13 +395,20 @@ async def test_rabbitmq_command_bus_acks_after_dispatch_success(logger) -> None:
         headers={"command_type": "todo.create"},
         correlation_id="corr-1",
     )
-    bus = RabbitMQCommandBus(RabbitMQCommandBusSettings(), logger, aio_pika_module=FakeAioPika)
+    bus = RabbitMQCommandBus(
+        RabbitMQCommandBusSettings(), logger, aio_pika_module=FakeAioPika
+    )
 
     await bus.handle_message(message, dispatcher)
 
     assert message.acked is True
     assert message.nacked is None
-    assert handler.calls == [({"title": "write docs"}, {"command_type": "todo.create", "correlation_id": "corr-1"})]
+    assert handler.calls == [
+        (
+            {"title": "write docs"},
+            {"command_type": "todo.create", "correlation_id": "corr-1"},
+        )
+    ]
 
 
 async def test_rabbitmq_command_bus_nacks_to_dlx_after_dispatch_error(logger) -> None:
@@ -292,7 +418,9 @@ async def test_rabbitmq_command_bus_nacks_to_dlx_after_dispatch_error(logger) ->
         headers={"command_type": "todo.create"},
         correlation_id="corr-1",
     )
-    bus = RabbitMQCommandBus(RabbitMQCommandBusSettings(), logger, aio_pika_module=FakeAioPika)
+    bus = RabbitMQCommandBus(
+        RabbitMQCommandBusSettings(), logger, aio_pika_module=FakeAioPika
+    )
 
     await bus.handle_message(message, dispatcher)
 
@@ -316,7 +444,9 @@ async def test_rabbitmq_command_bus_invalid_json_never_requeues(logger) -> None:
     assert message.nacked is False
 
 
-async def test_rabbitmq_command_bus_run_uses_named_consumer_and_dispatches(logger) -> None:
+async def test_rabbitmq_command_bus_run_uses_named_consumer_and_dispatches(
+    logger,
+) -> None:
     connection = FakeConnection()
 
     async def connector(url: str) -> FakeConnection:

--- a/tests/units/adapters/outbound/langsmith/test_config.py
+++ b/tests/units/adapters/outbound/langsmith/test_config.py
@@ -61,6 +61,28 @@ def test_resolve_langsmith_config_uses_custom_secret_names(
     assert resolved.tracing_mode == "langsmith"
 
 
+@pytest.mark.parametrize("empty_value", ["", " \t "])
+def test_resolve_langsmith_config_ignores_empty_string_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    empty_value: str,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-key")
+    monkeypatch.setenv("LANGSMITH_PROJECT", empty_value)
+    monkeypatch.setenv("LANGSMITH_ENDPOINT", empty_value)
+    monkeypatch.setenv("LANGSMITH_TRACING_MODE", empty_value)
+    settings = LangSmithSettings(
+        project="yaml-project",
+        endpoint="https://yaml.example.test",
+        tracing={"mode": "hybrid"},
+    )
+
+    resolved = resolve_langsmith_config(settings)
+
+    assert resolved.project == "yaml-project"
+    assert resolved.endpoint == "https://yaml.example.test"
+    assert resolved.tracing_mode == "hybrid"
+
+
 def test_resolve_langsmith_config_requires_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/units/adapters/outbound/langsmith/test_config.py
+++ b/tests/units/adapters/outbound/langsmith/test_config.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pytest
+
+from arclith.adapters.outbound.langsmith.config import resolve_langsmith_config
+from arclith.infrastructure.config import LangSmithSettings
+
+
+def test_resolve_langsmith_config_applies_environment_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-key")
+    monkeypatch.setenv("LANGSMITH_WORKSPACE_ID", "workspace-env")
+    monkeypatch.setenv("LANGSMITH_PROJECT", "project-env")
+    monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://eu.api.smith.langchain.com")
+    monkeypatch.setenv("LANGSMITH_TRACING", "false")
+    monkeypatch.setenv("LANGSMITH_TRACING_MODE", "hybrid")
+    monkeypatch.setenv("LANGSMITH_TRACING_SAMPLING_RATE", "0.25")
+    monkeypatch.setenv("LANGSMITH_HIDE_INPUTS", "false")
+    monkeypatch.setenv("LANGSMITH_HIDE_OUTPUTS", "true")
+    monkeypatch.setenv("LANGSMITH_HIDE_METADATA", "false")
+    settings = LangSmithSettings.model_validate(
+        {
+            "project": "yaml-project",
+            "endpoint": "https://yaml.example.test",
+            "tracing": {"enabled": True, "mode": "langsmith", "sampling_rate": 1.0},
+            "capture": {"inputs": False, "outputs": True, "metadata": False},
+        }
+    )
+
+    resolved = resolve_langsmith_config(settings)
+
+    assert resolved.project == "project-env"
+    assert resolved.endpoint == "https://eu.api.smith.langchain.com"
+    assert resolved.workspace_id == "workspace-env"
+    assert resolved.tracing_enabled is False
+    assert resolved.tracing_mode == "hybrid"
+    assert resolved.sampling_rate == 0.25
+    assert resolved.capture_inputs is True
+    assert resolved.capture_outputs is False
+    assert resolved.capture_metadata is True
+    assert "secret-key" not in repr(resolved)
+
+
+def test_resolve_langsmith_config_uses_custom_secret_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUSTOM_LANGSMITH_KEY", "custom-secret")
+    monkeypatch.setenv("CUSTOM_WORKSPACE", "custom-workspace")
+    settings = LangSmithSettings(
+        project="agent-tests",
+        api_key_env="CUSTOM_LANGSMITH_KEY",
+        workspace_id_env="CUSTOM_WORKSPACE",
+        tracing={"mode": "langsmith"},
+    )
+
+    resolved = resolve_langsmith_config(settings)
+
+    assert resolved.api_key == "custom-secret"
+    assert resolved.workspace_id == "custom-workspace"
+    assert resolved.tracing_mode == "langsmith"
+
+
+def test_resolve_langsmith_config_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="aucune cle API"):
+        resolve_langsmith_config(LangSmithSettings(project="agent-tests"))
+
+
+def test_resolve_langsmith_config_names_custom_missing_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("CUSTOM_LANGSMITH_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="CUSTOM_LANGSMITH_KEY"):
+        resolve_langsmith_config(
+            LangSmithSettings(
+                project="agent-tests",
+                api_key_env="CUSTOM_LANGSMITH_KEY",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("LANGSMITH_TRACING", "sometimes", "booleen"),
+        ("LANGSMITH_TRACING_SAMPLING_RATE", "many", "nombre"),
+        ("LANGSMITH_TRACING_SAMPLING_RATE", "1.5", "0.0 et 1.0"),
+        ("LANGSMITH_TRACING_MODE", "magic", "Valeurs"),
+    ],
+)
+def test_resolve_langsmith_config_rejects_invalid_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+    message: str,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-key")
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(RuntimeError, match=message):
+        resolve_langsmith_config(LangSmithSettings(project="agent-tests"))

--- a/tests/units/adapters/outbound/langsmith/test_fastapi.py
+++ b/tests/units/adapters/outbound/langsmith/test_fastapi.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from arclith.adapters.outbound.langsmith.fastapi import instrument_fastapi_app
+from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
+
+
+class RecordingSpan(TraceSpan):
+    def __init__(self) -> None:
+        self.outputs: list[object | None] = []
+        self.metadata: list[Mapping[str, object]] = []
+
+    def set_outputs(self, outputs: object | None) -> None:
+        self.outputs.append(outputs)
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        self.metadata.append(metadata)
+
+
+class RecordingTracer(TracePort):
+    def __init__(self) -> None:
+        self.context_parents: list[Mapping[str, str] | None] = []
+        self.spans: list[tuple[str, Mapping[str, object] | None, RecordingSpan]] = []
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        span = RecordingSpan()
+        self.spans.append((name, metadata, span))
+        yield span
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        self.context_parents.append(parent)
+        yield
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        return None
+
+    def flush(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self, timeout: float | None = None) -> None:
+        return None
+
+
+def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() -> None:
+    app = FastAPI()
+
+    @app.get("/items/{item_id}")
+    async def read_item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    tracer = RecordingTracer()
+    instrument_fastapi_app(app, tracer)
+
+    response = TestClient(app).get(
+        "/items/42?token=secret",
+        headers={
+            "langsmith-trace": "trace-value",
+            "baggage": "safe=yes",
+            "authorization": "Bearer secret",
+        },
+    )
+
+    assert response.status_code == 200
+    assert tracer.context_parents == [
+        {"langsmith-trace": "trace-value", "baggage": "safe=yes"}
+    ]
+    name, metadata, span = tracer.spans[0]
+    assert name == "http.server.request"
+    assert metadata == {"http.request.method": "GET", "url.scheme": "http"}
+    assert span.outputs == [{"status_code": 200}]
+    assert span.metadata == [
+        {"http.response.status_code": 200, "http.route": "/items/{item_id}"}
+    ]

--- a/tests/units/adapters/outbound/langsmith/test_privacy.py
+++ b/tests/units/adapters/outbound/langsmith/test_privacy.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from arclith.adapters.outbound.langsmith.privacy import trace_metadata, trace_payload
+
+
+class ExampleModel(BaseModel):
+    name: str
+
+
+@dataclass
+class ExampleData:
+    value: int
+
+
+def test_trace_payload_is_empty_when_capture_is_disabled() -> None:
+    assert trace_payload({"secret": "value"}, enabled=False) == {}
+    assert trace_payload(None, enabled=True) == {}
+
+
+def test_trace_payload_serializes_supported_values_without_binary_content() -> None:
+    payload = trace_payload(
+        {
+            "model": ExampleModel(name="demo"),
+            "data": ExampleData(value=7),
+            "sequence": (1, 2),
+            "binary": b"secret bytes",
+            "custom": object(),
+        },
+        enabled=True,
+    )
+
+    assert payload["model"] == {"name": "demo"}
+    assert payload["data"] == {"value": 7}
+    assert payload["sequence"] == [1, 2]
+    assert payload["binary"] == "<binary omitted>"
+    assert isinstance(payload["custom"], str)
+    assert trace_payload("hello", enabled=True) == {"value": "hello"}
+
+
+def test_trace_metadata_honors_capture_switch() -> None:
+    assert trace_metadata({"safe": True}, enabled=True) == {"safe": True}
+    assert trace_metadata({"safe": True}, enabled=False) == {}
+    assert trace_metadata(None, enabled=True) == {}

--- a/tests/units/adapters/outbound/langsmith/test_propagation.py
+++ b/tests/units/adapters/outbound/langsmith/test_propagation.py
@@ -1,0 +1,68 @@
+import urllib.parse
+
+from arclith.adapters.outbound.langsmith.propagation import (
+    filter_baggage,
+    merge_baggage,
+    normalized_parent_headers,
+)
+
+
+def test_filter_baggage_keeps_only_allowlisted_metadata_and_fields() -> None:
+    metadata = urllib.parse.quote('{"safe":"yes","secret":"no"}')
+    baggage = (
+        f"langsmith-metadata={metadata},langsmith-tags=dev,"
+        "langsmith-project=agent-tests,correlation.id=corr-1,token=secret"
+    )
+
+    filtered = filter_baggage(
+        baggage,
+        allowlist={"safe", "tags", "project", "correlation.id"},
+    )
+
+    assert "safe" in urllib.parse.unquote(filtered)
+    assert "secret" not in urllib.parse.unquote(filtered)
+    assert "langsmith-tags=dev" in filtered
+    assert "langsmith-project=agent-tests" in filtered
+    assert "correlation.id=corr-1" in filtered
+    assert "token=" not in filtered
+
+
+def test_filter_baggage_rejects_invalid_or_unallowed_values() -> None:
+    assert filter_baggage("", allowlist={"safe"}) == ""
+    assert filter_baggage("safe=value", allowlist=set()) == ""
+    assert (
+        filter_baggage("invalid,langsmith-metadata=not-json", allowlist={"safe"}) == ""
+    )
+
+
+def test_normalized_parent_headers_filters_transport_headers() -> None:
+    headers = normalized_parent_headers(
+        {
+            "LangSmith-Trace": "trace-value",
+            "TraceParent": "00-abc-def-01",
+            "Baggage": "safe=yes,secret=no",
+            "Authorization": "Bearer secret",
+        },
+        allowlist={"safe"},
+        langsmith_headers=True,
+        traceparent=True,
+    )
+
+    assert headers == {
+        "langsmith-trace": "trace-value",
+        "traceparent": "00-abc-def-01",
+        "baggage": "safe=yes",
+    }
+    assert (
+        normalized_parent_headers(
+            None,
+            allowlist=set(),
+            langsmith_headers=True,
+            traceparent=True,
+        )
+        == {}
+    )
+
+
+def test_merge_baggage_is_stable_and_deduplicated() -> None:
+    assert merge_baggage("a=1,b=2", "b=3,c=4") == "a=1,b=2,c=4"

--- a/tests/units/adapters/outbound/langsmith/test_runtime.py
+++ b/tests/units/adapters/outbound/langsmith/test_runtime.py
@@ -281,12 +281,11 @@ def test_runtime_context_can_override_tracing_and_preserves_body_errors(
                 "authorization": "Bearer secret",
             },
         ):
+            context_call = trace_calls[0]["context"]
+            assert context_call["enabled"] is False
+            assert context_call["project_name"] == "sensitive-project"
+            assert context_call["parent"] == {"langsmith-trace": "trace-value"}
             raise ValueError("business failure")
-
-    context_call = trace_calls[0]["context"]
-    assert context_call["enabled"] is False
-    assert context_call["project_name"] == "sensitive-project"
-    assert context_call["parent"] == {"langsmith-trace": "trace-value"}
 
 
 def test_runtime_propagates_only_allowlisted_baggage(

--- a/tests/units/adapters/outbound/langsmith/test_runtime.py
+++ b/tests/units/adapters/outbound/langsmith/test_runtime.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import builtins
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import langsmith
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+
+from arclith.adapters.outbound.langsmith.runtime import (
+    LangSmithRuntime,
+    LangSmithTraceSpan,
+)
+from arclith.adapters.outbound.noop.observability import NoOpTraceSpan
+from arclith.infrastructure.config import LangSmithSettings
+
+
+class FakeClient:
+    instances: list["FakeClient"] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.flush_calls: list[float | None] = []
+        self.close_calls: list[float | None] = []
+        self.instances.append(self)
+
+    def flush(self, timeout: float | None = None) -> None:
+        self.flush_calls.append(timeout)
+
+    def close(self, timeout: float | None = None) -> None:
+        self.close_calls.append(timeout)
+
+
+class FakeRunTree:
+    def __init__(self) -> None:
+        self.metadata: dict[str, Any] = {}
+        self.end_calls: list[dict[str, Any]] = []
+
+    def end(self, **kwargs: Any) -> None:
+        self.end_calls.append(kwargs)
+
+    def to_headers(self) -> dict[str, str]:
+        return {
+            "langsmith-trace": "trace-value",
+            "baggage": (
+                "langsmith-metadata=%7B%22safe%22%3A%22yes%22%2C"
+                "%22secret%22%3A%22no%22%7D,langsmith-project=agent-tests"
+            ),
+        }
+
+
+class FakeTraceContext:
+    def __init__(self, run_tree: FakeRunTree, *, fail_enter: bool = False) -> None:
+        self.run_tree = run_tree
+        self.fail_enter = fail_enter
+        self.exit_calls: list[tuple[Any, Any, Any]] = []
+
+    def __enter__(self) -> FakeRunTree:
+        if self.fail_enter:
+            raise RuntimeError("export unavailable")
+        return self.run_tree
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.exit_calls.append(exc_info)
+
+
+class FakeProcessor:
+    def __init__(self) -> None:
+        self.flush_calls: list[int] = []
+        self.shutdown_calls = 0
+
+    def force_flush(self, timeout_millis: int) -> None:
+        self.flush_calls.append(timeout_millis)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+def _runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+    *,
+    settings: dict[str, Any] | None = None,
+    anonymizer: Any | None = None,
+) -> tuple[LangSmithRuntime, list[dict[str, Any]], list[dict[str, Any]], FakeRunTree]:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-key")
+    FakeClient.instances.clear()
+    configure_calls: list[dict[str, Any]] = []
+    trace_calls: list[dict[str, Any]] = []
+    run_tree = FakeRunTree()
+
+    monkeypatch.setattr(langsmith, "Client", FakeClient)
+    monkeypatch.setattr(
+        langsmith,
+        "configure",
+        lambda **kwargs: configure_calls.append(kwargs),
+    )
+
+    def fake_trace(name: str, **kwargs: Any) -> FakeTraceContext:
+        trace_calls.append({"name": name, **kwargs})
+        return FakeTraceContext(run_tree)
+
+    monkeypatch.setattr(langsmith, "trace", fake_trace)
+
+    @contextmanager
+    def fake_tracing_context(**kwargs: Any) -> Iterator[None]:
+        trace_calls.append({"context": kwargs})
+        yield
+
+    monkeypatch.setattr(langsmith, "tracing_context", fake_tracing_context)
+    parsed = LangSmithSettings.model_validate(
+        {
+            "project": "agent-tests",
+            "capture": {"inputs": True, "outputs": True, "metadata": True},
+            **(settings or {}),
+        }
+    )
+    runtime = LangSmithRuntime(
+        parsed,
+        logger,
+        service_metadata={"service.name": "demo-api"},
+        anonymizer=anonymizer,
+    )
+    return runtime, configure_calls, trace_calls, run_tree
+
+
+def test_runtime_initializes_programmatically_without_mutating_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, configure_calls, _trace_calls, _run_tree = _runtime(monkeypatch, logger)
+
+    runtime.start()
+    runtime.start()
+
+    client = FakeClient.instances[0]
+    assert len(FakeClient.instances) == 1
+    assert client.kwargs["api_key"] == "secret-key"
+    assert client.kwargs["api_url"] == "https://api.smith.langchain.com"
+    assert client.kwargs["tracing_mode"] == "otel"
+    assert client.kwargs["tracing_sampling_rate"] == 1.0
+    assert configure_calls[0]["client"] is client
+    assert configure_calls[0]["metadata"] == {"service.name": "demo-api"}
+    assert runtime.client() is client
+    assert runtime.diagnostics()["backend"] == "langsmith"
+
+
+def test_runtime_forwards_project_owned_anonymizer(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    def redact(payload: dict[str, Any]) -> dict[str, Any]:
+        return {"redacted": bool(payload)}
+
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+        anonymizer=redact,
+    )
+
+    runtime.start()
+
+    assert FakeClient.instances[0].kwargs["anonymizer"] is redact
+
+
+def test_runtime_span_applies_capture_policy_and_finishes_run(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, trace_calls, run_tree = _runtime(monkeypatch, logger)
+
+    with runtime.span(
+        "resolve-intent",
+        kind="tool",
+        inputs={"prompt": "hello"},
+        tags=("request",),
+        metadata={"feature": "todo"},
+    ) as span:
+        assert isinstance(span, LangSmithTraceSpan)
+        span.set_metadata({"result.kind": "create"})
+        span.set_outputs({"result": "ok"})
+
+    call = next(call for call in trace_calls if "name" in call)
+    assert call["name"] == "resolve-intent"
+    assert call["run_type"] == "tool"
+    assert call["project_name"] is None
+    assert call["inputs"] == {"prompt": "hello"}
+    assert call["tags"] == ["arclith", "request"]
+    assert call["metadata"]["service.name"] == "demo-api"
+    assert run_tree.metadata == {"result.kind": "create"}
+    assert run_tree.end_calls == [{"outputs": {"result": "ok"}}]
+
+
+def test_runtime_span_preserves_business_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+    )
+
+    with pytest.raises(ValueError, match="business failure"):
+        with runtime.span("failing-operation"):
+            raise ValueError("business failure")
+
+
+def test_runtime_span_is_noop_when_tracing_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+        settings={"tracing": {"enabled": False}},
+    )
+
+    with runtime.span("disabled") as span:
+        assert isinstance(span, NoOpTraceSpan)
+
+    assert trace_calls == []
+
+
+def test_runtime_can_disable_automatic_langgraph_instrumentation(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, configure_calls, trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+        settings={"instrumentation": {"langgraph": False}},
+    )
+
+    runtime.start()
+    with runtime.span("manual-span"):
+        pass
+
+    assert configure_calls[0]["enabled"] is False
+    explicit_context = next(
+        call["context"] for call in trace_calls if "context" in call
+    )
+    assert explicit_context["enabled"] is True
+
+
+def test_runtime_runs_shared_provider_setup_before_automatic_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+    )
+    events: list[str] = []
+    runtime._opentelemetry_enabled = True
+    runtime._before_start = lambda: events.append("configure")
+    monkeypatch.setattr(
+        runtime,
+        "_attach_to_current_otel_provider",
+        lambda: events.append("attach"),
+    )
+
+    runtime.start()
+
+    assert events == ["configure", "attach"]
+
+
+def test_runtime_context_can_override_tracing_and_preserves_body_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, trace_calls, _run_tree = _runtime(monkeypatch, logger)
+
+    with pytest.raises(ValueError, match="business failure"):
+        with runtime.context(
+            enabled=False,
+            project="sensitive-project",
+            parent={
+                "langsmith-trace": "trace-value",
+                "authorization": "Bearer secret",
+            },
+        ):
+            raise ValueError("business failure")
+
+    context_call = trace_calls[0]["context"]
+    assert context_call["enabled"] is False
+    assert context_call["project_name"] == "sensitive-project"
+    assert context_call["parent"] == {"langsmith-trace": "trace-value"}
+
+
+def test_runtime_propagates_only_allowlisted_baggage(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, run_tree = _runtime(
+        monkeypatch,
+        logger,
+        settings={"propagation": {"baggage_allowlist": ["safe", "project"]}},
+    )
+    monkeypatch.setattr(
+        "langsmith.run_helpers.get_current_run_tree",
+        lambda: run_tree,
+    )
+    headers: dict[str, str] = {"authorization": "Bearer existing"}
+
+    runtime.inject(headers)
+
+    assert headers["langsmith-trace"] == "trace-value"
+    assert "safe" in headers["baggage"]
+    assert "secret" not in headers["baggage"]
+    assert headers["authorization"] == "Bearer existing"
+
+
+def test_runtime_is_fail_open_when_span_export_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, run_tree = _runtime(monkeypatch, logger)
+    monkeypatch.setattr(
+        langsmith,
+        "trace",
+        lambda *args, **kwargs: FakeTraceContext(run_tree, fail_enter=True),
+    )
+    executed = False
+
+    with runtime.span("unavailable") as span:
+        executed = True
+        assert isinstance(span, NoOpTraceSpan)
+
+    assert executed is True
+    assert logger.records[-1]["metadata"]["operation"] == "span.start"
+    assert "secret-key" not in str(logger.records)
+
+
+def test_runtime_can_raise_technical_failures_when_explicitly_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, run_tree = _runtime(
+        monkeypatch,
+        logger,
+        settings={"failure_mode": "raise"},
+    )
+    monkeypatch.setattr(
+        langsmith,
+        "trace",
+        lambda *args, **kwargs: FakeTraceContext(run_tree, fail_enter=True),
+    )
+
+    with pytest.raises(RuntimeError, match="export unavailable"):
+        with runtime.span("unavailable"):
+            pass
+
+
+def test_runtime_flush_and_close_are_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, configure_calls, _trace_calls, _run_tree = _runtime(monkeypatch, logger)
+    runtime.start()
+    processor = FakeProcessor()
+    runtime._otel_processor = processor
+
+    runtime.close(timeout=2.0)
+    runtime.close(timeout=2.0)
+
+    client = FakeClient.instances[0]
+    assert processor.flush_calls == [2000]
+    assert processor.shutdown_calls == 1
+    assert client.flush_calls == [2.0]
+    assert client.close_calls == [2.0]
+    assert configure_calls[-1] == {
+        "client": None,
+        "enabled": None,
+        "project_name": None,
+        "tags": None,
+        "metadata": None,
+    }
+    assert runtime.diagnostics()["closed"] is True
+
+
+def test_runtime_builds_per_agent_pydantic_ai_instrumentation(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+        settings={
+            "capture": {
+                "inputs": False,
+                "outputs": False,
+                "metadata": True,
+                "model_content": False,
+                "binary_content": False,
+                "model_request_parameters": False,
+            }
+        },
+    )
+    provider = TracerProvider()
+    monkeypatch.setattr(runtime, "_ensure_pydantic_otel_provider", lambda: provider)
+
+    capability = runtime.pydantic_ai_capability()
+
+    assert capability is not None
+    assert capability.settings.tracer.resource is provider.resource
+    assert capability.settings.include_content is False
+    assert capability.settings.include_binary_content is False
+    assert capability.settings.include_model_request_parameters is False
+    provider.shutdown()
+
+
+def test_runtime_attaches_langsmith_processor_to_current_otel_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+    )
+    provider = TracerProvider()
+    attached: list[Any] = []
+    monkeypatch.setattr(
+        "opentelemetry.trace.get_tracer_provider",
+        lambda: provider,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_attach_langsmith_processor",
+        lambda selected: attached.append(selected),
+    )
+
+    runtime.attach_to_current_opentelemetry()
+
+    assert attached == [provider]
+    provider.shutdown()
+
+
+def test_runtime_reuses_client_otel_provider_for_pydantic_ai(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    runtime, _configure_calls, _trace_calls, _run_tree = _runtime(
+        monkeypatch,
+        logger,
+    )
+    runtime.start()
+    provider = TracerProvider()
+    monkeypatch.setattr(
+        "opentelemetry.trace.get_tracer_provider",
+        lambda: provider,
+    )
+
+    selected = runtime._ensure_pydantic_otel_provider()
+
+    assert selected is provider
+    assert runtime._otel_processor is None
+    provider.shutdown()
+
+
+def test_runtime_reports_missing_optional_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    logger: Any,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-key")
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "langsmith":
+            raise ModuleNotFoundError("missing", name="langsmith")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    runtime = LangSmithRuntime(LangSmithSettings(project="agent-tests"), logger)
+
+    with pytest.raises(RuntimeError, match=r"arclith\[langsmith\]"):
+        runtime.start()

--- a/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_fastapi.py
@@ -2,10 +2,10 @@ from fastapi import FastAPI
 
 from arclith.adapters.outbound.opentelemetry.fastapi import (
     _build_resource,
-    _configure_opentelemetry,
     _headers_from_env,
     _instrument_logging_correlation,
     _resolve_endpoint,
+    configure_opentelemetry,
     instrument_fastapi_app,
 )
 from arclith.infrastructure.config import OpenTelemetrySettings
@@ -20,7 +20,7 @@ def test_instrument_fastapi_app_returns_when_exports_disabled() -> None:
 def test_configure_opentelemetry_skips_when_exports_disabled() -> None:
     settings = OpenTelemetrySettings(traces=False, metrics=False)
 
-    _configure_opentelemetry(settings, service_name="demo", service_version="1.0.0")
+    configure_opentelemetry(settings, service_name="demo", service_version="1.0.0")
 
 
 def test_build_resource_adds_service_identity_and_environment(monkeypatch) -> None:

--- a/tests/units/adapters/outbound/test_pydantic_ai_llm.py
+++ b/tests/units/adapters/outbound/test_pydantic_ai_llm.py
@@ -26,6 +26,35 @@ def test_pydantic_ai_llm_adapter_implements_llm_port() -> None:
     assert isinstance(adapter, LLMPort)
 
 
+def test_pydantic_ai_llm_adapter_scopes_instrumentation_to_built_agent(
+    monkeypatch,
+) -> None:
+    instrumentation = object()
+    seen: dict[str, object] = {}
+
+    class FakeAgent:
+        def __init__(self, model, **kwargs) -> None:
+            seen.update(kwargs)
+
+    monkeypatch.setattr(
+        llm_module, "build_pydantic_ai_model", lambda settings: object()
+    )
+    monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
+    adapter = PydanticAILLMAdapter(
+        LMSettings(
+            provider="openai",
+            model_name="local-model",
+            api_key="lm-studio",
+            base_url="http://127.0.0.1:1234/v1",
+        ),
+        instrumentation=instrumentation,
+    )
+
+    adapter._build_agent(output_type=dict, instructions="instructions")
+
+    assert seen["capabilities"] == [instrumentation]
+
+
 async def test_pydantic_ai_llm_adapter_returns_structured_output(monkeypatch) -> None:
     class Result:
         pass
@@ -37,7 +66,9 @@ async def test_pydantic_ai_llm_adapter_returns_structured_output(monkeypatch) ->
         async def run(self, prompt: str):
             return SimpleNamespace(output=self._output_type())
 
-    monkeypatch.setattr(llm_module, "build_pydantic_ai_model", lambda settings: object())
+    monkeypatch.setattr(
+        llm_module, "build_pydantic_ai_model", lambda settings: object()
+    )
     monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
     adapter = PydanticAILLMAdapter(
         LMSettings(
@@ -48,7 +79,9 @@ async def test_pydantic_ai_llm_adapter_returns_structured_output(monkeypatch) ->
         )
     )
 
-    result = await adapter.complete_structured("prompt", output_type=Result, instructions="instructions")
+    result = await adapter.complete_structured(
+        "prompt", output_type=Result, instructions="instructions"
+    )
 
     assert isinstance(result, Result)
 
@@ -87,7 +120,9 @@ async def test_pydantic_ai_llm_adapter_streams_structured_output(monkeypatch) ->
             seen["prompt"] = prompt
             return FakeStreamResult(self._output_type)
 
-    monkeypatch.setattr(llm_module, "build_pydantic_ai_model", lambda settings: object())
+    monkeypatch.setattr(
+        llm_module, "build_pydantic_ai_model", lambda settings: object()
+    )
     monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
     adapter = PydanticAILLMAdapter(
         LMSettings(
@@ -128,7 +163,9 @@ async def test_pydantic_ai_llm_adapter_streams_structured_output(monkeypatch) ->
     assert events[-1].metadata["snapshots"] == 1
 
 
-async def test_pydantic_ai_llm_adapter_can_disable_stream_snapshots(monkeypatch) -> None:
+async def test_pydantic_ai_llm_adapter_can_disable_stream_snapshots(
+    monkeypatch,
+) -> None:
     class Result:
         pass
 
@@ -143,9 +180,13 @@ async def test_pydantic_ai_llm_adapter_can_disable_stream_snapshots(monkeypatch)
 
         def run_stream(self, prompt: str):
             seen["run_stream"] = True
-            raise AssertionError("run_stream should not be called when snapshots are disabled")
+            raise AssertionError(
+                "run_stream should not be called when snapshots are disabled"
+            )
 
-    monkeypatch.setattr(llm_module, "build_pydantic_ai_model", lambda settings: object())
+    monkeypatch.setattr(
+        llm_module, "build_pydantic_ai_model", lambda settings: object()
+    )
     monkeypatch.setattr(pydantic_ai, "Agent", FakeAgent)
     adapter = PydanticAILLMAdapter(
         LMSettings(
@@ -162,7 +203,9 @@ async def test_pydantic_ai_llm_adapter_can_disable_stream_snapshots(monkeypatch)
             "prompt",
             output_type=Result,
             instructions="instructions",
-            stream_options=LLMStructuredStreamOptions(include_progress=False, include_snapshots=False),
+            stream_options=LLMStructuredStreamOptions(
+                include_progress=False, include_snapshots=False
+            ),
         )
     ]
 

--- a/tests/units/domain/ports/test_observability.py
+++ b/tests/units/domain/ports/test_observability.py
@@ -1,0 +1,46 @@
+import ast
+from pathlib import Path
+
+from arclith.adapters.outbound.noop.observability import NoOpTraceAdapter
+from arclith.domain.ports.outbound.observability import TracePort
+
+
+def test_noop_trace_adapter_honors_full_port_contract() -> None:
+    tracer = NoOpTraceAdapter()
+    headers: dict[str, str] = {}
+
+    assert isinstance(tracer, TracePort)
+    with tracer.context(enabled=False, parent={"traceparent": "ignored"}):
+        with tracer.span("operation", inputs={"secret": "ignored"}) as span:
+            span.set_metadata({"safe": True})
+            span.set_outputs({"status": "ok"})
+    tracer.inject(headers)
+    tracer.flush(1.0)
+    tracer.close(1.0)
+
+    assert headers == {}
+    assert tracer.diagnostics() == {"backend": "noop", "tracing": False}
+
+
+def test_core_does_not_import_observability_vendors() -> None:
+    root = Path(__file__).parents[4] / "arclith"
+
+    for package in (root / "domain", root / "application"):
+        for path in package.rglob("*.py"):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            imported_modules = {
+                node.module or ""
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom)
+            }
+            imported_modules.update(
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            )
+            assert not any(
+                module.startswith(("langsmith", "opentelemetry"))
+                for module in imported_modules
+            ), path

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -570,6 +570,22 @@ def test_load_config_dir_parallel_observability_scoped():
     assert config.adapters.opentelemetry is not None
 
 
+def test_parallel_observability_rejects_duplicate_native_trace_trees():
+    with pytest.raises(ValidationError, match="tracing.mode=otel"):
+        AppConfig.model_validate(
+            {
+                "adapters": {
+                    "observability": {"enabled": ["langsmith", "opentelemetry"]},
+                    "langsmith": {
+                        "project": "agent-tests",
+                        "tracing": {"mode": "langsmith"},
+                    },
+                    "opentelemetry": {},
+                }
+            }
+        )
+
+
 def test_load_config_dir_langgraph_scoped():
     path = _make_config_dir(
         {
@@ -651,11 +667,34 @@ def test_langgraph_settings_rejects_unknown_stream_mode():
 def test_langsmith_settings_defaults():
     settings = LangSmithSettings(project="agent-tests")
 
-    assert settings.tracing is True
+    assert settings.tracing.enabled is True
+    assert settings.tracing.mode == "otel"
+    assert settings.tracing.sampling_rate == 1.0
     assert settings.endpoint == "https://api.smith.langchain.com"
     assert settings.api_key_env == "LANGSMITH_API_KEY"
+    assert settings.workspace_id_env == "LANGSMITH_WORKSPACE_ID"
+    assert settings.capture.inputs is False
+    assert settings.capture.outputs is False
+    assert settings.capture.model_content is False
     assert settings.studio == "langgraph"
     assert settings.langgraph_api_min_version == "0.11.0"
+
+
+def test_langsmith_settings_migrates_legacy_tracing_boolean():
+    settings = LangSmithSettings(project="agent-tests", tracing=False)
+
+    assert settings.tracing.enabled is False
+
+
+@pytest.mark.parametrize("sampling_rate", [-0.01, 1.01])
+def test_langsmith_settings_rejects_invalid_sampling_rate(sampling_rate: float):
+    with pytest.raises(ValidationError, match="sampling_rate"):
+        LangSmithSettings.model_validate(
+            {
+                "project": "agent-tests",
+                "tracing": {"sampling_rate": sampling_rate},
+            }
+        )
 
 
 def test_opentelemetry_settings_defaults():

--- a/tests/units/test_arclith_langsmith.py
+++ b/tests/units/test_arclith_langsmith.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypedDict
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from arclith import Arclith
+from arclith.adapters.outbound.langsmith.runtime import LangSmithRuntime
+from arclith.adapters.outbound.noop.observability import NoOpTraceAdapter
+from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
+from arclith.infrastructure.observability_factory import (
+    _configure_shared_opentelemetry,
+)
+
+
+class RecordingSpan(TraceSpan):
+    def set_outputs(self, outputs: object | None) -> None:
+        return None
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        return None
+
+
+class RecordingTracer(TracePort):
+    def __init__(self, capability: object | None = None) -> None:
+        self.started = 0
+        self.closed = 0
+        self.capability = capability
+
+    def start(self) -> None:
+        self.started += 1
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        yield RecordingSpan()
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        yield
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        return None
+
+    def flush(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self, timeout: float | None = None) -> None:
+        self.closed += 1
+
+    def pydantic_ai_capability(self) -> object | None:
+        return self.capability
+
+
+def _config_dir(tmp_path: Path, *, langsmith: dict[str, Any] | None = None) -> Path:
+    config_dir = tmp_path / "config"
+    (config_dir / "adapters" / "outbound").mkdir(parents=True)
+    if langsmith is not None:
+        (config_dir / "adapters" / "adapters.yaml").write_text(
+            yaml.safe_dump({"observability": {"enabled": ["langsmith"]}}),
+            encoding="utf-8",
+        )
+        (config_dir / "adapters" / "outbound" / "langsmith.yaml").write_text(
+            yaml.safe_dump({"project": "agent-tests", **langsmith}),
+            encoding="utf-8",
+        )
+    return config_dir
+
+
+def test_arclith_returns_noop_tracer_by_default(tmp_path: Path) -> None:
+    arclith = Arclith(_config_dir(tmp_path))
+
+    assert isinstance(arclith.tracer(), NoOpTraceAdapter)
+    assert arclith.observability_diagnostics() == {
+        "backend": "noop",
+        "tracing": False,
+    }
+    arclith.flush_observability()
+    arclith.close_observability()
+
+
+def test_arclith_builds_langsmith_runtime_only_when_selected(tmp_path: Path) -> None:
+    arclith = Arclith(_config_dir(tmp_path, langsmith={"tracing": False}))
+
+    assert isinstance(arclith.tracer(), LangSmithRuntime)
+    assert arclith.observability_diagnostics()["started"] is False
+
+
+def test_arclith_rejects_selected_langsmith_without_adapter_config(
+    tmp_path: Path,
+) -> None:
+    arclith = Arclith(_config_dir(tmp_path))
+    # Exercise the factory's defensive guard independently from AppConfig's
+    # equivalent validation, for callers that assemble config programmatically.
+    arclith.config.adapters.observability.enabled = ["langsmith"]
+
+    with pytest.raises(RuntimeError, match="adapters.langsmith est absent"):
+        arclith.tracer()
+
+
+def test_shared_opentelemetry_setup_is_noop_without_complete_selection(
+    tmp_path: Path,
+) -> None:
+    inactive = Arclith(_config_dir(tmp_path / "inactive")).config
+    _configure_shared_opentelemetry(inactive)
+
+    selected = Arclith(_config_dir(tmp_path / "selected")).config
+    selected.adapters.observability.enabled = ["opentelemetry"]
+    _configure_shared_opentelemetry(selected)
+
+
+def test_arclith_forwards_provider_neutral_trace_anonymizer(tmp_path: Path) -> None:
+    def redact(payload: dict[str, Any]) -> dict[str, Any]:
+        return {"redacted": bool(payload)}
+
+    arclith = Arclith(
+        _config_dir(tmp_path, langsmith={}),
+        trace_anonymizer=redact,
+    )
+
+    assert isinstance(arclith.tracer(), LangSmithRuntime)
+    assert arclith.tracer()._anonymizer is redact
+
+
+def test_arclith_langsmith_client_is_an_explicit_escape_hatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inactive = Arclith(_config_dir(tmp_path / "inactive"))
+    with pytest.raises(RuntimeError, match="n'est pas active"):
+        inactive.langsmith_client()
+
+    active = Arclith(_config_dir(tmp_path / "active", langsmith={}))
+    sentinel = object()
+    monkeypatch.setattr(LangSmithRuntime, "client", lambda self: sentinel)
+
+    assert active.langsmith_client() is sentinel
+
+
+def test_fastapi_lifespan_starts_and_closes_observability(tmp_path: Path) -> None:
+    arclith = Arclith(_config_dir(tmp_path))
+    tracer = RecordingTracer()
+    arclith.__dict__["_trace_adapter"] = tracer
+    app = arclith.fastapi()
+
+    with TestClient(app) as client:
+        assert client.get("/openapi.json").status_code == 200
+        assert tracer.started == 1
+
+    assert tracer.closed == 1
+
+
+def test_arclith_fastapi_adds_langsmith_instrumentation_when_selected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Any, Any]] = []
+    monkeypatch.setattr(
+        "arclith.adapters.outbound.langsmith.fastapi.instrument_fastapi_app",
+        lambda app, tracer: calls.append((app, tracer)),
+    )
+    arclith = Arclith(
+        _config_dir(
+            tmp_path,
+            langsmith={"instrumentation": {"fastapi": True}},
+        )
+    )
+
+    app = arclith.fastapi()
+
+    assert calls == [(app, arclith.tracer())]
+
+
+@pytest.mark.asyncio
+async def test_arclith_fastmcp_instrumentation_is_idempotent(tmp_path: Path) -> None:
+    arclith = Arclith(_config_dir(tmp_path, langsmith={}))
+    arclith.__dict__["_trace_adapter"] = RecordingTracer()
+
+    async def echo(value: str) -> str:
+        return value
+
+    component = SimpleNamespace(name="echo", fn=echo)
+    mcp = SimpleNamespace(
+        _local_provider=SimpleNamespace(_components={"echo": component})
+    )
+
+    arclith.instrument_mcp(mcp)
+    first_wrapper = component.fn
+    arclith.instrument_mcp(mcp)
+
+    assert component.fn is first_wrapper
+    assert await component.fn("ok") == "ok"
+
+
+class GraphState(TypedDict, total=False):
+    value: str
+
+
+def test_langgraph_starts_configured_langsmith_runtime(tmp_path: Path) -> None:
+    graph = pytest.importorskip("langgraph.graph")
+    arclith = Arclith(_config_dir(tmp_path, langsmith={"tracing": False}))
+    tracer = RecordingTracer()
+    arclith.__dict__["_trace_adapter"] = tracer
+
+    def register(builder: Any, _arclith: Arclith) -> None:
+        builder.add_node("echo", lambda state: state)
+        builder.add_edge(graph.START, "echo")
+        builder.add_edge("echo", graph.END)
+
+    compiled = arclith.langgraph(GraphState, register)
+
+    assert tracer.started == 1
+    assert compiled.invoke({"value": "ok"}) == {"value": "ok"}
+
+
+def test_pydantic_ai_factory_injects_per_agent_capability(tmp_path: Path) -> None:
+    config_dir = _config_dir(tmp_path)
+    (config_dir / "adapters" / "outbound" / "lm.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "provider": "openai",
+                "model_name": "local-model",
+                "api_key": "local",
+                "base_url": "http://localhost:1234/v1",
+            }
+        ),
+        encoding="utf-8",
+    )
+    arclith = Arclith(config_dir)
+    capability = object()
+    arclith.__dict__["_trace_adapter"] = RecordingTracer(capability)
+
+    adapter = arclith.pydantic_ai_llm()
+
+    assert adapter._instrumentation is capability
+
+
+def test_pydantic_ai_factory_requires_lm_config(tmp_path: Path) -> None:
+    arclith = Arclith(_config_dir(tmp_path))
+
+    with pytest.raises(RuntimeError, match="config.adapters.lm"):
+        arclith.pydantic_ai_llm()

--- a/tests/units/test_arclith_opentelemetry.py
+++ b/tests/units/test_arclith_opentelemetry.py
@@ -40,7 +40,9 @@ def _make_config_dir(tmp_path: Path) -> Path:
     return config_dir
 
 
-def test_opentelemetry_hook_uses_configured_adapter(tmp_path: Path, monkeypatch) -> None:
+def test_opentelemetry_hook_uses_configured_adapter(
+    tmp_path: Path, monkeypatch
+) -> None:
     calls: list[dict[str, Any]] = []
 
     def fake_instrument_fastapi_app(
@@ -50,14 +52,18 @@ def test_opentelemetry_hook_uses_configured_adapter(tmp_path: Path, monkeypatch)
         service_name: str,
         service_version: str,
     ) -> None:
-        calls.append({
-            "app": app,
-            "settings": settings,
-            "service_name": service_name,
-            "service_version": service_version,
-        })
+        calls.append(
+            {
+                "app": app,
+                "settings": settings,
+                "service_name": service_name,
+                "service_version": service_version,
+            }
+        )
 
-    monkeypatch.setattr(otel_fastapi, "instrument_fastapi_app", fake_instrument_fastapi_app)
+    monkeypatch.setattr(
+        otel_fastapi, "instrument_fastapi_app", fake_instrument_fastapi_app
+    )
 
     arclith = Arclith(_make_config_dir(tmp_path))
     app = object()
@@ -70,7 +76,9 @@ def test_opentelemetry_hook_uses_configured_adapter(tmp_path: Path, monkeypatch)
     assert calls[0]["settings"].instrument_fastapi is True
 
 
-def test_fastapi_instruments_opentelemetry_after_middlewares(tmp_path: Path, monkeypatch) -> None:
+def test_fastapi_instruments_opentelemetry_after_middlewares(
+    tmp_path: Path, monkeypatch
+) -> None:
     events: list[str] = []
 
     def fake_add_fastapi_observability(self: Arclith, app: Any) -> None:
@@ -82,18 +90,47 @@ def test_fastapi_instruments_opentelemetry_after_middlewares(tmp_path: Path, mon
     def fake_instrument_fastapi_opentelemetry(self: Arclith, app: Any) -> None:
         events.append("opentelemetry")
 
-    monkeypatch.setattr(Arclith, "_add_fastapi_observability", fake_add_fastapi_observability)
-    monkeypatch.setattr(Arclith, "_add_fastapi_http_middlewares", fake_add_fastapi_http_middlewares)
-    monkeypatch.setattr(Arclith, "_instrument_fastapi_opentelemetry", fake_instrument_fastapi_opentelemetry)
+    monkeypatch.setattr(
+        Arclith, "_add_fastapi_observability", fake_add_fastapi_observability
+    )
+    monkeypatch.setattr(
+        Arclith, "_add_fastapi_http_middlewares", fake_add_fastapi_http_middlewares
+    )
+    monkeypatch.setattr(
+        Arclith,
+        "_instrument_fastapi_opentelemetry",
+        fake_instrument_fastapi_opentelemetry,
+    )
 
     Arclith(_make_config_dir(tmp_path)).fastapi()
 
     assert events == ["observability", "http", "opentelemetry"]
 
 
+def test_langsmith_runtime_preconfigures_shared_opentelemetry_provider(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[tuple[Any, str, str]] = []
+    monkeypatch.setattr(
+        otel_fastapi,
+        "configure_opentelemetry",
+        lambda settings, *, service_name, service_version: calls.append(
+            (settings, service_name, service_version)
+        ),
+    )
+    tracer = Arclith(_make_config_dir(tmp_path)).tracer()
+
+    tracer._before_start()  # type: ignore[attr-defined]
+
+    assert calls[0][1:] == ("demo-api", "1.2.3")
+
+
 def test_uvicorn_log_interceptor_keeps_injected_trace_metadata() -> None:
     logger = CapturingLogger()
-    record = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 1, "request finished", (), None)
+    record = logging.LogRecord(
+        "uvicorn.access", logging.INFO, __file__, 1, "request finished", (), None
+    )
     record.otelTraceID = "0" * 31 + "1"
     record.otelSpanID = "0" * 15 + "2"
     record.otelTraceSampled = True

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ all = [
     { name = "langgraph-checkpoint-sqlite" },
     { name = "langgraph-cli", extra = ["inmem"] },
     { name = "langgraph-store-mongodb" },
-    { name = "langsmith" },
+    { name = "langsmith", extra = ["otel"] },
     { name = "motor" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -178,7 +178,6 @@ langgraph = [
     { name = "langgraph" },
     { name = "langgraph-api" },
     { name = "langgraph-cli", extra = ["inmem"] },
-    { name = "langsmith" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
 ]
 langgraph-persistence-mongodb = [
@@ -194,6 +193,9 @@ langgraph-persistence-redis = [
 ]
 langgraph-persistence-sqlite = [
     { name = "langgraph-checkpoint-sqlite" },
+]
+langsmith = [
+    { name = "langsmith", extra = ["otel"] },
 ]
 mariadb = [
     { name = "asyncmy" },
@@ -288,8 +290,8 @@ requires-dist = [
     { name = "langgraph-cli", extras = ["inmem"], marker = "extra == 'langgraph'", specifier = ">=0.4.31" },
     { name = "langgraph-store-mongodb", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-store-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.4.0" },
-    { name = "langsmith", marker = "extra == 'langgraph'", specifier = ">=0.4.0" },
+    { name = "langsmith", extras = ["otel"], marker = "extra == 'all'", specifier = ">=0.10,<1" },
+    { name = "langsmith", extras = ["otel"], marker = "extra == 'langsmith'", specifier = ">=0.10,<1" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "motor", marker = "extra == 'all'", specifier = "==3.7.1" },
     { name = "motor", marker = "extra == 'mongodb'", specifier = "==3.7.1" },
@@ -322,7 +324,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Résumé

- ajoute un port de tracing provider-neutral, un tracer no-op et un runtime LangSmith lazy avec cycle de vie explicite ;
- câble LangGraph, Pydantic AI, FastAPI, FastMCP et RabbitMQ avec propagation distribuée et politiques de confidentialité ;
- sépare installation, activation et émission via le nouvel extra `arclith[langsmith]`, la sélection YAML et `tracing.enabled` ;
- ajoute les profils CLI `development` / `production`, la génération idempotente et la documentation Pages complète.

## Choix de compatibilité

- Le minimum réellement validé est `langsmith[otel]>=0.10,<1` ; la suite locale utilise `langsmith 0.10.15`.
- `langsmith` est retiré de l'extra `langgraph` et reste inclus dans `all`.
- Le runtime ne traduit pas implicitement le YAML en mutations de `os.environ` ; les variables `LANGSMITH_*` sont lues comme overrides opérationnels.
- Lorsque LangSmith et OpenTelemetry sont actifs ensemble, LangSmith doit utiliser le mode `otel` afin de partager un seul provider et éviter les spans dupliqués.
- Le rebase sur `main` conserve la capability de persistance LangGraph livrée par #183.

## Validation

- `make quality` : 629 passed, 2 skipped, couverture 90,06 %, Ruff/Bandit/mypy OK
- suite CLI : 116 passed, 1 skipped
- `make docs` : build MkDocs strict OK
- `uv lock --check` : racine et CLI OK
- import isolé sans extra : `arclith` importe sans installer ni charger `langsmith`
- test live LangSmith ajouté et désactivé par défaut ; non exécuté localement faute de credentials (`ARCLITH_LANGSMITH_INTEGRATION=1` + `LANGSMITH_API_KEY` requis)

Closes #180
