### PR TITLE
feat: ajoute un runtime LangGraph durable

### DIFF
--- a/arclith/adapters/inbound/langgraph_runtime/__init__.py
+++ b/arclith/adapters/inbound/langgraph_runtime/__init__.py
@@ -1,0 +1,43 @@
+from arclith.adapters.inbound.langgraph_runtime.api import (
+    create_langgraph_runtime_app,
+)
+from arclith.adapters.inbound.langgraph_runtime.catalog import (
+    InMemoryRuntimeCatalog,
+    PostgresRuntimeCatalog,
+    RunRecord,
+    RuntimeCatalog,
+    ThreadAlreadyExistsError,
+    ThreadRecord,
+)
+from arclith.adapters.inbound.langgraph_runtime.coordination import (
+    InMemoryRunCoordinator,
+    RedisRunCoordinator,
+    RunBusyError,
+    RunCoordinator,
+)
+from arclith.adapters.inbound.langgraph_runtime.loader import load_graphs
+from arclith.adapters.inbound.langgraph_runtime.runtime import (
+    LangGraphRuntime,
+    RunRequest,
+)
+from arclith.adapters.inbound.langgraph_runtime.server import (
+    create_durable_langgraph_runtime_app,
+)
+
+__all__ = [
+    "InMemoryRunCoordinator",
+    "InMemoryRuntimeCatalog",
+    "LangGraphRuntime",
+    "PostgresRuntimeCatalog",
+    "RedisRunCoordinator",
+    "RunBusyError",
+    "RunCoordinator",
+    "RunRecord",
+    "RunRequest",
+    "RuntimeCatalog",
+    "ThreadRecord",
+    "ThreadAlreadyExistsError",
+    "create_durable_langgraph_runtime_app",
+    "create_langgraph_runtime_app",
+    "load_graphs",
+]

--- a/arclith/adapters/inbound/langgraph_runtime/__main__.py
+++ b/arclith/adapters/inbound/langgraph_runtime/__main__.py
@@ -1,0 +1,4 @@
+from arclith.adapters.inbound.langgraph_runtime.server import main
+
+
+main()

--- a/arclith/adapters/inbound/langgraph_runtime/api.py
+++ b/arclith/adapters/inbound/langgraph_runtime/api.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import FastAPI, Query, Request, Response, status
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from arclith.adapters.inbound.langgraph_runtime.coordination import RunBusyError
+from arclith.adapters.inbound.langgraph_runtime.catalog import ThreadAlreadyExistsError
+from arclith.adapters.inbound.langgraph_runtime.runtime import (
+    AssistantNotFoundError,
+    LangGraphRuntime,
+    RunCancelledError,
+    RunNotFoundError,
+    RunRequest,
+    RuntimeStorageError,
+    ThreadNotFoundError,
+)
+
+_NOT_FOUND: dict[int | str, dict[str, Any]] = {
+    404: {"description": "Thread, run or assistant not found"}
+}
+_RUN_ERRORS: dict[int | str, dict[str, Any]] = {
+    404: {"description": "Thread or assistant not found"},
+    409: {"description": "Thread busy or run cancelled"},
+    500: {"description": "Graph execution failed"},
+    503: {"description": "Runtime storage unavailable"},
+}
+
+
+class ThreadCreatePayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    thread_id: UUID | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    if_exists: Literal["raise", "do_nothing"] | None = None
+
+
+class ThreadSearchPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    metadata: dict[str, Any] | None = None
+    status: str | None = None
+    limit: int = Field(default=10, ge=1, le=1000)
+    offset: int = Field(default=0, ge=0)
+
+
+class ThreadHistoryPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    limit: int = Field(default=10, ge=1, le=1000)
+
+
+class RunPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    assistant_id: str = Field(min_length=1, max_length=200)
+    input: Any = None
+    command: Any = None
+    config: dict[str, Any] | None = None
+    checkpoint: dict[str, Any] | None = None
+    checkpoint_id: str | None = None
+    stream_mode: str | list[str] | None = None
+    on_disconnect: Literal["cancel", "continue"] = "cancel"
+    multitask_strategy: Literal["reject"] = "reject"
+
+    def as_runtime_request(self) -> RunRequest:
+        return RunRequest(
+            assistant_id=self.assistant_id,
+            input=self.input,
+            command=self.command,
+            config=self.config,
+            checkpoint=self.checkpoint,
+            checkpoint_id=self.checkpoint_id,
+            stream_mode=self.stream_mode,
+            on_disconnect=self.on_disconnect,
+            multitask_strategy=self.multitask_strategy,
+        )
+
+
+def create_langgraph_runtime_app(runtime: LangGraphRuntime) -> FastAPI:
+    app = FastAPI(
+        title="Arclith Open Source LangGraph Runtime",
+        version="1.0.0",
+    )
+    app.state.langgraph_runtime = runtime
+    _register_exception_handlers(app)
+
+    @app.get(
+        "/info",
+        status_code=status.HTTP_200_OK,
+        responses={503: {"description": "Runtime unavailable"}},
+    )
+    async def info() -> dict[str, Any]:
+        return {
+            "version": "arclith-open-source",
+            "flags": {
+                "assistants": True,
+                "crons": False,
+                "langsmith": False,
+            },
+            "host": {"kind": "self-hosted-open-source"},
+        }
+
+    @app.get(
+        "/health",
+        status_code=status.HTTP_200_OK,
+        responses={503: {"description": "Runtime unavailable"}},
+    )
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get(
+        "/ready",
+        status_code=status.HTTP_200_OK,
+        responses={503: {"description": "Runtime storage unavailable"}},
+    )
+    async def ready() -> dict[str, str]:
+        if not await runtime.ready():
+            raise RuntimeStorageError("Runtime storage is not ready")
+        return {"status": "ready"}
+
+    @app.post(
+        "/assistants/search",
+        status_code=status.HTTP_200_OK,
+        responses={503: {"description": "Runtime unavailable"}},
+    )
+    async def search_assistants() -> list[dict[str, Any]]:
+        return runtime.assistants()
+
+    @app.get(
+        "/assistants/{assistant_id}",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def get_assistant(assistant_id: str) -> dict[str, Any]:
+        return runtime.assistant(assistant_id)
+
+    @app.post(
+        "/threads/search",
+        status_code=status.HTTP_200_OK,
+        responses={503: {"description": "Runtime storage unavailable"}},
+    )
+    async def search_threads(payload: ThreadSearchPayload) -> list[dict[str, Any]]:
+        records = await runtime.search_threads(
+            metadata=payload.metadata,
+            status=payload.status,
+            limit=payload.limit,
+            offset=payload.offset,
+        )
+        return [record.as_api_dict() for record in records]
+
+    @app.post(
+        "/threads",
+        status_code=status.HTTP_200_OK,
+        responses={
+            409: {"description": "Thread already exists"},
+            503: {"description": "Runtime storage unavailable"},
+        },
+    )
+    async def create_thread(payload: ThreadCreatePayload) -> dict[str, Any]:
+        record = await runtime.create_thread(
+            thread_id=str(payload.thread_id) if payload.thread_id else None,
+            metadata=payload.metadata,
+            if_exists=payload.if_exists,
+        )
+        return record.as_api_dict()
+
+    @app.get(
+        "/threads/{thread_id}",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def get_thread(thread_id: UUID) -> dict[str, Any]:
+        return (await runtime.get_thread(str(thread_id))).as_api_dict()
+
+    @app.delete(
+        "/threads/{thread_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+        responses=_NOT_FOUND,
+    )
+    async def delete_thread(thread_id: UUID) -> Response:
+        await runtime.delete_thread(str(thread_id))
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @app.get(
+        "/threads/{thread_id}/state",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def get_thread_state(thread_id: UUID) -> dict[str, Any]:
+        return await runtime.state(str(thread_id))
+
+    @app.post(
+        "/threads/{thread_id}/history",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def get_thread_history(
+        thread_id: UUID,
+        payload: ThreadHistoryPayload,
+    ) -> list[dict[str, Any]]:
+        return await runtime.history(str(thread_id), limit=payload.limit)
+
+    @app.post(
+        "/threads/{thread_id}/runs/wait",
+        status_code=status.HTTP_200_OK,
+        responses=_RUN_ERRORS,
+    )
+    async def wait_for_run(thread_id: UUID, payload: RunPayload) -> Any:
+        return await runtime.wait(
+            str(thread_id),
+            payload.as_runtime_request(),
+        )
+
+    @app.post(
+        "/threads/{thread_id}/runs/stream",
+        status_code=status.HTTP_200_OK,
+        responses=_RUN_ERRORS,
+    )
+    async def stream_run(thread_id: UUID, payload: RunPayload) -> StreamingResponse:
+        resolved_thread = str(thread_id)
+        await runtime.get_thread(resolved_thread)
+        runtime.assistant(payload.assistant_id)
+        return StreamingResponse(
+            runtime.stream(resolved_thread, payload.as_runtime_request()),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-store",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @app.get(
+        "/threads/{thread_id}/runs",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def list_runs(
+        thread_id: UUID,
+        limit: int = Query(default=10, ge=1, le=1000),
+        offset: int = Query(default=0, ge=0),
+        run_status: str | None = Query(default=None, alias="status"),
+    ) -> list[dict[str, Any]]:
+        runs = await runtime.list_runs(
+            str(thread_id),
+            status=run_status,
+            limit=limit,
+            offset=offset,
+        )
+        return [run.as_api_dict() for run in runs]
+
+    @app.get(
+        "/threads/{thread_id}/runs/{run_id}",
+        status_code=status.HTTP_200_OK,
+        responses=_NOT_FOUND,
+    )
+    async def get_run(thread_id: UUID, run_id: UUID) -> dict[str, Any]:
+        return (await runtime.get_run(str(thread_id), str(run_id))).as_api_dict()
+
+    @app.post(
+        "/threads/{thread_id}/runs/{run_id}/cancel",
+        status_code=status.HTTP_204_NO_CONTENT,
+        responses=_NOT_FOUND,
+    )
+    async def cancel_run(thread_id: UUID, run_id: UUID) -> Response:
+        await runtime.cancel_run(str(thread_id), str(run_id))
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    return app
+
+
+def _register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(ThreadNotFoundError)
+    @app.exception_handler(RunNotFoundError)
+    @app.exception_handler(AssistantNotFoundError)
+    async def not_found(_request: Request, error: Exception) -> JSONResponse:
+        return JSONResponse(status_code=404, content={"detail": str(error)})
+
+    @app.exception_handler(RunBusyError)
+    @app.exception_handler(RunCancelledError)
+    @app.exception_handler(ThreadAlreadyExistsError)
+    async def conflict(_request: Request, error: Exception) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": str(error)})
+
+    @app.exception_handler(RuntimeStorageError)
+    async def unavailable(
+        _request: Request,
+        _error: RuntimeStorageError,
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "The LangGraph runtime storage is unavailable."},
+        )
+
+    @app.exception_handler(Exception)
+    async def execution_error(_request: Request, error: Exception) -> JSONResponse:
+        if _is_storage_error(error):
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "The LangGraph runtime storage is unavailable."},
+            )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "The graph execution failed."},
+        )
+
+
+def _is_storage_error(error: Exception) -> bool:
+    module = error.__class__.__module__.split(".", maxsplit=1)[0]
+    return module in {"psycopg", "psycopg_pool", "redis"}

--- a/arclith/adapters/inbound/langgraph_runtime/catalog.py
+++ b/arclith/adapters/inbound/langgraph_runtime/catalog.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+
+class ThreadAlreadyExistsError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ThreadRecord:
+    thread_id: str
+    status: str = "idle"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def as_api_dict(self) -> dict[str, Any]:
+        return {
+            "thread_id": self.thread_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "metadata": self.metadata,
+            "status": self.status,
+            "config": {"configurable": {"thread_id": self.thread_id}},
+            "values": None,
+            "interrupts": {},
+        }
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    run_id: str
+    thread_id: str
+    assistant_id: str
+    status: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    input: Any = None
+    output: Any = None
+    error: dict[str, Any] | None = None
+
+    def as_api_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "thread_id": self.thread_id,
+            "assistant_id": self.assistant_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "status": self.status,
+            "metadata": {},
+        }
+
+
+class RuntimeCatalog(Protocol):
+    async def setup(self) -> None: ...
+
+    async def healthcheck(self) -> bool: ...
+
+    async def create_thread(
+        self,
+        thread_id: str,
+        metadata: dict[str, Any],
+        *,
+        if_exists: str | None = None,
+    ) -> ThreadRecord: ...
+
+    async def get_thread(self, thread_id: str) -> ThreadRecord | None: ...
+
+    async def search_threads(
+        self,
+        *,
+        metadata: dict[str, Any] | None,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[ThreadRecord]: ...
+
+    async def set_thread_status(self, thread_id: str, status: str) -> None: ...
+
+    async def delete_thread(self, thread_id: str) -> None: ...
+
+    async def create_run(self, record: RunRecord) -> RunRecord: ...
+
+    async def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        output: Any = None,
+        error: dict[str, Any] | None = None,
+    ) -> RunRecord | None: ...
+
+    async def get_run(self, thread_id: str, run_id: str) -> RunRecord | None: ...
+
+    async def list_runs(
+        self,
+        thread_id: str,
+        *,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[RunRecord]: ...
+
+
+class InMemoryRuntimeCatalog:
+    def __init__(self) -> None:
+        self._threads: dict[str, ThreadRecord] = {}
+        self._runs: dict[str, RunRecord] = {}
+
+    async def setup(self) -> None:
+        return None
+
+    async def healthcheck(self) -> bool:
+        return True
+
+    async def create_thread(
+        self,
+        thread_id: str,
+        metadata: dict[str, Any],
+        *,
+        if_exists: str | None = None,
+    ) -> ThreadRecord:
+        existing = self._threads.get(thread_id)
+        if existing is not None:
+            if if_exists == "raise":
+                raise ThreadAlreadyExistsError(f"Thread {thread_id} already exists")
+            return existing
+        record = ThreadRecord(thread_id=thread_id, metadata=dict(metadata))
+        self._threads[thread_id] = record
+        return record
+
+    async def get_thread(self, thread_id: str) -> ThreadRecord | None:
+        return self._threads.get(thread_id)
+
+    async def search_threads(
+        self,
+        *,
+        metadata: dict[str, Any] | None,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[ThreadRecord]:
+        records = sorted(
+            self._threads.values(), key=lambda item: item.created_at, reverse=True
+        )
+        if status is not None:
+            records = [record for record in records if record.status == status]
+        if metadata:
+            records = [
+                record
+                for record in records
+                if all(
+                    record.metadata.get(key) == value for key, value in metadata.items()
+                )
+            ]
+        return records[offset : offset + limit]
+
+    async def set_thread_status(self, thread_id: str, status: str) -> None:
+        record = self._threads.get(thread_id)
+        if record is None:
+            return
+        self._threads[thread_id] = ThreadRecord(
+            thread_id=record.thread_id,
+            status=status,
+            metadata=record.metadata,
+            created_at=record.created_at,
+            updated_at=datetime.now(UTC),
+        )
+
+    async def delete_thread(self, thread_id: str) -> None:
+        self._threads.pop(thread_id, None)
+        self._runs = {
+            run_id: run
+            for run_id, run in self._runs.items()
+            if run.thread_id != thread_id
+        }
+
+    async def create_run(self, record: RunRecord) -> RunRecord:
+        self._runs[record.run_id] = record
+        await self.set_thread_status(record.thread_id, "busy")
+        return record
+
+    async def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        output: Any = None,
+        error: dict[str, Any] | None = None,
+    ) -> RunRecord | None:
+        record = self._runs.get(run_id)
+        if record is None:
+            return None
+        updated = RunRecord(
+            run_id=record.run_id,
+            thread_id=record.thread_id,
+            assistant_id=record.assistant_id,
+            status=status,
+            created_at=record.created_at,
+            updated_at=datetime.now(UTC),
+            input=record.input,
+            output=output,
+            error=error,
+        )
+        self._runs[run_id] = updated
+        thread_status = "idle" if status == "success" else status
+        await self.set_thread_status(record.thread_id, thread_status)
+        return updated
+
+    async def get_run(self, thread_id: str, run_id: str) -> RunRecord | None:
+        record = self._runs.get(run_id)
+        if record is None or record.thread_id != thread_id:
+            return None
+        return record
+
+    async def list_runs(
+        self,
+        thread_id: str,
+        *,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[RunRecord]:
+        records = sorted(
+            (run for run in self._runs.values() if run.thread_id == thread_id),
+            key=lambda item: item.created_at,
+            reverse=True,
+        )
+        if status is not None:
+            records = [record for record in records if record.status == status]
+        return records[offset : offset + limit]
+
+
+class PostgresRuntimeCatalog:
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+
+    async def setup(self) -> None:
+        async with self._pool.connection() as connection:
+            await connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS arclith_langgraph_thread (
+                    thread_id UUID PRIMARY KEY,
+                    status TEXT NOT NULL DEFAULT 'idle',
+                    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """
+            )
+            await connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS arclith_langgraph_run (
+                    run_id UUID PRIMARY KEY,
+                    thread_id UUID NOT NULL REFERENCES arclith_langgraph_thread(thread_id)
+                        ON DELETE CASCADE,
+                    assistant_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    input JSONB,
+                    output JSONB,
+                    error JSONB,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """
+            )
+            await connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS arclith_langgraph_run_thread_created_idx
+                ON arclith_langgraph_run (thread_id, created_at DESC)
+                """
+            )
+
+    async def healthcheck(self) -> bool:
+        try:
+            async with self._pool.connection() as connection:
+                cursor = await connection.execute(
+                    """
+                    SELECT
+                        to_regclass('arclith_langgraph_thread') AS thread_table,
+                        to_regclass('arclith_langgraph_run') AS run_table,
+                        to_regclass('checkpoints') AS checkpoint_table,
+                        to_regclass('store') AS store_table
+                    """
+                )
+                row = await cursor.fetchone()
+        except Exception:
+            return False
+        return row is not None and all(row.values())
+
+    async def create_thread(
+        self,
+        thread_id: str,
+        metadata: dict[str, Any],
+        *,
+        if_exists: str | None = None,
+    ) -> ThreadRecord:
+        async with self._pool.connection() as connection:
+            cursor = await connection.execute(
+                """
+                INSERT INTO arclith_langgraph_thread (thread_id, metadata)
+                VALUES (%s, %s::jsonb)
+                ON CONFLICT (thread_id) DO NOTHING
+                RETURNING thread_id, status, metadata, created_at, updated_at
+                """,
+                (thread_id, json.dumps(metadata)),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            if if_exists == "raise":
+                raise ThreadAlreadyExistsError(f"Thread {thread_id} already exists")
+            existing = await self.get_thread(thread_id)
+            if existing is None:
+                raise RuntimeError("Thread creation did not return a record")
+            return existing
+        return _thread_from_row(row)
+
+    async def get_thread(self, thread_id: str) -> ThreadRecord | None:
+        async with self._pool.connection() as connection:
+            cursor = await connection.execute(
+                """
+                SELECT thread_id, status, metadata, created_at, updated_at
+                FROM arclith_langgraph_thread
+                WHERE thread_id = %s
+                """,
+                (thread_id,),
+            )
+            row = await cursor.fetchone()
+        return _thread_from_row(row) if row is not None else None
+
+    async def search_threads(
+        self,
+        *,
+        metadata: dict[str, Any] | None,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[ThreadRecord]:
+        encoded_metadata = json.dumps(metadata) if metadata else None
+        parameters = (
+            status,
+            status,
+            encoded_metadata,
+            encoded_metadata,
+            limit,
+            offset,
+        )
+        async with self._pool.connection() as connection:
+            cursor = await connection.execute(
+                """
+                SELECT thread_id, status, metadata, created_at, updated_at
+                FROM arclith_langgraph_thread
+                WHERE (%s::text IS NULL OR status = %s)
+                  AND (%s::jsonb IS NULL OR metadata @> %s::jsonb)
+                ORDER BY created_at DESC
+                LIMIT %s OFFSET %s
+                """,
+                parameters,
+            )
+            rows = await cursor.fetchall()
+        return [_thread_from_row(row) for row in rows]
+
+    async def set_thread_status(self, thread_id: str, status: str) -> None:
+        async with self._pool.connection() as connection:
+            await connection.execute(
+                """
+                UPDATE arclith_langgraph_thread
+                SET status = %s, updated_at = now()
+                WHERE thread_id = %s
+                """,
+                (status, thread_id),
+            )
+
+    async def delete_thread(self, thread_id: str) -> None:
+        async with self._pool.connection() as connection:
+            await connection.execute(
+                "DELETE FROM arclith_langgraph_thread WHERE thread_id = %s",
+                (thread_id,),
+            )
+
+    async def create_run(self, record: RunRecord) -> RunRecord:
+        async with self._pool.connection() as connection:
+            async with connection.transaction():
+                cursor = await connection.execute(
+                    """
+                    INSERT INTO arclith_langgraph_run (
+                        run_id, thread_id, assistant_id, status, input
+                    ) VALUES (%s, %s, %s, %s, %s::jsonb)
+                    RETURNING run_id, thread_id, assistant_id, status, input, output,
+                              error, created_at, updated_at
+                    """,
+                    (
+                        record.run_id,
+                        record.thread_id,
+                        record.assistant_id,
+                        record.status,
+                        json.dumps(record.input),
+                    ),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    raise RuntimeError("Run creation did not return a record")
+                await connection.execute(
+                    """
+                    UPDATE arclith_langgraph_thread
+                    SET status = 'busy', updated_at = now()
+                    WHERE thread_id = %s
+                    """,
+                    (record.thread_id,),
+                )
+        return _run_from_row(row)
+
+    async def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        output: Any = None,
+        error: dict[str, Any] | None = None,
+    ) -> RunRecord | None:
+        async with self._pool.connection() as connection:
+            async with connection.transaction():
+                cursor = await connection.execute(
+                    """
+                    UPDATE arclith_langgraph_run
+                    SET status = %s, output = %s::jsonb, error = %s::jsonb,
+                        updated_at = now()
+                    WHERE run_id = %s
+                    RETURNING run_id, thread_id, assistant_id, status, input, output,
+                              error, created_at, updated_at
+                    """,
+                    (status, json.dumps(output), json.dumps(error), run_id),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                record = _run_from_row(row)
+                thread_status = "idle" if status == "success" else status
+                await connection.execute(
+                    """
+                    UPDATE arclith_langgraph_thread
+                    SET status = %s, updated_at = now()
+                    WHERE thread_id = %s
+                    """,
+                    (thread_status, record.thread_id),
+                )
+        return record
+
+    async def get_run(self, thread_id: str, run_id: str) -> RunRecord | None:
+        async with self._pool.connection() as connection:
+            cursor = await connection.execute(
+                """
+                SELECT run_id, thread_id, assistant_id, status, input, output,
+                       error, created_at, updated_at
+                FROM arclith_langgraph_run
+                WHERE thread_id = %s AND run_id = %s
+                """,
+                (thread_id, run_id),
+            )
+            row = await cursor.fetchone()
+        return _run_from_row(row) if row is not None else None
+
+    async def list_runs(
+        self,
+        thread_id: str,
+        *,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[RunRecord]:
+        parameters = (thread_id, status, status, limit, offset)
+        async with self._pool.connection() as connection:
+            cursor = await connection.execute(
+                """
+                SELECT run_id, thread_id, assistant_id, status, input, output,
+                       error, created_at, updated_at
+                FROM arclith_langgraph_run
+                WHERE thread_id = %s
+                  AND (%s::text IS NULL OR status = %s)
+                ORDER BY created_at DESC
+                LIMIT %s OFFSET %s
+                """,
+                parameters,
+            )
+            rows = await cursor.fetchall()
+        return [_run_from_row(row) for row in rows]
+
+
+def _thread_from_row(row: Any) -> ThreadRecord:
+    return ThreadRecord(
+        thread_id=str(row["thread_id"]),
+        status=str(row["status"]),
+        metadata=dict(row["metadata"] or {}),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _run_from_row(row: Any) -> RunRecord:
+    return RunRecord(
+        run_id=str(row["run_id"]),
+        thread_id=str(row["thread_id"]),
+        assistant_id=str(row["assistant_id"]),
+        status=str(row["status"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        input=row["input"],
+        output=row["output"],
+        error=dict(row["error"]) if row["error"] else None,
+    )

--- a/arclith/adapters/inbound/langgraph_runtime/catalog.py
+++ b/arclith/adapters/inbound/langgraph_runtime/catalog.py
@@ -56,9 +56,11 @@ class RunRecord:
 
 
 class RuntimeCatalog(Protocol):
-    async def setup(self) -> None: ...
+    async def setup(self) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def healthcheck(self) -> bool: ...
+    async def healthcheck(self) -> bool:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
     async def create_thread(
         self,
@@ -66,9 +68,11 @@ class RuntimeCatalog(Protocol):
         metadata: dict[str, Any],
         *,
         if_exists: str | None = None,
-    ) -> ThreadRecord: ...
+    ) -> ThreadRecord:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def get_thread(self, thread_id: str) -> ThreadRecord | None: ...
+    async def get_thread(self, thread_id: str) -> ThreadRecord | None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
     async def search_threads(
         self,
@@ -77,13 +81,17 @@ class RuntimeCatalog(Protocol):
         status: str | None,
         limit: int,
         offset: int,
-    ) -> list[ThreadRecord]: ...
+    ) -> list[ThreadRecord]:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def set_thread_status(self, thread_id: str, status: str) -> None: ...
+    async def set_thread_status(self, thread_id: str, status: str) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def delete_thread(self, thread_id: str) -> None: ...
+    async def delete_thread(self, thread_id: str) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def create_run(self, record: RunRecord) -> RunRecord: ...
+    async def create_run(self, record: RunRecord) -> RunRecord:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
     async def finish_run(
         self,
@@ -92,9 +100,11 @@ class RuntimeCatalog(Protocol):
         status: str,
         output: Any = None,
         error: dict[str, Any] | None = None,
-    ) -> RunRecord | None: ...
+    ) -> RunRecord | None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def get_run(self, thread_id: str, run_id: str) -> RunRecord | None: ...
+    async def get_run(self, thread_id: str, run_id: str) -> RunRecord | None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
     async def list_runs(
         self,
@@ -103,7 +113,8 @@ class RuntimeCatalog(Protocol):
         status: str | None,
         limit: int,
         offset: int,
-    ) -> list[RunRecord]: ...
+    ) -> list[RunRecord]:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
 
 class InMemoryRuntimeCatalog:

--- a/arclith/adapters/inbound/langgraph_runtime/coordination.py
+++ b/arclith/adapters/inbound/langgraph_runtime/coordination.py
@@ -32,7 +32,7 @@ class RunCoordinator(Protocol):
 
 class InMemoryRunCoordinator:
     def __init__(self) -> None:
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._active_threads: set[str] = set()
         self._cancelled: set[str] = set()
 
     @asynccontextmanager
@@ -40,14 +40,13 @@ class InMemoryRunCoordinator:
         self, thread_id: str, *, timeout_seconds: int
     ) -> AsyncIterator[None]:
         del timeout_seconds
-        lock = self._locks.setdefault(thread_id, asyncio.Lock())
-        if lock.locked():
+        if thread_id in self._active_threads:
             raise RunBusyError(f"Thread {thread_id} already has an active run")
-        await lock.acquire()
+        self._active_threads.add(thread_id)
         try:
             yield
         finally:
-            lock.release()
+            self._active_threads.discard(thread_id)
 
     async def request_cancel(self, run_id: str) -> None:
         self._cancelled.add(run_id)

--- a/arclith/adapters/inbound/langgraph_runtime/coordination.py
+++ b/arclith/adapters/inbound/langgraph_runtime/coordination.py
@@ -99,6 +99,7 @@ class RedisRunCoordinator:
             try:
                 await renewal
             except asyncio.CancelledError:
+                # Expected after cancelling the lease-renewal task above.
                 pass
             try:
                 await lock.release()

--- a/arclith/adapters/inbound/langgraph_runtime/coordination.py
+++ b/arclith/adapters/inbound/langgraph_runtime/coordination.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Protocol
+
+
+class RunBusyError(RuntimeError):
+    pass
+
+
+class RunCoordinator(Protocol):
+    def thread_lock(self, thread_id: str, *, timeout_seconds: int) -> Any: ...
+
+    async def request_cancel(self, run_id: str) -> None: ...
+
+    async def is_cancelled(self, run_id: str) -> bool: ...
+
+    async def clear_cancel(self, run_id: str) -> None: ...
+
+    async def healthcheck(self) -> bool: ...
+
+    async def close(self) -> None: ...
+
+
+class InMemoryRunCoordinator:
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._cancelled: set[str] = set()
+
+    @asynccontextmanager
+    async def thread_lock(
+        self, thread_id: str, *, timeout_seconds: int
+    ) -> AsyncIterator[None]:
+        del timeout_seconds
+        lock = self._locks.setdefault(thread_id, asyncio.Lock())
+        if lock.locked():
+            raise RunBusyError(f"Thread {thread_id} already has an active run")
+        await lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+
+    async def request_cancel(self, run_id: str) -> None:
+        self._cancelled.add(run_id)
+
+    async def is_cancelled(self, run_id: str) -> bool:
+        return run_id in self._cancelled
+
+    async def clear_cancel(self, run_id: str) -> None:
+        self._cancelled.discard(run_id)
+
+    async def close(self) -> None:
+        return None
+
+    async def healthcheck(self) -> bool:
+        return True
+
+
+class RedisRunCoordinator:
+    def __init__(
+        self,
+        client: Any,
+        *,
+        prefix: str = "arclith:langgraph",
+        lease_seconds: float = 30,
+    ) -> None:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds doit etre strictement positif")
+        self._client = client
+        self._prefix = prefix.strip(":")
+        self._lease_seconds = lease_seconds
+
+    @asynccontextmanager
+    async def thread_lock(
+        self, thread_id: str, *, timeout_seconds: int
+    ) -> AsyncIterator[None]:
+        del timeout_seconds
+        lock = self._client.lock(
+            f"{self._prefix}:thread:{thread_id}:lock",
+            timeout=self._lease_seconds,
+            blocking_timeout=0,
+        )
+        if not await lock.acquire(blocking=False):
+            raise RunBusyError(f"Thread {thread_id} already has an active run")
+        owner = asyncio.current_task()
+        renewal = asyncio.create_task(self._renew_lock(lock, owner))
+        try:
+            yield
+        finally:
+            renewal.cancel()
+            try:
+                await renewal
+            except asyncio.CancelledError:
+                pass
+            try:
+                await lock.release()
+            except Exception as error:  # pragma: no cover - defensive Redis race
+                if error.__class__.__name__ != "LockNotOwnedError":
+                    raise
+
+    async def _renew_lock(self, lock: Any, owner: asyncio.Task[Any] | None) -> None:
+        while True:
+            await asyncio.sleep(self._lease_seconds / 3)
+            try:
+                extended = await lock.extend(
+                    self._lease_seconds,
+                    replace_ttl=True,
+                )
+            except Exception:
+                extended = False
+            if not extended:
+                if owner is not None:
+                    owner.cancel()
+                return
+
+    async def request_cancel(self, run_id: str) -> None:
+        await self._client.set(
+            f"{self._prefix}:run:{run_id}:cancelled",
+            "1",
+            ex=3600,
+        )
+
+    async def is_cancelled(self, run_id: str) -> bool:
+        value = await self._client.get(f"{self._prefix}:run:{run_id}:cancelled")
+        return value is not None
+
+    async def clear_cancel(self, run_id: str) -> None:
+        await self._client.delete(f"{self._prefix}:run:{run_id}:cancelled")
+
+    async def healthcheck(self) -> bool:
+        try:
+            return bool(await self._client.ping())
+        except Exception:
+            return False
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/arclith/adapters/inbound/langgraph_runtime/coordination.py
+++ b/arclith/adapters/inbound/langgraph_runtime/coordination.py
@@ -11,17 +11,23 @@ class RunBusyError(RuntimeError):
 
 
 class RunCoordinator(Protocol):
-    def thread_lock(self, thread_id: str, *, timeout_seconds: int) -> Any: ...
+    def thread_lock(self, thread_id: str, *, timeout_seconds: int) -> Any:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def request_cancel(self, run_id: str) -> None: ...
+    async def request_cancel(self, run_id: str) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def is_cancelled(self, run_id: str) -> bool: ...
+    async def is_cancelled(self, run_id: str) -> bool:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def clear_cancel(self, run_id: str) -> None: ...
+    async def clear_cancel(self, run_id: str) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def healthcheck(self) -> bool: ...
+    async def healthcheck(self) -> bool:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
-    async def close(self) -> None: ...
+    async def close(self) -> None:
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
 
 class InMemoryRunCoordinator:

--- a/arclith/adapters/inbound/langgraph_runtime/loader.py
+++ b/arclith/adapters/inbound/langgraph_runtime/loader.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_graphs(config_path: str | Path) -> dict[str, Any]:
+    path = Path(config_path).resolve()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    configured = payload.get("graphs")
+    if not isinstance(configured, dict) or not configured:
+        raise ValueError("langgraph.json doit declarer au moins un graphe")
+
+    os.environ["ARCLITH_LANGGRAPH_PERSISTENCE_MODE"] = "agent_server"
+    graphs: dict[str, Any] = {}
+    for assistant_id, entrypoint in configured.items():
+        if not isinstance(assistant_id, str) or not assistant_id.strip():
+            raise ValueError("Chaque graphe LangGraph doit avoir un nom non vide")
+        if not isinstance(entrypoint, str):
+            raise ValueError(f"Entrypoint invalide pour le graphe {assistant_id}")
+        graph = _load_entrypoint(entrypoint, base_dir=path.parent)
+        if not callable(getattr(graph, "ainvoke", None)):
+            raise TypeError(f"Le graphe {assistant_id} ne fournit pas ainvoke()")
+        if not callable(getattr(graph, "astream", None)):
+            raise TypeError(f"Le graphe {assistant_id} ne fournit pas astream()")
+        graphs[assistant_id] = graph
+    return graphs
+
+
+def _load_entrypoint(entrypoint: str, *, base_dir: Path) -> Any:
+    if ":" not in entrypoint:
+        raise ValueError(
+            "Un entrypoint LangGraph doit utiliser le format module:attribut"
+        )
+    module_spec, attribute = entrypoint.rsplit(":", 1)
+    module = _load_module(module_spec, base_dir=base_dir)
+    graph = getattr(module, attribute, None)
+    if graph is None:
+        raise AttributeError(f"Attribut LangGraph introuvable: {entrypoint}")
+    return graph
+
+
+def _load_module(module_spec: str, *, base_dir: Path) -> Any:
+    if "/" not in module_spec and not module_spec.endswith(".py"):
+        return importlib.import_module(module_spec)
+
+    file_path = (base_dir / module_spec).resolve()
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Module LangGraph introuvable: {file_path}")
+
+    package_root, module_name = _module_name_from_path(file_path)
+    if package_root is not None and module_name is not None:
+        root = str(package_root)
+        if root not in sys.path:
+            sys.path.insert(0, root)
+        return importlib.import_module(module_name)
+
+    generated_name = f"arclith_runtime_graph_{abs(hash(file_path))}"
+    spec = importlib.util.spec_from_file_location(generated_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Impossible de charger le module {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[generated_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _module_name_from_path(path: Path) -> tuple[Path | None, str | None]:
+    parts = path.parts
+    if "src" not in parts:
+        return None, None
+    src_index = len(parts) - 1 - tuple(reversed(parts)).index("src")
+    relative = Path(*parts[src_index + 1 :]).with_suffix("")
+    return Path(*parts[: src_index + 1]), ".".join(relative.parts)

--- a/arclith/adapters/inbound/langgraph_runtime/runtime.py
+++ b/arclith/adapters/inbound/langgraph_runtime/runtime.py
@@ -158,7 +158,7 @@ class LangGraphRuntime:
 
     async def state(self, thread_id: str) -> dict[str, Any]:
         await self.get_thread(thread_id)
-        graph = next(iter(self.graphs.values()))
+        graph = await self._thread_graph(thread_id)
         snapshot = await graph.aget_state(_graph_config(thread_id, None))
         if not snapshot.config:
             return _empty_snapshot(thread_id)
@@ -166,7 +166,7 @@ class LangGraphRuntime:
 
     async def history(self, thread_id: str, *, limit: int) -> list[dict[str, Any]]:
         await self.get_thread(thread_id)
-        graph = next(iter(self.graphs.values()))
+        graph = await self._thread_graph(thread_id)
         snapshots = graph.aget_state_history(
             _graph_config(thread_id, None),
             limit=limit,
@@ -283,6 +283,17 @@ class LangGraphRuntime:
             input=jsonable(request.input),
         )
         return await self.catalog.create_run(record)
+
+    async def _thread_graph(self, thread_id: str) -> Any:
+        runs = await self.catalog.list_runs(
+            thread_id,
+            status=None,
+            limit=1,
+            offset=0,
+        )
+        if runs:
+            return self._graph(runs[0].assistant_id)
+        return next(iter(self.graphs.values()))
 
     @asynccontextmanager
     async def _run_session(

--- a/arclith/adapters/inbound/langgraph_runtime/runtime.py
+++ b/arclith/adapters/inbound/langgraph_runtime/runtime.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+from typing import Any
+
+from uuid6 import uuid7
+
+from arclith.adapters.inbound.langgraph_runtime.catalog import (
+    RunRecord,
+    RuntimeCatalog,
+    ThreadRecord,
+)
+from arclith.adapters.inbound.langgraph_runtime.coordination import (
+    RunBusyError,
+    RunCoordinator,
+)
+from arclith.adapters.inbound.langgraph_runtime.serialization import (
+    jsonable,
+    safe_error,
+    snapshot_to_dict,
+    sse_event,
+)
+
+
+class ThreadNotFoundError(LookupError):
+    pass
+
+
+class RunNotFoundError(LookupError):
+    pass
+
+
+class AssistantNotFoundError(LookupError):
+    pass
+
+
+class RunCancelledError(RuntimeError):
+    pass
+
+
+class RuntimeStorageError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RunRequest:
+    assistant_id: str
+    input: Any = None
+    command: Any = None
+    config: dict[str, Any] | None = None
+    checkpoint: dict[str, Any] | None = None
+    checkpoint_id: str | None = None
+    stream_mode: str | list[str] | None = None
+    on_disconnect: str = "cancel"
+    multitask_strategy: str = "reject"
+
+
+class LangGraphRuntime:
+    def __init__(
+        self,
+        graphs: Mapping[str, Any],
+        catalog: RuntimeCatalog,
+        coordinator: RunCoordinator,
+        *,
+        run_timeout_seconds: int = 900,
+        cancel_poll_seconds: float = 0.2,
+    ) -> None:
+        if not graphs:
+            raise ValueError("Le runtime LangGraph exige au moins un graphe")
+        if run_timeout_seconds <= 0:
+            raise ValueError("run_timeout_seconds doit etre strictement positif")
+        if cancel_poll_seconds <= 0:
+            raise ValueError("cancel_poll_seconds doit etre strictement positif")
+        self.graphs = dict(graphs)
+        self.catalog = catalog
+        self.coordinator = coordinator
+        self.run_timeout_seconds = run_timeout_seconds
+        self.cancel_poll_seconds = cancel_poll_seconds
+
+    async def setup(self) -> None:
+        await self.catalog.setup()
+
+    async def ready(self) -> bool:
+        catalog_ready, coordinator_ready = await asyncio.gather(
+            self.catalog.healthcheck(),
+            self.coordinator.healthcheck(),
+        )
+        return catalog_ready and coordinator_ready
+
+    def assistant(self, assistant_id: str) -> dict[str, Any]:
+        self._graph(assistant_id)
+        return {
+            "assistant_id": assistant_id,
+            "graph_id": assistant_id,
+            "name": assistant_id,
+            "metadata": {"runtime": "arclith-open-source"},
+            "config": {},
+            "version": 1,
+        }
+
+    def assistants(self) -> list[dict[str, Any]]:
+        return [self.assistant(assistant_id) for assistant_id in self.graphs]
+
+    async def create_thread(
+        self,
+        *,
+        thread_id: str | None,
+        metadata: dict[str, Any] | None,
+        if_exists: str | None,
+    ) -> ThreadRecord:
+        resolved_id = thread_id or str(uuid7())
+        return await self.catalog.create_thread(
+            resolved_id,
+            metadata or {},
+            if_exists=if_exists,
+        )
+
+    async def get_thread(self, thread_id: str) -> ThreadRecord:
+        record = await self.catalog.get_thread(thread_id)
+        if record is None:
+            raise ThreadNotFoundError(f"Thread {thread_id} not found")
+        return record
+
+    async def search_threads(
+        self,
+        *,
+        metadata: dict[str, Any] | None,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[ThreadRecord]:
+        return await self.catalog.search_threads(
+            metadata=metadata,
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def delete_thread(self, thread_id: str) -> None:
+        await self.get_thread(thread_id)
+        async with self.coordinator.thread_lock(
+            thread_id,
+            timeout_seconds=self.run_timeout_seconds,
+        ):
+            seen: set[int] = set()
+            for graph in self.graphs.values():
+                checkpointer = getattr(graph, "checkpointer", None)
+                if checkpointer is None or id(checkpointer) in seen:
+                    continue
+                seen.add(id(checkpointer))
+                delete = getattr(checkpointer, "adelete_thread", None)
+                if callable(delete):
+                    await delete(thread_id)
+            await self.catalog.delete_thread(thread_id)
+
+    async def state(self, thread_id: str) -> dict[str, Any]:
+        await self.get_thread(thread_id)
+        graph = next(iter(self.graphs.values()))
+        snapshot = await graph.aget_state(_graph_config(thread_id, None))
+        if not snapshot.config:
+            return _empty_snapshot(thread_id)
+        return snapshot_to_dict(snapshot)
+
+    async def history(self, thread_id: str, *, limit: int) -> list[dict[str, Any]]:
+        await self.get_thread(thread_id)
+        graph = next(iter(self.graphs.values()))
+        snapshots = graph.aget_state_history(
+            _graph_config(thread_id, None),
+            limit=limit,
+        )
+        return [snapshot_to_dict(snapshot) async for snapshot in snapshots]
+
+    async def wait(self, thread_id: str, request: RunRequest) -> Any:
+        await self.get_thread(thread_id)
+        graph = self._graph(request.assistant_id)
+        async with self._run_session(thread_id, request) as run:
+            async with asyncio.timeout(self.run_timeout_seconds):
+                output = await self._invoke(
+                    graph,
+                    thread_id,
+                    run.run_id,
+                    request,
+                )
+            encoded = jsonable(output)
+            await self.catalog.finish_run(
+                run.run_id,
+                status="success",
+                output=encoded,
+            )
+            return encoded
+
+    async def stream(
+        self,
+        thread_id: str,
+        request: RunRequest,
+    ) -> AsyncIterator[bytes]:
+        await self.get_thread(thread_id)
+        graph = self._graph(request.assistant_id)
+        stream = None
+        try:
+            async with self._run_session(thread_id, request) as run:
+                async with asyncio.timeout(self.run_timeout_seconds):
+                    modes = _stream_modes(request.stream_mode)
+                    stream = graph.astream(
+                        _run_input(request),
+                        _graph_config(thread_id, request),
+                        stream_mode=modes,
+                    )
+                    yield sse_event(
+                        "metadata",
+                        {"run_id": run.run_id, "thread_id": thread_id},
+                    )
+                    async for mode, chunk in self._cancel_aware_stream(
+                        stream,
+                        run.run_id,
+                        modes,
+                    ):
+                        yield sse_event(mode, chunk)
+                state = await graph.aget_state(_graph_config(thread_id, None))
+                output = jsonable(state.values) if state.config else None
+                await self.catalog.finish_run(
+                    run.run_id,
+                    status="success",
+                    output=output,
+                )
+        except asyncio.CancelledError:
+            raise
+        except RunBusyError:
+            yield sse_event(
+                "error",
+                {
+                    "error": "RunBusyError",
+                    "message": "Thread already has an active run.",
+                },
+            )
+        except RunCancelledError:
+            yield sse_event(
+                "error",
+                {"error": "RunCancelledError", "message": "Run cancelled."},
+            )
+        except Exception:
+            yield _execution_error_event()
+        finally:
+            await _close_stream(stream)
+
+    async def cancel_run(self, thread_id: str, run_id: str) -> None:
+        run = await self.get_run(thread_id, run_id)
+        if run.status != "running":
+            return
+        await self.coordinator.request_cancel(run_id)
+
+    async def get_run(self, thread_id: str, run_id: str) -> RunRecord:
+        record = await self.catalog.get_run(thread_id, run_id)
+        if record is None:
+            raise RunNotFoundError(f"Run {run_id} not found")
+        return record
+
+    async def list_runs(
+        self,
+        thread_id: str,
+        *,
+        status: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[RunRecord]:
+        await self.get_thread(thread_id)
+        return await self.catalog.list_runs(
+            thread_id,
+            status=status,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def _start_run(self, thread_id: str, request: RunRequest) -> RunRecord:
+        record = RunRecord(
+            run_id=str(uuid7()),
+            thread_id=thread_id,
+            assistant_id=request.assistant_id,
+            status="running",
+            input=jsonable(request.input),
+        )
+        return await self.catalog.create_run(record)
+
+    @asynccontextmanager
+    async def _run_session(
+        self,
+        thread_id: str,
+        request: RunRequest,
+    ) -> AsyncIterator[RunRecord]:
+        async with self.coordinator.thread_lock(
+            thread_id,
+            timeout_seconds=self.run_timeout_seconds,
+        ):
+            run = await self._start_run(thread_id, request)
+            try:
+                yield run
+            except asyncio.CancelledError as error:
+                if request.on_disconnect == "cancel":
+                    await self.coordinator.request_cancel(run.run_id)
+                await self._finish_error(run.run_id, "interrupted", error)
+                raise
+            except RunCancelledError as error:
+                await self._finish_error(run.run_id, "interrupted", error)
+                raise
+            except Exception as error:
+                await self._finish_error(run.run_id, "error", error)
+                raise
+            finally:
+                with suppress(Exception):
+                    await self.coordinator.clear_cancel(run.run_id)
+
+    async def _finish_error(
+        self, run_id: str, status: str, error: BaseException
+    ) -> None:
+        await self.catalog.finish_run(
+            run_id,
+            status=status,
+            error=safe_error(error),
+        )
+
+    async def _invoke(
+        self,
+        graph: Any,
+        thread_id: str,
+        run_id: str,
+        request: RunRequest,
+    ) -> Any:
+        execution = asyncio.create_task(
+            graph.ainvoke(
+                _run_input(request),
+                _graph_config(thread_id, request),
+            )
+        )
+        cancellation = asyncio.create_task(self._wait_for_cancel(run_id))
+        try:
+            done, _pending = await asyncio.wait(
+                {execution, cancellation},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if cancellation in done:
+                try:
+                    await cancellation
+                except Exception:
+                    execution.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await execution
+                    raise
+                execution.cancel()
+                with suppress(asyncio.CancelledError):
+                    await execution
+                raise RunCancelledError(f"Run {run_id} cancelled")
+            return await execution
+        finally:
+            cancellation.cancel()
+            with suppress(asyncio.CancelledError):
+                await cancellation
+
+    async def _cancel_aware_stream(
+        self,
+        stream: Any,
+        run_id: str,
+        modes: list[str],
+    ) -> AsyncIterator[tuple[str, Any]]:
+        iterator = stream.__aiter__()
+        while True:
+            next_item = asyncio.create_task(anext(iterator))
+            cancellation = asyncio.create_task(self._wait_for_cancel(run_id))
+            try:
+                done, _pending = await asyncio.wait(
+                    {next_item, cancellation},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if cancellation in done:
+                    try:
+                        await cancellation
+                    except Exception:
+                        next_item.cancel()
+                        with suppress(asyncio.CancelledError, StopAsyncIteration):
+                            await next_item
+                        raise
+                    next_item.cancel()
+                    with suppress(asyncio.CancelledError, StopAsyncIteration):
+                        await next_item
+                    raise RunCancelledError(f"Run {run_id} cancelled")
+                try:
+                    item = await next_item
+                except StopAsyncIteration:
+                    return
+                yield _stream_item(item, modes)
+            finally:
+                cancellation.cancel()
+                with suppress(asyncio.CancelledError):
+                    await cancellation
+
+    async def _wait_for_cancel(self, run_id: str) -> None:
+        while not await self.coordinator.is_cancelled(run_id):
+            await asyncio.sleep(self.cancel_poll_seconds)
+
+    def _graph(self, assistant_id: str) -> Any:
+        graph = self.graphs.get(assistant_id)
+        if graph is None:
+            raise AssistantNotFoundError(f"Assistant {assistant_id} not found")
+        return graph
+
+
+def _run_input(request: RunRequest) -> Any:
+    if request.command is None:
+        return request.input
+    if not isinstance(request.command, Mapping):
+        return request.command
+    from langgraph.types import Command
+
+    return Command(**request.command)
+
+
+def _graph_config(thread_id: str, request: RunRequest | None) -> dict[str, Any]:
+    configured = dict(request.config or {}) if request is not None else {}
+    configurable = dict(configured.get("configurable") or {})
+    configurable["thread_id"] = thread_id
+    if request is not None:
+        checkpoint = request.checkpoint or {}
+        checkpoint_id = request.checkpoint_id or checkpoint.get("checkpoint_id")
+        if checkpoint_id:
+            configurable["checkpoint_id"] = checkpoint_id
+        if checkpoint.get("checkpoint_ns") is not None:
+            configurable["checkpoint_ns"] = checkpoint["checkpoint_ns"]
+    configured["configurable"] = configurable
+    return configured
+
+
+def _stream_modes(configured: str | list[str] | None) -> list[str]:
+    modes = [configured] if isinstance(configured, str) else list(configured or [])
+    if not modes:
+        modes = ["values"]
+    normalized = ["messages" if mode == "messages-tuple" else mode for mode in modes]
+    return list(dict.fromkeys(normalized))
+
+
+def _stream_item(item: Any, modes: list[str]) -> tuple[str, Any]:
+    if len(modes) > 1 and isinstance(item, tuple) and len(item) == 2:
+        return str(item[0]), item[1]
+    return modes[0], item
+
+
+def _empty_snapshot(thread_id: str) -> dict[str, Any]:
+    return {
+        "values": {},
+        "next": [],
+        "tasks": [],
+        "metadata": None,
+        "created_at": None,
+        "checkpoint": {
+            "thread_id": thread_id,
+            "checkpoint_ns": "",
+            "checkpoint_id": None,
+        },
+        "parent_checkpoint": None,
+    }
+
+
+def _execution_error_event() -> bytes:
+    return sse_event(
+        "error",
+        {
+            "error": "GraphExecutionError",
+            "message": "The graph execution failed.",
+        },
+    )
+
+
+async def _close_stream(stream: Any) -> None:
+    if stream is None:
+        return
+    close = getattr(stream, "aclose", None)
+    if callable(close):
+        with suppress(RuntimeError):
+            await close()

--- a/arclith/adapters/inbound/langgraph_runtime/serialization.py
+++ b/arclith/adapters/inbound/langgraph_runtime/serialization.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from fastapi.encoders import jsonable_encoder
+
+
+def jsonable(value: Any) -> Any:
+    return jsonable_encoder(
+        value,
+        custom_encoder={
+            datetime: lambda item: item.isoformat(),
+            date: lambda item: item.isoformat(),
+            UUID: str,
+            Path: str,
+            Enum: lambda item: item.value,
+        },
+    )
+
+
+def snapshot_to_dict(snapshot: Any) -> dict[str, Any]:
+    return {
+        "values": jsonable(snapshot.values),
+        "next": list(snapshot.next),
+        "tasks": jsonable(list(snapshot.tasks)),
+        "metadata": jsonable(snapshot.metadata),
+        "created_at": snapshot.created_at,
+        "checkpoint": _checkpoint(snapshot.config),
+        "parent_checkpoint": _checkpoint(snapshot.parent_config),
+    }
+
+
+def sse_event(event: str, data: Any) -> bytes:
+    encoded = json.dumps(jsonable(data), ensure_ascii=False, separators=(",", ":"))
+    return f"event: {event}\ndata: {encoded}\n\n".encode()
+
+
+def safe_error(error: BaseException) -> dict[str, str]:
+    return {
+        "error": error.__class__.__name__,
+        "message": str(error)[:1000],
+    }
+
+
+def _checkpoint(config: Any) -> dict[str, Any] | None:
+    if not isinstance(config, Mapping):
+        return None
+    configurable = config.get("configurable")
+    if not isinstance(configurable, Mapping):
+        return None
+    return {
+        str(key): jsonable(value)
+        for key, value in configurable.items()
+        if value is not None
+    }

--- a/arclith/adapters/inbound/langgraph_runtime/server.py
+++ b/arclith/adapters/inbound/langgraph_runtime/server.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+
+from arclith.adapters.inbound.langgraph_runtime.api import (
+    create_langgraph_runtime_app,
+)
+from arclith.adapters.inbound.langgraph_runtime.catalog import (
+    PostgresRuntimeCatalog,
+)
+from arclith.adapters.inbound.langgraph_runtime.coordination import (
+    RedisRunCoordinator,
+)
+from arclith.adapters.inbound.langgraph_runtime.loader import load_graphs
+from arclith.adapters.inbound.langgraph_runtime.runtime import LangGraphRuntime
+
+
+def create_durable_langgraph_runtime_app(
+    config_path: str | Path = "langgraph.json",
+    *,
+    database_uri: str | None = None,
+    redis_uri: str | None = None,
+    redis_prefix: str | None = None,
+    run_timeout_seconds: int | None = None,
+) -> FastAPI:
+    resolved_database_uri = _required_uri(
+        database_uri,
+        primary_env="DATABASE_URI",
+        fallback_env="POSTGRESQL_URL",
+    )
+    resolved_redis_uri = _required_uri(
+        redis_uri,
+        primary_env="REDIS_URI",
+        fallback_env="REDIS_URL",
+    )
+    graphs = load_graphs(config_path)
+
+    pool, catalog = _postgres_catalog(resolved_database_uri)
+    redis_client = _redis_client(resolved_redis_uri)
+    coordinator = RedisRunCoordinator(
+        redis_client,
+        prefix=redis_prefix
+        or os.getenv("ARCLITH_LANGGRAPH_REDIS_PREFIX")
+        or "arclith:langgraph",
+        lease_seconds=_positive_int_env(
+            "ARCLITH_LANGGRAPH_REDIS_LEASE_SECONDS",
+            30,
+        ),
+    )
+    runtime = LangGraphRuntime(
+        graphs,
+        catalog,
+        coordinator,
+        run_timeout_seconds=run_timeout_seconds
+        or _positive_int_env("ARCLITH_LANGGRAPH_RUN_TIMEOUT_SECONDS", 900),
+    )
+    app = create_langgraph_runtime_app(runtime)
+    auto_setup = _boolean_env("ARCLITH_LANGGRAPH_AUTO_SETUP", True)
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        await pool.open()
+        try:
+            saver, store = await _build_langgraph_persistence(
+                pool,
+                setup=auto_setup,
+            )
+            _attach_persistence(graphs.values(), saver=saver, store=store)
+            if auto_setup:
+                await runtime.setup()
+            if not await coordinator.healthcheck():
+                raise RuntimeError("Redis coordination is unavailable")
+            yield
+        finally:
+            await coordinator.close()
+            await pool.close()
+
+    app.router.lifespan_context = lifespan
+    return app
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Arclith durable open source LangGraph runtime",
+    )
+    parser.add_argument(
+        "--config",
+        default=os.getenv("ARCLITH_LANGGRAPH_CONFIG", "langgraph.json"),
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("LANGGRAPH_HOST", "0.0.0.0"),  # nosec B104  # noqa: S104
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=_positive_int_env("LANGGRAPH_PORT", 2024),
+    )
+    parser.add_argument(
+        "--graceful-timeout",
+        type=int,
+        default=_positive_int_env("ARCLITH_GRACEFUL_TIMEOUT_SECONDS", 120),
+    )
+    args = parser.parse_args(argv)
+
+    import uvicorn
+
+    uvicorn.run(
+        create_durable_langgraph_runtime_app(args.config),
+        host=args.host,
+        port=args.port,
+        timeout_graceful_shutdown=args.graceful_timeout,
+        access_log=os.getenv("ARCLITH_ACCESS_LOG", "false").lower() == "true",
+    )
+
+
+async def _build_langgraph_persistence(
+    pool: Any,
+    *,
+    setup: bool,
+) -> tuple[Any, Any]:
+    try:
+        from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+        from langgraph.store.postgres.aio import AsyncPostgresStore
+    except ImportError as error:
+        raise RuntimeError(
+            "Le runtime durable exige arclith[langgraph-runtime]"
+        ) from error
+
+    saver = AsyncPostgresSaver(pool)
+    store = AsyncPostgresStore(pool)
+    if setup:
+        await saver.setup()
+        await store.setup()
+    return saver, store
+
+
+def _attach_persistence(graphs: Any, *, saver: Any, store: Any) -> None:
+    for graph in graphs:
+        graph.checkpointer = saver
+        graph.store = store
+
+
+def _postgres_catalog(database_uri: str) -> tuple[Any, PostgresRuntimeCatalog]:
+    try:
+        from psycopg.rows import dict_row
+        from psycopg_pool import AsyncConnectionPool
+    except ImportError as error:
+        raise RuntimeError(
+            "Le runtime durable exige arclith[langgraph-runtime]"
+        ) from error
+
+    pool = AsyncConnectionPool(
+        conninfo=database_uri,
+        kwargs={
+            "autocommit": True,
+            "prepare_threshold": 0,
+            "row_factory": dict_row,
+        },
+        min_size=1,
+        max_size=_positive_int_env("ARCLITH_LANGGRAPH_POSTGRES_POOL_SIZE", 10),
+        open=False,
+    )
+    return pool, PostgresRuntimeCatalog(pool)
+
+
+def _redis_client(redis_uri: str) -> Any:
+    try:
+        from redis.asyncio import Redis
+    except ImportError as error:
+        raise RuntimeError(
+            "Le runtime durable exige arclith[langgraph-runtime]"
+        ) from error
+    return Redis.from_url(
+        redis_uri,
+        decode_responses=True,
+        health_check_interval=30,
+    )
+
+
+def _required_uri(
+    configured: str | None,
+    *,
+    primary_env: str,
+    fallback_env: str,
+) -> str:
+    value = configured or os.getenv(primary_env) or os.getenv(fallback_env)
+    if not value:
+        raise RuntimeError(
+            f"Variable {primary_env} ou {fallback_env} requise pour le runtime durable"
+        )
+    return _normalize_postgresql_scheme(value)
+
+
+def _normalize_postgresql_scheme(uri: str) -> str:
+    for scheme in ("postgresql+asyncpg://", "postgresql+psycopg://"):
+        if uri.startswith(scheme):
+            return f"postgresql://{uri.removeprefix(scheme)}"
+    return uri
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = int(raw)
+    if value <= 0:
+        raise ValueError(f"{name} doit etre strictement positif")
+    return value
+
+
+def _boolean_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} doit etre un booleen")
+
+
+if __name__ == "__main__":  # pragma: no cover - console entrypoint
+    main()

--- a/cli/arclith_cli/runtime_templates.py
+++ b/cli/arclith_cli/runtime_templates.py
@@ -132,6 +132,13 @@ case "$mode" in
             echo "langgraph.json missing; configure agent/langgraph or set ARCLITH_AGENT_COMMAND." >&2
             exit 64
         fi
+        if [ "${{ARCLITH_AGENT_RUNTIME:-development}}" = "durable" ]; then
+            exec arclith-agent-runtime \\
+                --config "${{ARCLITH_LANGGRAPH_CONFIG:-langgraph.json}}" \\
+                --host "${{LANGGRAPH_HOST:-0.0.0.0}}" \\
+                --port "${{LANGGRAPH_PORT:-2024}}" \\
+                "$@"
+        fi
         exec langgraph dev \\
             --host "${{LANGGRAPH_HOST:-0.0.0.0}}" \\
             --port "${{LANGGRAPH_PORT:-2024}}" \\

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -83,6 +83,8 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;" in entrypoint
     assert "bus|command_bus|command-bus)" in entrypoint
     assert "langgraph dev" in entrypoint
+    assert '"${ARCLITH_AGENT_RUNTIME:-development}" = "durable"' in entrypoint
+    assert "exec arclith-agent-runtime" in entrypoint
     assert '_VALID_MODES = {"api", "mcp_http", "mcp_sse", "all"}' in main
     assert 'arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])' in main
     assert arclith_run.stat().st_mode & stat.S_IXUSR

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -87,12 +87,14 @@ requires-dist = [
     { name = "hvac", marker = "extra == 'vault'", specifier = "==2.3.0" },
     { name = "langgraph", marker = "extra == 'all'", specifier = ">=1.0.8" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.8" },
+    { name = "langgraph", marker = "extra == 'langgraph-runtime'", specifier = ">=1.0.8" },
     { name = "langgraph-api", marker = "extra == 'all'", specifier = ">=0.11.0" },
     { name = "langgraph-api", marker = "extra == 'langgraph'", specifier = ">=0.11.0" },
     { name = "langgraph-checkpoint-mongodb", marker = "extra == 'all'", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph-checkpoint-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-runtime'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'langgraph-persistence-redis'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-checkpoint-sqlite", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
@@ -118,6 +120,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.30.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'all'", specifier = ">=3.2.0,<4.0.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.2.0,<4.0.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-runtime'", specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'all'", specifier = ">=2.24.0,<3.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'langgraph'", specifier = ">=2.24.0,<3.0.0" },
@@ -128,14 +131,16 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "redis", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
+    { name = "redis", marker = "extra == 'langgraph-runtime'", specifier = ">=5.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'all'", specifier = ">=2.0.36" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'mariadb'", specifier = ">=2.0.36" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'postgresql'", specifier = ">=2.0.36" },
     { name = "uuid6", specifier = "==2025.0.1" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
+    { name = "uvicorn", marker = "extra == 'langgraph-runtime'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-runtime", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/docs/capabilities/agent-persistence.md
+++ b/docs/capabilities/agent-persistence.md
@@ -182,6 +182,59 @@ Pour l'Agent Server, PostgreSQL est le backend géré par défaut. MongoDB se co
 store custom Agent Server est un async context manager référencé par `checkpointer.path` ou
 `store.path`.
 
+### Runtime Durable Open Source
+
+Arclith fournit aussi `arclith-agent-runtime`, un serveur autonome destiné aux déploiements qui ne
+disposent pas de `LANGGRAPH_CLOUD_LICENSE_KEY`. Il ne requiert ni clé LangGraph Cloud ni clé
+LangSmith. `LANGSMITH_API_KEY` reste une intégration d'observabilité optionnelle et indépendante.
+
+Installer puis sélectionner le runtime dans l'image standard :
+
+```bash
+uv add "arclith[langgraph,langgraph-runtime]"
+ARCLITH_AGENT_RUNTIME=durable ./arclith-run agent
+```
+
+Variables requises :
+
+| Variable primaire | Alias accepté | Contenu |
+|---|---|---|
+| `DATABASE_URI` | `POSTGRESQL_URL` | URI PostgreSQL du runtime |
+| `REDIS_URI` | `REDIS_URL` | URI Redis de coordination |
+
+Le runtime charge les graphes de `langgraph.json`, force le mode de persistance `agent_server` à
+l'import, puis attache un `AsyncPostgresSaver` et un `AsyncPostgresStore` sur un pool partagé. Il
+ajoute un catalogue PostgreSQL pour les métadonnées de threads et de runs. Redis ne contient pas la
+conversation : il fournit un verrou distribué par thread et les demandes d'annulation, avec une
+expiration de sécurité. Le verrou est renouvelé pendant le run et expire en 30 secondes par défaut
+si un pod disparaît sans arrêt gracieux.
+
+Surface HTTP compatible avec les usages Jarvis et le SDK LangGraph :
+
+- assistants : recherche et lecture ;
+- threads : création, recherche, lecture, suppression, état et historique ;
+- runs : attente, streaming SSE, liste, lecture et annulation ;
+- streaming : événements `metadata`, `values`, `custom` et `messages` ;
+- reprise : `checkpoint`, `checkpoint_id` et `command` LangGraph.
+
+Cette surface n'est pas une réimplémentation exhaustive de la plateforme LangGraph. Les crons,
+déploiements, revisions d'assistants, webhooks, double-texting autre que `reject` et services
+LangSmith ne sont pas fournis. `/info` annonce explicitement ces limites.
+
+Garde-fous de production :
+
+- une base ou un schéma isolé par agent/trust boundary ;
+- un utilisateur PostgreSQL dédié, autorisé à créer les tables au premier démarrage ;
+- un utilisateur Redis et `ARCLITH_LANGGRAPH_REDIS_PREFIX` dédiés ;
+- une NetworkPolicy limitant les flux aux seuls PostgreSQL et Redis ;
+- `terminationGracePeriodSeconds` supérieur à `ARCLITH_GRACEFUL_TIMEOUT_SECONDS` ;
+- sauvegarde PostgreSQL vérifiée par restauration, Redis restant reconstructible ;
+- aucun URI ni message d'exception interne écrit dans la réponse SSE.
+
+Le schéma est créé de façon idempotente au démarrage. Pour une gouvernance DDL séparée, exécuter une
+première initialisation avec un rôle propriétaire, puis lancer les pods avec
+`ARCLITH_LANGGRAPH_AUTO_SETUP=false` après avoir retiré les privilèges de création au rôle runtime.
+
 ## Validation
 
 En embedded, deux appels avec le même `thread_id` doivent reprendre le même état :
@@ -214,6 +267,9 @@ un second `thread_id`.
 | état absent au second run | vérifier `configurable.thread_id` et sa stabilité |
 | aucun objet injecté sous Agent Server | comportement attendu : le serveur fournit ses backends |
 | `setup()` asynchrone en embedded | utiliser une implémentation sync ou le mode Agent Server |
+| `/ready` retourne `503` | vérifier PostgreSQL, Redis, credentials et NetworkPolicy |
+| second run refusé avec `409` | un run est déjà actif pour ce `thread_id` |
+| état présent mais thread absent | ne pas écrire directement dans les tables du checkpointer ; créer le thread via l'API |
 
 ## Projet
 

--- a/docs/capabilities/runtime.md
+++ b/docs/capabilities/runtime.md
@@ -34,7 +34,7 @@ arclith-run
 | `api` | `MODE=api python main.py` |
 | `mcp_http` | `MODE=mcp_http python main.py` |
 | `bus` | `MODE=bus python main.py` |
-| `agent` | `langgraph dev` ou `ARCLITH_AGENT_COMMAND` |
+| `agent` | `langgraph dev`, runtime durable Arclith ou `ARCLITH_AGENT_COMMAND` |
 
 ## Variables Utiles
 
@@ -45,7 +45,13 @@ arclith-run
 | `ARCLITH_MCP_PORT` | port exposé MCP |
 | `ARCLITH_PROBE_PORT` | port probes |
 | `ARCLITH_AGENT_PORT` | port LangGraph |
+| `ARCLITH_AGENT_RUNTIME` | `development` (défaut) ou `durable` |
 | `ARCLITH_AGENT_COMMAND` | commande agent personnalisée |
+
+Le profil `durable` lance `arclith-agent-runtime` et requiert l'extra
+`arclith[langgraph-runtime]`, PostgreSQL et Redis. Il conserve les threads et checkpoints sans clé
+de licence LangGraph Cloud. Voir [Agent Persistence](agent-persistence.md) pour le contrat et les
+limites de compatibilité.
 
 ## Règles
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -341,6 +341,36 @@ Pydantic AI ne sont pas créées deux fois.
 
 ---
 
+## ADR-015 — Runtime LangGraph durable open source sur PostgreSQL et Redis
+
+**Date :** 2026-08-28
+
+**Contexte :** `langgraph dev` est volontairement volatile et le serveur standalone officiel de
+production requiert une licence LangGraph Cloud. Les projets Jarvis doivent conserver threads,
+runs, checkpoints et mémoire après redémarrage, tout en gardant LangSmith optionnel et sans exposer
+les agents privés au navigateur.
+
+**Décision :** fournir un runtime inbound optionnel sous `arclith[langgraph-runtime]`. Il charge le
+contrat `langgraph.json`, expose le sous-ensemble HTTP/SSE nécessaire au SDK et au Gateway, et attache
+les implémentations officielles `AsyncPostgresSaver` / `AsyncPostgresStore`. Un catalogue PostgreSQL
+séparé conserve les métadonnées de threads/runs. Redis sert uniquement aux verrous distribués et à
+l'annulation ; il ne devient pas une source de vérité durable.
+
+Le runtime de développement reste le défaut. Le choix de production est explicite via
+`ARCLITH_AGENT_RUNTIME=durable`, avec `DATABASE_URI` et `REDIS_URI` injectées au runtime.
+
+**Conséquences :**
+
+- aucune clé `LANGGRAPH_CLOUD_LICENSE_KEY` ou `LANGSMITH_API_KEY` n'est requise ;
+- PostgreSQL est sauvegardé/restauré comme donnée critique, Redis est reconstructible ;
+- chaque agent reçoit une base ou un schéma et un préfixe Redis isolés ;
+- un seul run peut muter un thread à la fois, y compris avec plusieurs replicas ;
+- arrêt client, annulation explicite et timeout mettent à jour le statut du run ;
+- les erreurs de graphe sont conservées pour l'exploitation mais assainies dans les réponses ;
+- la surface ne prétend pas fournir crons, déploiements, webhooks ou plateforme LangSmith.
+
+---
+
 **Contexte :** Exposer les services via le Model Context Protocol.
 
 **Décision :** `fastmcp>=3.1.0` avec trois transports : stdio, SSE, streamable-HTTP.

--- a/docs/quickstarts/agent.md
+++ b/docs/quickstarts/agent.md
@@ -52,6 +52,11 @@ export LANGGRAPH_CLI_NO_ANALYTICS=1
 uv run langgraph dev --no-browser --allow-blocking --port 2024
 ```
 
+Cette commande est volatile et réservée au développement. Pour conserver threads, runs et
+checkpoints en production sans licence LangGraph Cloud, installer `arclith[langgraph-runtime]` et
+utiliser `ARCLITH_AGENT_RUNTIME=durable`; voir
+[Agent Persistence](../capabilities/agent-persistence.md#runtime-durable-open-source).
+
 Dans un second terminal:
 
 ```bash

--- a/docs/runtime-docker.md
+++ b/docs/runtime-docker.md
@@ -40,7 +40,7 @@ image Docker Arclith
 | `mcp` / `mcp_http` | `MODE=mcp_http python main.py` |
 | `mcp_sse` | `MODE=mcp_sse python main.py` |
 | `bus` / `command_bus` / `command-bus` | `MODE=bus python main.py` |
-| `agent` | `langgraph dev` ou `ARCLITH_AGENT_COMMAND` |
+| `agent` | `langgraph dev`, `arclith-agent-runtime` durable ou `ARCLITH_AGENT_COMMAND` |
 | `all` | `MODE=all python main.py` |
 
 Les modes `bus`, `agent` et `all` supposent que le projet a bien les adapters, runners et

--- a/docs/runtime-docker/local-agent.md
+++ b/docs/runtime-docker/local-agent.md
@@ -12,6 +12,12 @@ Le mode `agent` nécessite:
 - un `langgraph.json`;
 - les variables LLM et LangSmith injectées au runtime.
 
+En production durable sans Agent Server sous licence, ajouter également :
+
+```bash
+uv add "arclith[langgraph,langgraph-runtime]"
+```
+
 Préparer le projet:
 
 ```bash
@@ -79,6 +85,41 @@ docker run --rm \
   -p 2024:2024 \
   my-service:local agent
 ```
+
+`langgraph dev` garde son stockage en mémoire et reste réservé au développement. Le runtime durable
+open source Arclith se sélectionne sans modifier l'image :
+
+```bash
+docker run --rm \
+  --env-file .env.local \
+  -e ARCLITH_AGENT_RUNTIME=durable \
+  -e DATABASE_URI='postgresql://runtime@postgres/runtime' \
+  -e REDIS_URI='redis://runtime@redis/1' \
+  -e ARCLITH_LANGGRAPH_REDIS_PREFIX='my-agent:langgraph' \
+  -p 2024:2024 \
+  my-service:local agent
+```
+
+Les URI de cet exemple sont des formes sans credential à adapter : en exploitation, injecter les
+valeurs complètes par secret. Le runtime crée les tables LangGraph, son catalogue de threads/runs,
+expose `/health` et `/ready`, puis exécute les graphes déclarés dans `langgraph.json`. PostgreSQL
+porte l'état durable ; Redis porte exclusivement les verrous de thread et signaux d'annulation.
+
+Variables de réglage :
+
+| Variable | Défaut | Rôle |
+|---|---:|---|
+| `ARCLITH_LANGGRAPH_CONFIG` | `langgraph.json` | fichier des graphes |
+| `ARCLITH_LANGGRAPH_REDIS_PREFIX` | `arclith:langgraph` | espace de coordination isolé |
+| `ARCLITH_LANGGRAPH_REDIS_LEASE_SECONDS` | `30` | durée du verrou renouvelé par thread |
+| `ARCLITH_LANGGRAPH_POSTGRES_POOL_SIZE` | `10` | connexions PostgreSQL maximum |
+| `ARCLITH_LANGGRAPH_RUN_TIMEOUT_SECONDS` | `900` | durée maximale d'un run |
+| `ARCLITH_GRACEFUL_TIMEOUT_SECONDS` | `120` | arrêt gracieux Uvicorn |
+| `ARCLITH_LANGGRAPH_AUTO_SETUP` | `true` | applique les tables/indexes au démarrage |
+
+Une base ou un schéma dédié par agent est recommandé : les tables de checkpoints sont partagées par
+`thread_id`, et l'isolation évite qu'un identifiant fourni par un client ne croise un autre agent.
+Un préfixe Redis distinct est obligatoire entre runtimes partageant le même serveur.
 
 ## Vérifier
 
@@ -161,8 +202,8 @@ docker run --rm --env-file .env.local my-service:local agent
 - API locale `:2024` testée même sans LangSmith.
 - Traces LangSmith/OpenTelemetry activées par configuration, pas par code métier.
 - Checkpointer/store gérés une seule fois : par Arclith embedded ou par l'Agent Server.
-- En production, remplacer `langgraph dev` par la commande serveur validée du projet via
-  `ARCLITH_AGENT_COMMAND` si nécessaire.
+- En production durable, utiliser `ARCLITH_AGENT_RUNTIME=durable` avec PostgreSQL et Redis, ou une
+  commande serveur validée du projet via `ARCLITH_AGENT_COMMAND`.
 
 Page suivante: [autres modes locaux](local-other-modes.md). Voir aussi
 [Validation IA locale](../learning/local-ai-validation.md).

--- a/journal/2026-08-28-langgraph-runtime-open-source.md
+++ b/journal/2026-08-28-langgraph-runtime-open-source.md
@@ -1,0 +1,32 @@
+# Runtime LangGraph Durable Open Source
+
+## Contexte
+
+Les agents Arclith utilisaient `langgraph dev`, dont les threads et checkpoints disparaissent au
+redémarrage. Le serveur standalone officiel de production n'est pas utilisable sans clé de licence
+LangGraph Cloud.
+
+## Changements
+
+- ajout d'un serveur FastAPI autonome compatible avec les routes threads/runs utilisées par Jarvis ;
+- persistance des checkpoints et du store via les adapters PostgreSQL officiels de LangGraph ;
+- catalogue PostgreSQL des threads et runs ;
+- coordination Redis des verrous par thread et demandes d'annulation ;
+- streaming SSE `metadata`, `values`, `custom` et `messages` ;
+- reprise par checkpoint/command, historique, état et suppression ;
+- sélection par `ARCLITH_AGENT_RUNTIME=durable` dans l'entrypoint Docker généré ;
+- extra optionnel `arclith[langgraph-runtime]` et commande `arclith-agent-runtime` ;
+- documentation du contrat, des limites et des garde-fous Kubernetes.
+
+## Sécurité et exploitation
+
+Les URI restent exclusivement dans l'environnement runtime. Les erreurs SSE sont assainies. Le
+runtime expose `/ready`, borne son pool PostgreSQL, impose un seul run par thread et applique un
+timeout. PostgreSQL est la source durable ; Redis ne contient que des données de coordination à TTL.
+
+## Validation
+
+- tests unitaires du contrat HTTP/SSE, reprise, concurrence, annulation, catalogue et cycle de vie ;
+- lint Ruff, mypy, Bandit et seuil Radon ;
+- couverture projet supérieure ou égale à 90 % ;
+- build strict de la documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 Homepage = "https://github.com/karned-rekipe/arclith"
 Repository = "https://github.com/karned-rekipe/arclith"
 
+[project.scripts]
+arclith-agent-runtime = "arclith.adapters.inbound.langgraph_runtime.server:main"
+
 [project.optional-dependencies]
 mongodb = ["motor==3.7.1"]
 duckdb  = ["duckdb==1.5.0", "pytz==2024.1"]
@@ -46,6 +49,7 @@ cache   = ["redis>=5.0.0"]
 auth    = ["PyJWT[crypto]>=2.8.0", "httpx>=0.27.0"]
 rabbitmq = ["aio-pika>=10.0.1,<11.0.0"]
 langgraph = ["langgraph>=1.0.8", "langgraph-api>=0.11.0", "langgraph-cli[inmem]>=0.4.31", "pydantic-ai-slim[anthropic,openai]>=2.24.0,<3.0.0"]
+langgraph-runtime = ["langgraph>=1.0.8", "langgraph-checkpoint-postgres>=3.0.0,<4.0.0", "psycopg[binary,pool]>=3.2.0,<4.0.0", "redis>=5.0.0", "uvicorn==0.41.0"]
 langgraph-persistence-sqlite = ["langgraph-checkpoint-sqlite>=3.0.0,<4.0.0"]
 langgraph-persistence-postgresql = ["langgraph-checkpoint-postgres>=3.0.0,<4.0.0", "psycopg[binary,pool]>=3.2.0,<4.0.0"]
 langgraph-persistence-mongodb = ["langgraph-checkpoint-mongodb>=0.3.0,<1.0.0", "langgraph-store-mongodb>=0.2.0,<1.0.0"]

--- a/tests/integration/fixtures/langgraph-runtime.json
+++ b/tests/integration/fixtures/langgraph-runtime.json
@@ -1,0 +1,5 @@
+{
+  "graphs": {
+    "integration_agent": "./langgraph_runtime_graph.py:graph"
+  }
+}

--- a/tests/integration/fixtures/langgraph_runtime_graph.py
+++ b/tests/integration/fixtures/langgraph_runtime_graph.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+
+def _last_content(messages: list[BaseMessage]) -> str:
+    return str(messages[-1].content) if messages else ""
+
+
+async def respond(state: MessagesState) -> dict[str, Any]:
+    return {
+        "messages": [
+            AIMessage(content=f"Echo: {_last_content(state.get('messages', []))}")
+        ]
+    }
+
+
+builder = StateGraph(MessagesState)
+builder.add_node("respond", respond)
+builder.add_edge(START, "respond")
+builder.add_edge("respond", END)
+graph = builder.compile()

--- a/tests/integration/test_langgraph_runtime.py
+++ b/tests/integration/test_langgraph_runtime.py
@@ -78,4 +78,5 @@ def test_durable_runtime_resumes_after_complete_server_restart() -> None:
                 "success",
             ]
         finally:
-            assert second_server.delete(f"/threads/{thread_id}").status_code == 204
+            deleted = second_server.delete(f"/threads/{thread_id}")
+            assert deleted.status_code == 204

--- a/tests/integration/test_langgraph_runtime.py
+++ b/tests/integration/test_langgraph_runtime.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from arclith.adapters.inbound.langgraph_runtime.server import (
+    create_durable_langgraph_runtime_app,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (
+        os.getenv("ARCLITH_TEST_POSTGRESQL_URL") and os.getenv("ARCLITH_TEST_REDIS_URL")
+    ),
+    reason="ARCLITH_TEST_POSTGRESQL_URL et ARCLITH_TEST_REDIS_URL non configures",
+)
+
+CONFIG_PATH = Path(__file__).parent / "fixtures" / "langgraph-runtime.json"
+
+
+def _app():
+    return create_durable_langgraph_runtime_app(
+        CONFIG_PATH,
+        database_uri=os.environ["ARCLITH_TEST_POSTGRESQL_URL"],
+        redis_uri=os.environ["ARCLITH_TEST_REDIS_URL"],
+        redis_prefix="arclith:integration-runtime",
+    )
+
+
+def test_durable_runtime_resumes_after_complete_server_restart() -> None:
+    thread_id = str(uuid4())
+    with TestClient(_app()) as first_server:
+        created = first_server.post(
+            "/threads",
+            json={"thread_id": thread_id, "metadata": {"test": "integration"}},
+        )
+        assert created.status_code == 200
+        first_run = first_server.post(
+            f"/threads/{thread_id}/runs/wait",
+            json={
+                "assistant_id": "integration_agent",
+                "input": {"messages": [{"role": "user", "content": "premier"}]},
+            },
+        )
+        assert first_run.status_code == 200
+        assert first_run.json()["messages"][-1]["content"] == "Echo: premier"
+
+    with TestClient(_app()) as second_server:
+        try:
+            restored = second_server.get(f"/threads/{thread_id}/state")
+            assert restored.status_code == 200
+            assert restored.json()["values"]["messages"][-1]["content"] == (
+                "Echo: premier"
+            )
+
+            second_run = second_server.post(
+                f"/threads/{thread_id}/runs/wait",
+                json={
+                    "assistant_id": "integration_agent",
+                    "input": {"messages": [{"role": "user", "content": "suite"}]},
+                },
+            )
+            assert second_run.status_code == 200
+            assert second_run.json()["messages"][-1]["content"] == "Echo: suite"
+
+            history = second_server.post(
+                f"/threads/{thread_id}/history",
+                json={"limit": 100},
+            )
+            assert history.status_code == 200
+            assert len(history.json()) >= 4
+            runs = second_server.get(f"/threads/{thread_id}/runs")
+            assert [run["status"] for run in runs.json()] == [
+                "success",
+                "success",
+            ]
+        finally:
+            assert second_server.delete(f"/threads/{thread_id}").status_code == 204

--- a/tests/units/adapters/inbound/test_langgraph_runtime.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage, BaseMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.config import get_stream_writer
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from arclith.adapters.inbound.langgraph_runtime import (
+    InMemoryRunCoordinator,
+    InMemoryRuntimeCatalog,
+    LangGraphRuntime,
+    RunBusyError,
+    RunRequest,
+    create_langgraph_runtime_app,
+    load_graphs,
+)
+from arclith.adapters.inbound.langgraph_runtime.runtime import (
+    RunCancelledError,
+    _graph_config,
+    _run_input,
+    _stream_item,
+    _stream_modes,
+)
+
+THREAD_ID = "01993fb0-7a3d-71a0-9c20-d7abbd755180"
+
+
+def _graph(*, delay: float = 0, fail: bool = False) -> Any:
+    builder = StateGraph(MessagesState)
+
+    async def respond(state: MessagesState) -> dict[str, Any]:
+        if delay:
+            await asyncio.sleep(delay)
+        if fail:
+            raise ValueError("graph failed")
+        writer = get_stream_writer()
+        writer({"kind": "progress", "message": "working"})
+        content = _last_content(state.get("messages", []))
+        return {"messages": [AIMessage(content=f"Echo: {content}")]}
+
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    builder.add_edge("respond", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+def _last_content(messages: list[BaseMessage]) -> str:
+    return str(messages[-1].content) if messages else ""
+
+
+def _runtime(graph: Any | None = None) -> LangGraphRuntime:
+    return LangGraphRuntime(
+        {"test_agent": graph or _graph()},
+        InMemoryRuntimeCatalog(),
+        InMemoryRunCoordinator(),
+        cancel_poll_seconds=0.01,
+    )
+
+
+def test_runtime_validates_configuration_and_exposes_assistants() -> None:
+    with pytest.raises(ValueError, match="au moins un graphe"):
+        LangGraphRuntime({}, InMemoryRuntimeCatalog(), InMemoryRunCoordinator())
+    with pytest.raises(ValueError, match="run_timeout_seconds"):
+        LangGraphRuntime(
+            {"test": _graph()},
+            InMemoryRuntimeCatalog(),
+            InMemoryRunCoordinator(),
+            run_timeout_seconds=0,
+        )
+    with pytest.raises(ValueError, match="cancel_poll_seconds"):
+        LangGraphRuntime(
+            {"test": _graph()},
+            InMemoryRuntimeCatalog(),
+            InMemoryRunCoordinator(),
+            cancel_poll_seconds=0,
+        )
+
+    runtime = _runtime()
+    assert runtime.assistants()[0]["metadata"] == {"runtime": "arclith-open-source"}
+
+
+def test_http_runtime_exposes_thread_run_history_and_sse_contract() -> None:
+    runtime = _runtime()
+    client = TestClient(create_langgraph_runtime_app(runtime))
+
+    assert client.get("/info").status_code == 200
+    assert client.get("/ready").json() == {"status": "ready"}
+    assert client.post("/assistants/search", json={}).json()[0]["assistant_id"] == (
+        "test_agent"
+    )
+    assert client.get("/assistants/test_agent").status_code == 200
+    assert client.get("/assistants/missing").status_code == 404
+
+    created = client.post(
+        "/threads",
+        json={"thread_id": THREAD_ID, "metadata": {"tenant": "one"}},
+    )
+    assert created.status_code == 200
+    assert created.json()["thread_id"] == THREAD_ID
+    assert created.json()["status"] == "idle"
+    assert client.get(f"/threads/{THREAD_ID}").status_code == 200
+    assert (
+        client.post("/threads/search", json={"metadata": {"tenant": "one"}}).json()[0][
+            "thread_id"
+        ]
+        == THREAD_ID
+    )
+    assert client.get(f"/threads/{THREAD_ID}/state").json()["values"] == {}
+
+    waited = client.post(
+        f"/threads/{THREAD_ID}/runs/wait",
+        json={
+            "assistant_id": "test_agent",
+            "input": {"messages": [{"role": "user", "content": "bonjour"}]},
+        },
+    )
+    assert waited.status_code == 200
+    assert waited.json()["messages"][-1]["content"] == "Echo: bonjour"
+
+    history = client.post(f"/threads/{THREAD_ID}/history", json={"limit": 100})
+    assert history.status_code == 200
+    assert history.json()[0]["checkpoint"]["thread_id"] == THREAD_ID
+    assert history.json()[0]["values"]["messages"][-1]["content"] == "Echo: bonjour"
+    assert (
+        client.get(f"/threads/{THREAD_ID}/state").json()["values"]["messages"][-1][
+            "content"
+        ]
+        == "Echo: bonjour"
+    )
+
+    streamed = client.post(
+        f"/threads/{THREAD_ID}/runs/stream",
+        json={
+            "assistant_id": "test_agent",
+            "input": {"messages": [{"role": "user", "content": "suite"}]},
+            "stream_mode": ["values", "custom"],
+        },
+        headers={"Accept": "text/event-stream"},
+    )
+    assert streamed.status_code == 200
+    assert streamed.headers["content-type"].startswith("text/event-stream")
+    assert "event: metadata" in streamed.text
+    assert "event: custom" in streamed.text
+    assert "event: values" in streamed.text
+    assert "Echo: suite" in streamed.text
+
+    runs = client.get(f"/threads/{THREAD_ID}/runs").json()
+    assert [run["status"] for run in runs] == ["success", "success"]
+    run_id = runs[0]["run_id"]
+    assert client.get(f"/threads/{THREAD_ID}/runs/{run_id}").status_code == 200
+    assert client.post(f"/threads/{THREAD_ID}/runs/{run_id}/cancel").status_code == 204
+
+    deleted = client.delete(f"/threads/{THREAD_ID}")
+    assert deleted.status_code == 204
+    assert client.get(f"/threads/{THREAD_ID}").status_code == 404
+
+
+def test_http_runtime_maps_validation_conflicts_and_execution_errors() -> None:
+    runtime = _runtime(_graph(fail=True))
+    client = TestClient(
+        create_langgraph_runtime_app(runtime),
+        raise_server_exceptions=False,
+    )
+    client.post("/threads", json={"thread_id": THREAD_ID})
+
+    duplicate = client.post(
+        "/threads",
+        json={"thread_id": THREAD_ID, "if_exists": "raise"},
+    )
+    unknown = client.post(
+        "/threads/01993fb0-7a3d-71a0-9c20-d7abbd755181/runs/wait",
+        json={"assistant_id": "test_agent"},
+    )
+    missing_assistant = client.post(
+        f"/threads/{THREAD_ID}/runs/wait",
+        json={"assistant_id": "missing"},
+    )
+    failed = client.post(
+        f"/threads/{THREAD_ID}/runs/wait",
+        json={"assistant_id": "test_agent", "input": {"messages": []}},
+    )
+    unsupported_strategy = client.post(
+        f"/threads/{THREAD_ID}/runs/wait",
+        json={"assistant_id": "test_agent", "multitask_strategy": "enqueue"},
+    )
+
+    assert duplicate.status_code == 409
+    assert unknown.status_code == 404
+    assert missing_assistant.status_code == 404
+    assert failed.status_code == 500
+    assert unsupported_strategy.status_code == 422
+    assert client.get(f"/threads/{THREAD_ID}").json()["status"] == "error"
+
+
+def test_http_runtime_sanitizes_stream_errors_and_reports_storage_readiness() -> None:
+    runtime = _runtime(_graph(fail=True))
+    client = TestClient(create_langgraph_runtime_app(runtime))
+    client.post("/threads", json={"thread_id": THREAD_ID})
+
+    failed = client.post(
+        f"/threads/{THREAD_ID}/runs/stream",
+        json={
+            "assistant_id": "test_agent",
+            "input": {"messages": [{"role": "user", "content": "secret"}]},
+        },
+    )
+    assert failed.status_code == 200
+    assert "GraphExecutionError" in failed.text
+    assert "graph failed" not in failed.text
+    assert client.get(f"/threads/{THREAD_ID}").json()["status"] == "error"
+
+    class UnhealthyCoordinator(InMemoryRunCoordinator):
+        async def healthcheck(self) -> bool:
+            return False
+
+    unavailable = LangGraphRuntime(
+        {"test_agent": _graph()},
+        InMemoryRuntimeCatalog(),
+        UnhealthyCoordinator(),
+    )
+    unavailable_client = TestClient(create_langgraph_runtime_app(unavailable))
+    assert unavailable_client.get("/ready").status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_runtime_cancels_an_active_run_and_persists_status() -> None:
+    runtime = _runtime(_graph(delay=30))
+    await runtime.setup()
+    await runtime.create_thread(
+        thread_id=THREAD_ID,
+        metadata=None,
+        if_exists=None,
+    )
+    task = asyncio.create_task(
+        runtime.wait(
+            THREAD_ID,
+            RunRequest(
+                assistant_id="test_agent",
+                input={"messages": [{"role": "user", "content": "slow"}]},
+            ),
+        )
+    )
+    while not (
+        runs := await runtime.list_runs(
+            THREAD_ID,
+            status=None,
+            limit=10,
+            offset=0,
+        )
+    ):
+        await asyncio.sleep(0)
+
+    await runtime.cancel_run(THREAD_ID, runs[0].run_id)
+    with pytest.raises(RunCancelledError):
+        await task
+
+    stored = await runtime.get_run(THREAD_ID, runs[0].run_id)
+    assert stored.status == "interrupted"
+    assert (await runtime.get_thread(THREAD_ID)).status == "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_runtime_cancels_an_active_stream_with_sanitized_sse() -> None:
+    runtime = _runtime(_graph(delay=30))
+    await runtime.create_thread(
+        thread_id=THREAD_ID,
+        metadata=None,
+        if_exists=None,
+    )
+
+    async def consume() -> list[bytes]:
+        return [
+            chunk
+            async for chunk in runtime.stream(
+                THREAD_ID,
+                RunRequest(
+                    assistant_id="test_agent",
+                    input={"messages": [{"role": "user", "content": "slow"}]},
+                ),
+            )
+        ]
+
+    task = asyncio.create_task(consume())
+    while not (
+        runs := await runtime.list_runs(
+            THREAD_ID,
+            status=None,
+            limit=10,
+            offset=0,
+        )
+    ):
+        await asyncio.sleep(0)
+
+    await runtime.cancel_run(THREAD_ID, runs[0].run_id)
+    chunks = await task
+    assert b'"error":"RunCancelledError"' in b"".join(chunks)
+    assert (await runtime.get_run(THREAD_ID, runs[0].run_id)).status == ("interrupted")
+
+
+@pytest.mark.asyncio
+async def test_in_memory_coordinator_rejects_concurrent_thread_runs() -> None:
+    coordinator = InMemoryRunCoordinator()
+
+    async with coordinator.thread_lock(THREAD_ID, timeout_seconds=10):
+        with pytest.raises(RunBusyError):
+            async with coordinator.thread_lock(THREAD_ID, timeout_seconds=10):
+                pass
+
+    assert await coordinator.healthcheck() is True
+    await coordinator.close()
+
+
+@pytest.mark.asyncio
+async def test_busy_run_does_not_create_a_second_record_or_change_status() -> None:
+    runtime = _runtime(_graph(delay=30))
+    await runtime.create_thread(
+        thread_id=THREAD_ID,
+        metadata=None,
+        if_exists=None,
+    )
+    task = asyncio.create_task(
+        runtime.wait(
+            THREAD_ID,
+            RunRequest(
+                assistant_id="test_agent",
+                input={"messages": [{"role": "user", "content": "slow"}]},
+            ),
+        )
+    )
+    while not (
+        runs := await runtime.list_runs(
+            THREAD_ID,
+            status=None,
+            limit=10,
+            offset=0,
+        )
+    ):
+        await asyncio.sleep(0)
+
+    with pytest.raises(RunBusyError):
+        await runtime.wait(
+            THREAD_ID,
+            RunRequest(assistant_id="test_agent", input={"messages": []}),
+        )
+    busy_stream = b"".join(
+        [
+            chunk
+            async for chunk in runtime.stream(
+                THREAD_ID,
+                RunRequest(assistant_id="test_agent", input={"messages": []}),
+            )
+        ]
+    )
+    assert b'"error":"RunBusyError"' in busy_stream
+    assert (
+        len(
+            await runtime.list_runs(
+                THREAD_ID,
+                status=None,
+                limit=10,
+                offset=0,
+            )
+        )
+        == 1
+    )
+    assert (await runtime.get_thread(THREAD_ID)).status == "busy"
+
+    await runtime.cancel_run(THREAD_ID, runs[0].run_id)
+    with pytest.raises(RunCancelledError):
+        await task
+
+
+def test_runtime_request_helpers_preserve_resume_and_stream_contract() -> None:
+    request = RunRequest(
+        assistant_id="test",
+        input={"ignored": True},
+        command={"resume": "approved"},
+        config={"configurable": {"tenant": "one"}},
+        checkpoint={"checkpoint_id": "checkpoint", "checkpoint_ns": "namespace"},
+    )
+    command = _run_input(request)
+    assert command.resume == "approved"
+    assert _graph_config(THREAD_ID, request)["configurable"] == {
+        "tenant": "one",
+        "thread_id": THREAD_ID,
+        "checkpoint_id": "checkpoint",
+        "checkpoint_ns": "namespace",
+    }
+    assert _graph_config(THREAD_ID, None) == {"configurable": {"thread_id": THREAD_ID}}
+    assert _stream_modes(None) == ["values"]
+    assert _stream_modes(["messages-tuple", "custom", "custom"]) == [
+        "messages",
+        "custom",
+    ]
+    assert _stream_item(("custom", {"value": 1}), ["values", "custom"]) == (
+        "custom",
+        {"value": 1},
+    )
+    assert _stream_item({"value": 1}, ["values"]) == (
+        "values",
+        {"value": 1},
+    )
+
+
+def test_load_graphs_supports_src_entrypoints_and_rejects_invalid_contract(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    package = tmp_path / "src" / "demo_runtime"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "graph.py").write_text(
+        """
+class Graph:
+    async def ainvoke(self, value, config):
+        return value
+    async def astream(self, value, config, **kwargs):
+        if False:
+            yield value
+graph = Graph()
+bad = object()
+""",
+        encoding="utf-8",
+    )
+    config = tmp_path / "langgraph.json"
+    config.write_text(
+        json.dumps({"graphs": {"demo": "./src/demo_runtime/graph.py:graph"}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("ARCLITH_LANGGRAPH_PERSISTENCE_MODE", "embedded")
+    assert list(load_graphs(config)) == ["demo"]
+    assert os.environ["ARCLITH_LANGGRAPH_PERSISTENCE_MODE"] == "agent_server"
+
+    config.write_text(
+        json.dumps({"graphs": {"demo": "./src/demo_runtime/graph.py:bad"}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(TypeError, match="ainvoke"):
+        load_graphs(config)
+
+    config.write_text(json.dumps({"graphs": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="au moins un graphe"):
+        load_graphs(config)
+
+
+def test_load_graphs_supports_module_entrypoints_and_rejects_bad_configs(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    import sys
+
+    module = tmp_path / "runtime_module.py"
+    module.write_text(
+        """
+class Graph:
+    async def ainvoke(self, value, config):
+        return value
+    async def astream(self, value, config, **kwargs):
+        if False:
+            yield value
+graph = Graph()
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    config = tmp_path / "module.json"
+    config.write_text(
+        json.dumps({"graphs": {"module": "runtime_module:graph"}}),
+        encoding="utf-8",
+    )
+    assert list(load_graphs(config)) == ["module"]
+    sys.modules.pop("runtime_module", None)
+
+    invalid_payloads = [
+        {},
+        {"graphs": {"": "runtime_module:graph"}},
+        {"graphs": {"demo": 42}},
+        {"graphs": {"demo": "missing_separator"}},
+        {"graphs": {"demo": "runtime_module:missing"}},
+        {"graphs": {"demo": "./missing.py:graph"}},
+    ]
+    for index, payload in enumerate(invalid_payloads):
+        path = tmp_path / f"invalid-{index}.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises((ValueError, AttributeError, FileNotFoundError)):
+            load_graphs(path)

--- a/tests/units/adapters/inbound/test_langgraph_runtime.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime.py
@@ -319,6 +319,36 @@ async def test_in_memory_coordinator_rejects_concurrent_thread_runs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_state_and_history_use_the_graph_from_the_latest_run() -> None:
+    first_graph = _graph()
+    second_graph = _graph()
+    runtime = LangGraphRuntime(
+        {"first": first_graph, "second": second_graph},
+        InMemoryRuntimeCatalog(),
+        InMemoryRunCoordinator(),
+        cancel_poll_seconds=0.01,
+    )
+    await runtime.create_thread(
+        thread_id=THREAD_ID,
+        metadata=None,
+        if_exists=None,
+    )
+    await runtime.wait(
+        THREAD_ID,
+        RunRequest(
+            assistant_id="second",
+            input={"messages": [{"role": "user", "content": "second graph"}]},
+        ),
+    )
+
+    state = await runtime.state(THREAD_ID)
+    history = await runtime.history(THREAD_ID, limit=10)
+    assert state["values"]["messages"][-1]["content"] == "Echo: second graph"
+    assert history[0]["values"]["messages"][-1]["content"] == ("Echo: second graph")
+    assert (await first_graph.aget_state(_graph_config(THREAD_ID, None))).values == {}
+
+
+@pytest.mark.asyncio
 async def test_busy_run_does_not_create_a_second_record_or_change_status() -> None:
     runtime = _runtime(_graph(delay=30))
     await runtime.create_thread(

--- a/tests/units/adapters/inbound/test_langgraph_runtime_catalog.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_catalog.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from arclith.adapters.inbound.langgraph_runtime.catalog import (
+    PostgresRuntimeCatalog,
+    RunRecord,
+    ThreadAlreadyExistsError,
+)
+
+THREAD_ID = "01993fb0-7a3d-71a0-9c20-d7abbd755180"
+RUN_ID = "01993fb0-7a3d-71a0-9c20-d7abbd755181"
+NOW = datetime(2026, 8, 28, tzinfo=UTC)
+
+
+class FakeCursor:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+
+    async def fetchone(self) -> Any:
+        return self.response
+
+    async def fetchall(self) -> list[Any]:
+        return list(self.response or [])
+
+
+class FakeConnection:
+    def __init__(
+        self, responses: list[Any], *, failure: Exception | None = None
+    ) -> None:
+        self.responses = responses
+        self.failure = failure
+        self.executions: list[tuple[str, Any]] = []
+
+    async def execute(self, statement: str, parameters: Any = None) -> FakeCursor:
+        self.executions.append((" ".join(statement.split()), parameters))
+        if self.failure is not None:
+            raise self.failure
+        response = self.responses.pop(0) if self.responses else None
+        return FakeCursor(response)
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator[None]:
+        yield
+
+
+class FakePool:
+    def __init__(self, *responses: Any, failure: Exception | None = None) -> None:
+        self.connection_instance = FakeConnection(list(responses), failure=failure)
+
+    @asynccontextmanager
+    async def connection(self) -> AsyncIterator[FakeConnection]:
+        yield self.connection_instance
+
+
+def _thread_row(*, status: str = "idle") -> dict[str, Any]:
+    return {
+        "thread_id": THREAD_ID,
+        "status": status,
+        "metadata": {"tenant": "one"},
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+
+
+def _run_row(*, status: str = "running", error: Any = None) -> dict[str, Any]:
+    return {
+        "run_id": RUN_ID,
+        "thread_id": THREAD_ID,
+        "assistant_id": "assistant",
+        "status": status,
+        "input": {"value": 1},
+        "output": {"value": 2} if status == "success" else None,
+        "error": error,
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+
+
+@pytest.mark.asyncio
+async def test_postgres_catalog_sets_up_and_reports_health() -> None:
+    pool = FakePool(
+        None,
+        None,
+        None,
+        {
+            "thread_table": "arclith_langgraph_thread",
+            "run_table": "arclith_langgraph_run",
+            "checkpoint_table": "checkpoints",
+            "store_table": "store",
+        },
+    )
+    catalog = PostgresRuntimeCatalog(pool)
+
+    await catalog.setup()
+    assert await catalog.healthcheck() is True
+    assert len(pool.connection_instance.executions) == 4
+    assert (
+        "CREATE TABLE IF NOT EXISTS arclith_langgraph_thread"
+        in (pool.connection_instance.executions[0][0])
+    )
+
+    assert (
+        await PostgresRuntimeCatalog(
+            FakePool(failure=ConnectionError("database unavailable"))
+        ).healthcheck()
+        is False
+    )
+    assert await PostgresRuntimeCatalog(FakePool(None)).healthcheck() is False
+
+
+@pytest.mark.asyncio
+async def test_postgres_catalog_manages_threads_and_filters() -> None:
+    pool = FakePool(
+        _thread_row(),
+        _thread_row(),
+        [_thread_row()],
+        None,
+        None,
+        None,
+    )
+    catalog = PostgresRuntimeCatalog(pool)
+
+    created = await catalog.create_thread(THREAD_ID, {"tenant": "one"})
+    fetched = await catalog.get_thread(THREAD_ID)
+    searched = await catalog.search_threads(
+        metadata={"tenant": "one"},
+        status="idle",
+        limit=20,
+        offset=1,
+    )
+    await catalog.set_thread_status(THREAD_ID, "busy")
+    await catalog.delete_thread(THREAD_ID)
+
+    assert created.thread_id == THREAD_ID
+    assert fetched is not None and fetched.metadata == {"tenant": "one"}
+    assert searched == [created]
+    search_parameters = pool.connection_instance.executions[2][1]
+    assert search_parameters == (
+        "idle",
+        "idle",
+        '{"tenant": "one"}',
+        '{"tenant": "one"}',
+        20,
+        1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_catalog_handles_thread_conflicts() -> None:
+    catalog = PostgresRuntimeCatalog(FakePool(None))
+    with pytest.raises(ThreadAlreadyExistsError):
+        await catalog.create_thread(
+            THREAD_ID,
+            {},
+            if_exists="raise",
+        )
+
+    existing = await PostgresRuntimeCatalog(
+        FakePool(None, _thread_row())
+    ).create_thread(THREAD_ID, {}, if_exists="do_nothing")
+    assert existing.thread_id == THREAD_ID
+
+    with pytest.raises(RuntimeError, match="did not return"):
+        await PostgresRuntimeCatalog(FakePool(None, None)).create_thread(
+            THREAD_ID,
+            {},
+        )
+
+
+@pytest.mark.asyncio
+async def test_postgres_catalog_manages_runs_and_statuses() -> None:
+    pool = FakePool(
+        _run_row(),
+        None,
+        _run_row(status="success"),
+        None,
+        _run_row(status="success"),
+        [_run_row(status="success")],
+    )
+    catalog = PostgresRuntimeCatalog(pool)
+    original = RunRecord(
+        run_id=RUN_ID,
+        thread_id=THREAD_ID,
+        assistant_id="assistant",
+        status="running",
+        input={"value": 1},
+    )
+
+    created = await catalog.create_run(original)
+    finished = await catalog.finish_run(
+        RUN_ID,
+        status="success",
+        output={"value": 2},
+    )
+    fetched = await catalog.get_run(THREAD_ID, RUN_ID)
+    listed = await catalog.list_runs(
+        THREAD_ID,
+        status="success",
+        limit=10,
+        offset=0,
+    )
+
+    assert created.status == "running"
+    assert finished is not None and finished.output == {"value": 2}
+    assert fetched is not None and fetched.as_api_dict()["run_id"] == RUN_ID
+    assert listed[0].status == "success"
+    assert pool.connection_instance.executions[-1][1] == (
+        THREAD_ID,
+        "success",
+        "success",
+        10,
+        0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_catalog_handles_missing_runs_and_unfiltered_lists() -> None:
+    missing_create = PostgresRuntimeCatalog(FakePool(None))
+    with pytest.raises(RuntimeError, match="Run creation"):
+        await missing_create.create_run(
+            RunRecord(
+                run_id=RUN_ID,
+                thread_id=THREAD_ID,
+                assistant_id="assistant",
+                status="running",
+            )
+        )
+
+    catalog = PostgresRuntimeCatalog(FakePool(None, None, []))
+    assert await catalog.finish_run(RUN_ID, status="error") is None
+    assert await catalog.get_run(THREAD_ID, RUN_ID) is None
+    assert (
+        await catalog.list_runs(
+            THREAD_ID,
+            status=None,
+            limit=10,
+            offset=0,
+        )
+        == []
+    )

--- a/tests/units/adapters/inbound/test_langgraph_runtime_coordination.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_coordination.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from arclith.adapters.inbound.langgraph_runtime.coordination import (
+    RedisRunCoordinator,
+    RunBusyError,
+)
+
+
+class FakeLock:
+    def __init__(self, acquired: bool, *, extendable: bool = True) -> None:
+        self.acquired = acquired
+        self.extendable = extendable
+        self.released = False
+        self.extended = 0
+
+    async def acquire(self, *, blocking: bool) -> bool:
+        assert blocking is False
+        return self.acquired
+
+    async def release(self) -> None:
+        self.released = True
+
+    async def extend(self, _seconds: float, *, replace_ttl: bool) -> bool:
+        assert replace_ttl is True
+        self.extended += 1
+        return self.extendable
+
+
+class FakeRedis:
+    def __init__(
+        self,
+        *,
+        acquired: bool = True,
+        healthy: bool = True,
+        extendable: bool = True,
+    ) -> None:
+        self.acquired = acquired
+        self.healthy = healthy
+        self.extendable = extendable
+        self.values: dict[str, str] = {}
+        self.closed = False
+        self.last_lock: FakeLock | None = None
+
+    def lock(self, _name: str, **options: Any) -> FakeLock:
+        assert options["blocking_timeout"] == 0
+        self.last_lock = FakeLock(self.acquired, extendable=self.extendable)
+        return self.last_lock
+
+    async def set(self, key: str, value: str, *, ex: int) -> None:
+        assert ex == 3600
+        self.values[key] = value
+
+    async def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    async def delete(self, key: str) -> None:
+        self.values.pop(key, None)
+
+    async def ping(self) -> bool:
+        return self.healthy
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_redis_coordinator_locks_cancels_and_closes() -> None:
+    client = FakeRedis()
+    coordinator = RedisRunCoordinator(client, prefix="demo", lease_seconds=0.03)
+
+    async with coordinator.thread_lock("thread", timeout_seconds=42):
+        assert client.last_lock is not None
+        assert client.last_lock.released is False
+        await asyncio.sleep(0.02)
+    assert client.last_lock.released is True
+    assert client.last_lock.extended >= 1
+
+    await coordinator.request_cancel("run")
+    assert await coordinator.is_cancelled("run") is True
+    await coordinator.clear_cancel("run")
+    assert await coordinator.is_cancelled("run") is False
+    assert await coordinator.healthcheck() is True
+    await coordinator.close()
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_redis_coordinator_rejects_busy_thread() -> None:
+    coordinator = RedisRunCoordinator(FakeRedis(acquired=False))
+
+    with pytest.raises(RunBusyError):
+        async with coordinator.thread_lock("thread", timeout_seconds=42):
+            pass
+
+
+def test_redis_coordinator_rejects_invalid_lease() -> None:
+    with pytest.raises(ValueError, match="lease_seconds"):
+        RedisRunCoordinator(FakeRedis(), lease_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_redis_coordinator_cancels_owner_when_lease_is_lost() -> None:
+    coordinator = RedisRunCoordinator(
+        FakeRedis(extendable=False),
+        lease_seconds=0.03,
+    )
+
+    async def hold_lock() -> None:
+        async with coordinator.thread_lock("thread", timeout_seconds=42):
+            await asyncio.sleep(1)
+
+    task = asyncio.create_task(hold_lock())
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/units/adapters/inbound/test_langgraph_runtime_server.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_server.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from arclith.adapters.inbound.langgraph_runtime import server
+from arclith.adapters.inbound.langgraph_runtime.catalog import InMemoryRuntimeCatalog
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.opened = False
+        self.closed = False
+
+    async def open(self) -> None:
+        self.opened = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeRedis:
+    def __init__(self, *, healthy: bool = True) -> None:
+        self.healthy = healthy
+        self.closed = False
+
+    async def ping(self) -> bool:
+        return self.healthy
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FakeGraph:
+    checkpointer: Any = None
+    store: Any = None
+
+    async def ainvoke(self, value: Any, config: Any) -> Any:
+        return value
+
+    async def astream(self, value: Any, config: Any, **kwargs: Any) -> Any:
+        if False:
+            yield value
+
+
+class FakePersistence:
+    def __init__(self) -> None:
+        self.setup_called = False
+
+    async def setup(self) -> None:
+        self.setup_called = True
+
+
+@pytest.mark.asyncio
+async def test_build_persistence_sets_up_saver_and_store(monkeypatch: Any) -> None:
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from langgraph.store.postgres.aio import AsyncPostgresStore
+
+    saver = FakePersistence()
+    store = FakePersistence()
+
+    monkeypatch.setattr(
+        server,
+        "AsyncPostgresSaver",
+        AsyncPostgresSaver,
+        raising=False,
+    )
+    monkeypatch.setattr(AsyncPostgresSaver, "__new__", lambda _cls, _pool: saver)
+    monkeypatch.setattr(AsyncPostgresStore, "__new__", lambda _cls, _pool: store)
+
+    resolved = await server._build_langgraph_persistence(object(), setup=True)
+
+    assert resolved == (saver, store)
+    assert saver.setup_called is True
+    assert store.setup_called is True
+
+    saver.setup_called = False
+    store.setup_called = False
+    assert await server._build_langgraph_persistence(object(), setup=False) == (
+        saver,
+        store,
+    )
+    assert saver.setup_called is False
+    assert store.setup_called is False
+
+
+def test_create_durable_app_owns_resources_and_attaches_persistence(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    pool = FakePool()
+    redis = FakeRedis()
+    graph = FakeGraph()
+    saver = FakePersistence()
+    store = FakePersistence()
+
+    async def build_persistence(_pool: Any, *, setup: bool) -> tuple[Any, Any]:
+        assert setup is True
+        return saver, store
+
+    monkeypatch.setattr(server, "load_graphs", lambda _path: {"demo": graph})
+    monkeypatch.setattr(
+        server,
+        "_postgres_catalog",
+        lambda _uri: (pool, InMemoryRuntimeCatalog()),
+    )
+    monkeypatch.setattr(server, "_redis_client", lambda _uri: redis)
+    monkeypatch.setattr(server, "_build_langgraph_persistence", build_persistence)
+
+    app = server.create_durable_langgraph_runtime_app(
+        tmp_path / "langgraph.json",
+        database_uri="postgresql://database/runtime",
+        redis_uri="redis://cache/1",
+        redis_prefix="demo",
+        run_timeout_seconds=42,
+    )
+    with TestClient(app) as client:
+        assert client.get("/ready").json() == {"status": "ready"}
+        assert graph.checkpointer is saver
+        assert graph.store is store
+        assert pool.opened is True
+
+    assert pool.closed is True
+    assert redis.closed is True
+
+
+def test_create_durable_app_rejects_unhealthy_redis(
+    monkeypatch: Any,
+) -> None:
+    pool = FakePool()
+    redis = FakeRedis(healthy=False)
+    graph = FakeGraph()
+
+    async def build_persistence(_pool: Any, *, setup: bool) -> tuple[Any, Any]:
+        assert setup is True
+        return FakePersistence(), FakePersistence()
+
+    monkeypatch.setattr(server, "load_graphs", lambda _path: {"demo": graph})
+    monkeypatch.setattr(
+        server,
+        "_postgres_catalog",
+        lambda _uri: (pool, InMemoryRuntimeCatalog()),
+    )
+    monkeypatch.setattr(server, "_redis_client", lambda _uri: redis)
+    monkeypatch.setattr(server, "_build_langgraph_persistence", build_persistence)
+
+    app = server.create_durable_langgraph_runtime_app(
+        database_uri="postgresql://database/runtime",
+        redis_uri="redis://cache/1",
+    )
+    with pytest.raises(RuntimeError, match="Redis coordination"):
+        with TestClient(app):
+            pass
+    assert pool.closed is True
+    assert redis.closed is True
+
+
+def test_server_configuration_helpers(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("POSTGRESQL_URL", raising=False)
+    with pytest.raises(RuntimeError, match="DATABASE_URI"):
+        server._required_uri(
+            None,
+            primary_env="DATABASE_URI",
+            fallback_env="POSTGRESQL_URL",
+        )
+
+    monkeypatch.setenv("DATABASE_URI", "postgresql+psycopg://host/database")
+    assert (
+        server._required_uri(
+            None,
+            primary_env="DATABASE_URI",
+            fallback_env="POSTGRESQL_URL",
+        )
+        == "postgresql://host/database"
+    )
+    assert (
+        server._normalize_postgresql_scheme("postgresql+asyncpg://host/database")
+        == "postgresql://host/database"
+    )
+    assert server._normalize_postgresql_scheme("redis://host/1") == "redis://host/1"
+
+    monkeypatch.delenv("RUNTIME_TEST_NUMBER", raising=False)
+    assert server._positive_int_env("RUNTIME_TEST_NUMBER", 7) == 7
+    monkeypatch.setenv("RUNTIME_TEST_NUMBER", "8")
+    assert server._positive_int_env("RUNTIME_TEST_NUMBER", 7) == 8
+    monkeypatch.setenv("RUNTIME_TEST_NUMBER", "0")
+    with pytest.raises(ValueError, match="strictement positif"):
+        server._positive_int_env("RUNTIME_TEST_NUMBER", 7)
+
+    monkeypatch.delenv("RUNTIME_TEST_BOOLEAN", raising=False)
+    assert server._boolean_env("RUNTIME_TEST_BOOLEAN", True) is True
+    for value in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("RUNTIME_TEST_BOOLEAN", value)
+        assert server._boolean_env("RUNTIME_TEST_BOOLEAN", False) is True
+    for value in ("0", "false", "NO", "off"):
+        monkeypatch.setenv("RUNTIME_TEST_BOOLEAN", value)
+        assert server._boolean_env("RUNTIME_TEST_BOOLEAN", True) is False
+    monkeypatch.setenv("RUNTIME_TEST_BOOLEAN", "invalid")
+    with pytest.raises(ValueError, match="booleen"):
+        server._boolean_env("RUNTIME_TEST_BOOLEAN", True)
+
+
+def test_server_builders_and_main(monkeypatch: Any) -> None:
+    pool, catalog = server._postgres_catalog("postgresql://host/database")
+    assert catalog is not None
+    assert pool.closed is True
+
+    redis = server._redis_client("redis://host/1")
+    assert redis.connection_pool.connection_kwargs["db"] == 1
+
+    graph = FakeGraph()
+    saver = FakePersistence()
+    store = FakePersistence()
+    server._attach_persistence([graph], saver=saver, store=store)
+    assert graph.checkpointer is saver
+    assert graph.store is store
+
+    app = FastAPI()
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        server,
+        "create_durable_langgraph_runtime_app",
+        lambda config: app,
+    )
+
+    def run(received_app: Any, **options: Any) -> None:
+        captured.update({"app": received_app, **options})
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", run)
+    server.main(
+        [
+            "--config",
+            "runtime.json",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "2124",
+            "--graceful-timeout",
+            "45",
+        ]
+    )
+    assert captured["app"] is app
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 2124
+    assert captured["timeout_graceful_shutdown"] == 45

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,13 @@ langgraph-persistence-redis = [
 langgraph-persistence-sqlite = [
     { name = "langgraph-checkpoint-sqlite" },
 ]
+langgraph-runtime = [
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "redis" },
+    { name = "uvicorn" },
+]
 langsmith = [
     { name = "langsmith", extra = ["otel"] },
 ]
@@ -276,12 +283,14 @@ requires-dist = [
     { name = "hvac", marker = "extra == 'vault'", specifier = "==2.3.0" },
     { name = "langgraph", marker = "extra == 'all'", specifier = ">=1.0.8" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.8" },
+    { name = "langgraph", marker = "extra == 'langgraph-runtime'", specifier = ">=1.0.8" },
     { name = "langgraph-api", marker = "extra == 'all'", specifier = ">=0.11.0" },
     { name = "langgraph-api", marker = "extra == 'langgraph'", specifier = ">=0.11.0" },
     { name = "langgraph-checkpoint-mongodb", marker = "extra == 'all'", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph-checkpoint-mongodb", marker = "extra == 'langgraph-persistence-mongodb'", specifier = ">=0.3.0,<1.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.0.0,<4.0.0" },
+    { name = "langgraph-checkpoint-postgres", marker = "extra == 'langgraph-runtime'", specifier = ">=3.0.0,<4.0.0" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'all'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-checkpoint-redis", marker = "extra == 'langgraph-persistence-redis'", specifier = ">=0.2.0,<1.0.0" },
     { name = "langgraph-checkpoint-sqlite", marker = "extra == 'all'", specifier = ">=3.0.0,<4.0.0" },
@@ -307,6 +316,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.30.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'all'", specifier = ">=3.2.0,<4.0.0" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-persistence-postgresql'", specifier = ">=3.2.0,<4.0.0" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'langgraph-runtime'", specifier = ">=3.2.0,<4.0.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'all'", specifier = ">=2.24.0,<3.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'langgraph'", specifier = ">=2.24.0,<3.0.0" },
@@ -317,14 +327,16 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "redis", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
+    { name = "redis", marker = "extra == 'langgraph-runtime'", specifier = ">=5.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'all'", specifier = ">=2.0.36" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'mariadb'", specifier = ">=2.0.36" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'postgresql'", specifier = ">=2.0.36" },
     { name = "uuid6", specifier = "==2025.0.1" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
+    { name = "uvicorn", marker = "extra == 'langgraph-runtime'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "rabbitmq", "langgraph", "langgraph-runtime", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Contexte

Closes #187. `langgraph dev` conserve les threads en mémoire, tandis que Jarvis doit reprendre ses conversations et checkpoints après recréation des pods sans dépendre d'une licence LangGraph Cloud.

## Changements

- ajoute `arclith-agent-runtime`, un serveur FastAPI open source chargé depuis `langgraph.json` ;
- expose assistants, threads, state/history et runs wait/stream/list/get/cancel avec SSE `metadata`, `values`, `custom` et `messages` ;
- utilise `AsyncPostgresSaver` et `AsyncPostgresStore` sur un pool partagé, plus un catalogue PostgreSQL transactionnel des threads/runs ;
- utilise Redis uniquement pour les verrous renouvelés par thread et les signaux d'annulation à TTL ;
- conserve `langgraph dev` par défaut et active le runtime durable avec `ARCLITH_AGENT_RUNTIME=durable` ;
- ajoute l'extra optionnel `arclith[langgraph-runtime]`, les probes et le contrôle `ARCLITH_LANGGRAPH_AUTO_SETUP`.

## Impact

- API : nouveau sous-ensemble HTTP/SSE compatible avec les usages Gateway/SDK de Jarvis ; aucune route existante modifiée.
- Domaine : aucun import LangGraph/PostgreSQL/Redis ajouté au domaine.
- Données : nouvelles tables LangGraph officielles et tables `arclith_langgraph_thread` / `arclith_langgraph_run` dans une base dédiée au runtime.
- Configuration : nouvelles URI runtime `DATABASE_URI`/`REDIS_URI` et réglages `ARCLITH_LANGGRAPH_*`; aucun secret versionné.
- RabbitMQ/MCP/ports : aucun changement ; le port agent reste 2024.
- Release : commit `feat`, donc release Arclith attendue via semantic-release.

## Validation

- `make quality` : 729 tests passés, 4 intégrations optionnelles ignorées, couverture 91,12 %, Ruff, Bandit, Radon et mypy conformes ;
- `make test` dans `cli/` : 119 tests passés, 1 ignoré ;
- `uv run --frozen --group docs mkdocs build --strict` ;
- build wheel/sdist et installation isolée de `arclith[langgraph-runtime]` depuis `site-packages` ;
- intégration réelle PostgreSQL 17 + Redis 8 : création, premier run, arrêt complet du serveur, reprise du même checkpoint, second run, historique, suppression ; catalogue, checkpoints et Redis vérifiés à zéro après nettoyage.

## Documentation et déploiement

- ADR-015, capability Agent Persistence, runtime Docker, quickstart et journal ajoutés/mis à jour ;
- PostgreSQL est la source durable sauvegardable, Redis reste reconstructible ;
- en production, prévoir une base ou un schéma et un préfixe Redis isolés par agent, des NetworkPolicies, puis désactiver l'auto-setup après initialisation si le rôle runtime ne doit pas conserver les droits DDL.

## Risques restants

La surface est volontairement limitée aux usages Jarvis : crons, webhooks, revisions/déploiements d'assistants, plateforme LangSmith et stratégies de double-texting autres que `reject` ne sont pas implémentés.
