### PR TITLE
fix: reject unknown configuration keys

### DIFF
--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -137,6 +137,12 @@ def _resolve_secrets(data: dict, base_path: Path) -> dict:
     return resolve_dict_secrets(data, resolver)
 
 
+def _prepare_config(data: dict, base_path: Path) -> dict:
+    """Resolve loader directives and return only AppConfig input fields."""
+    resolved = _resolve_secrets(data, base_path)
+    return {key: value for key, value in resolved.items() if key != "secrets"}
+
+
 # ── Public loaders ────────────────────────────────────────────────────────────
 
 
@@ -150,7 +156,7 @@ def load_config_dir(path: Path) -> AppConfig:
     if not path.is_dir():
         raise ValueError(f"Expected a config directory, got: {path}")
 
-    merged = _resolve_secrets(_build_merged_dict(path), path.parent)
+    merged = _prepare_config(_build_merged_dict(path), path.parent)
     return AppConfig.model_validate(merged)
 
 
@@ -167,7 +173,7 @@ def load_config_file(path: Path) -> AppConfig:
     with open(path) as f:
         data = yaml.safe_load(f) or {}
 
-    data = _resolve_secrets(data, path.parent)
+    data = _prepare_config(data, path.parent)
     return AppConfig.model_validate(data)
 
 

--- a/arclith/infrastructure/settings/_base.py
+++ b/arclith/infrastructure/settings/_base.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class SettingsModel(BaseModel):
+    """Base model for configuration sections loaded from YAML."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/arclith/infrastructure/settings/app.py
+++ b/arclith/infrastructure/settings/app.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 from arclith.infrastructure.settings.langgraph import LangGraphSettings
 from arclith.infrastructure.settings.langsmith import LangSmithSettings
@@ -33,7 +35,7 @@ _OBSERVABILITY_CONFIG_SECTIONS: dict[ObservabilityAdapter, str] = {
 }
 
 
-class SoftDeleteSettings(BaseModel):
+class SoftDeleteSettings(SettingsModel):
     retention_days: float | None = None
 
     @field_validator("retention_days")
@@ -44,7 +46,7 @@ class SoftDeleteSettings(BaseModel):
         return v
 
 
-class AdaptersSettings(BaseModel):
+class AdaptersSettings(SettingsModel):
     logger: str = "console"
     repository: str = "memory"
     observability: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
@@ -128,24 +130,24 @@ class AdaptersSettings(BaseModel):
             )
 
 
-class ApiSettings(BaseModel):
+class ApiSettings(SettingsModel):
     host: str = "0.0.0.0"  # nosec B104
     port: int = 8000
     reload: bool = True
 
 
-class McpSettings(BaseModel):
+class McpSettings(SettingsModel):
     host: str = "127.0.0.1"
     port: int = 8001
 
 
-class ProbeSettings(BaseModel):
+class ProbeSettings(SettingsModel):
     host: str = "0.0.0.0"  # nosec B104
     port: int = 9000
     enabled: bool = True
 
 
-class KeycloakSettings(BaseModel):
+class KeycloakSettings(SettingsModel):
     url: str
     realm: str
     audience: str | None = None
@@ -154,18 +156,18 @@ class KeycloakSettings(BaseModel):
     )
 
 
-class TenantSettings(BaseModel):
+class TenantSettings(SettingsModel):
     vault_addr: str = "http://127.0.0.1:8200"
     vault_mount: str = "kv"
     vault_path_prefix: str
     tenant_claim: str = "sub"
 
 
-class LicenseSettings(BaseModel):
+class LicenseSettings(SettingsModel):
     role: str = "rekipe:licensed"
 
 
-class CacheSettings(BaseModel):
+class CacheSettings(SettingsModel):
     backend: Literal["memory", "redis"] = "memory"
     redis_url: str = "redis://127.0.0.1:6379"
     jwks_ttl: int = 3600
@@ -175,7 +177,7 @@ class CacheSettings(BaseModel):
 CommandBusAdapter = Literal["rabbitmq"]
 
 
-class RabbitMQCommandBusSettings(BaseModel):
+class RabbitMQCommandBusSettings(SettingsModel):
     url: str = "amqp://guest:guest@127.0.0.1:5672/"
     exchange: str = "arclith.commands"
     exchange_type: Literal["direct", "topic"] = "topic"
@@ -216,7 +218,7 @@ class RabbitMQCommandBusSettings(BaseModel):
         return v
 
 
-class CommandBusSettings(BaseModel):
+class CommandBusSettings(SettingsModel):
     enabled: list[CommandBusAdapter] = Field(default_factory=list)
     rabbitmq: RabbitMQCommandBusSettings = RabbitMQCommandBusSettings()
 
@@ -233,17 +235,17 @@ class CommandBusSettings(BaseModel):
         return adapter in self.enabled
 
 
-class IdempotencySettings(BaseModel):
+class IdempotencySettings(SettingsModel):
     enabled: bool = True
     ttl_seconds: int = 86400  # 24 hours
     required: bool = False  # If True, reject POST without Idempotency-Key
 
 
-class ETagSettings(BaseModel):
+class ETagSettings(SettingsModel):
     enabled: bool = True
 
 
-class CacheControlSettings(BaseModel):
+class CacheControlSettings(SettingsModel):
     get_single_max_age: int = 300  # 5 minutes
     get_list_max_age: int = 60  # 1 minute
 
@@ -255,19 +257,19 @@ class CacheControlSettings(BaseModel):
         return v
 
 
-class HttpSettings(BaseModel):
+class HttpSettings(SettingsModel):
     idempotency: IdempotencySettings = IdempotencySettings()
     etag: ETagSettings = ETagSettings()
     cache_control: CacheControlSettings = CacheControlSettings()
 
 
-class AppSettings(BaseModel):
+class AppSettings(SettingsModel):
     name: str = "arclith-service"
     version: str = "0.0.0"
     description: str = "API service built with arclith framework"
 
 
-class AppConfig(BaseModel):
+class AppConfig(SettingsModel):
     app: AppSettings = AppSettings()
     adapters: AdaptersSettings = AdaptersSettings()
     soft_delete: SoftDeleteSettings = SoftDeleteSettings()

--- a/arclith/infrastructure/settings/langgraph.py
+++ b/arclith/infrastructure/settings/langgraph.py
@@ -4,12 +4,12 @@ from typing import Annotated, Literal
 
 from pydantic import (
     AfterValidator,
-    BaseModel,
-    ConfigDict,
     Field,
     field_validator,
     model_validator,
 )
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 LangGraphStreamMode = Literal[
     "values", "updates", "custom", "messages", "checkpoints", "tasks", "debug"
@@ -34,9 +34,7 @@ _NormalizedAdapter = Annotated[str, AfterValidator(_normalize_adapter)]
 _NonBlankString = Annotated[str, AfterValidator(_require_non_blank)]
 
 
-class LangGraphSemanticSearchSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangGraphSemanticSearchSettings(SettingsModel):
     enabled: bool = False
     embed: str | None = None
     dims: int | None = None
@@ -67,9 +65,7 @@ class LangGraphSemanticSearchSettings(BaseModel):
         return self
 
 
-class LangGraphCheckpointerSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangGraphCheckpointerSettings(SettingsModel):
     adapter: _NormalizedAdapter = "none"
     setup: bool = False
     ttl_seconds: int | None = None
@@ -87,9 +83,7 @@ class LangGraphCheckpointerSettings(BaseModel):
         return v
 
 
-class LangGraphStoreSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangGraphStoreSettings(SettingsModel):
     adapter: _NormalizedAdapter = "none"
     setup: bool = False
     connection_uri_env: str | None = None
@@ -113,9 +107,7 @@ class LangGraphStoreSettings(BaseModel):
         return value
 
 
-class LangGraphPersistenceSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangGraphPersistenceSettings(SettingsModel):
     enabled: bool = False
     mode: Literal["auto", "embedded", "agent_server"] = "auto"
     checkpointer: LangGraphCheckpointerSettings = Field(
@@ -124,7 +116,7 @@ class LangGraphPersistenceSettings(BaseModel):
     store: LangGraphStoreSettings = Field(default_factory=LangGraphStoreSettings)
 
 
-class LangGraphSettings(BaseModel):
+class LangGraphSettings(SettingsModel):
     name: str = "agent"
     graph: str = "agent"
     entrypoint: str

--- a/arclith/infrastructure/settings/langsmith.py
+++ b/arclith/infrastructure/settings/langsmith.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 
-class LangSmithTracingSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithTracingSettings(SettingsModel):
     enabled: bool = True
     mode: Literal["langsmith", "otel", "hybrid"] = "otel"
     sampling_rate: float = 1.0
@@ -20,9 +20,7 @@ class LangSmithTracingSettings(BaseModel):
         return v
 
 
-class LangSmithInstrumentationSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithInstrumentationSettings(SettingsModel):
     langgraph: bool = True
     pydantic_ai: bool = True
     fastapi: bool = False
@@ -30,9 +28,7 @@ class LangSmithInstrumentationSettings(BaseModel):
     command_bus: bool = True
 
 
-class LangSmithCaptureSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithCaptureSettings(SettingsModel):
     inputs: bool = False
     outputs: bool = False
     metadata: bool = True
@@ -41,9 +37,7 @@ class LangSmithCaptureSettings(BaseModel):
     model_request_parameters: bool = False
 
 
-class LangSmithPropagationSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithPropagationSettings(SettingsModel):
     enabled: bool = True
     langsmith_headers: bool = True
     traceparent: bool = True
@@ -58,9 +52,7 @@ class LangSmithPropagationSettings(BaseModel):
         return normalized
 
 
-class LangSmithLifecycleSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithLifecycleSettings(SettingsModel):
     flush_timeout_seconds: float = 5.0
 
     @field_validator("flush_timeout_seconds")
@@ -71,16 +63,12 @@ class LangSmithLifecycleSettings(BaseModel):
         return v
 
 
-class LangSmithDiagnosticsSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithDiagnosticsSettings(SettingsModel):
     enabled: bool = False
     log_level: Literal["debug", "info", "warning", "error"] = "info"
 
 
-class LangSmithSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class LangSmithSettings(SettingsModel):
     project: str
     endpoint: str = "https://api.smith.langchain.com"
     api_key_env: str = "LANGSMITH_API_KEY"

--- a/arclith/infrastructure/settings/llm.py
+++ b/arclith/infrastructure/settings/llm.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from arclith.infrastructure.settings._base import SettingsModel
 
 
-class LMSettings(BaseModel):
+class LMSettings(SettingsModel):
     provider: Literal["anthropic", "openai"] = "anthropic"
     model_name: str = "claude-sonnet-4-5"
     api_key: str = ""

--- a/arclith/infrastructure/settings/observability.py
+++ b/arclith/infrastructure/settings/observability.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field, field_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 ObservabilityAdapter = Literal["langsmith", "opentelemetry"]
 
 
-class ObservabilitySettings(BaseModel):
+class ObservabilitySettings(SettingsModel):
     enabled: list[ObservabilityAdapter] = Field(default_factory=list)
 
     @field_validator("enabled")

--- a/arclith/infrastructure/settings/opentelemetry.py
+++ b/arclith/infrastructure/settings/opentelemetry.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 
-class OpenTelemetryServiceSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryServiceSettings(SettingsModel):
     name: str | None = None
     namespace: str | None = None
     version: str | None = None
@@ -18,18 +18,14 @@ def _default_resource_detectors() -> list[Literal["env", "process", "host"]]:
     return ["env", "process", "host"]
 
 
-class OpenTelemetryResourceSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryResourceSettings(SettingsModel):
     attributes: dict[str, str | bool | int | float] = Field(default_factory=dict)
     detectors: list[Literal["env", "process", "host"]] = Field(
         default_factory=_default_resource_detectors
     )
 
 
-class OpenTelemetryExportSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryExportSettings(SettingsModel):
     protocol: Literal["http/protobuf", "grpc"] = "http/protobuf"
     endpoint: str = "http://localhost:4318"
     traces_endpoint: str | None = None
@@ -56,9 +52,7 @@ class OpenTelemetryExportSettings(BaseModel):
         return v
 
 
-class OpenTelemetryTracesSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryTracesSettings(SettingsModel):
     enabled: bool = True
     sampler: Literal[
         "always_on",
@@ -78,9 +72,7 @@ class OpenTelemetryTracesSettings(BaseModel):
         return v
 
 
-class OpenTelemetryMetricsSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryMetricsSettings(SettingsModel):
     enabled: bool = False
     export_interval_millis: int = 60000
     export_timeout_millis: int = 30000
@@ -94,16 +86,12 @@ class OpenTelemetryMetricsSettings(BaseModel):
         return v
 
 
-class OpenTelemetryLogsSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryLogsSettings(SettingsModel):
     enabled: bool = False
     correlate: bool = True
 
 
-class OpenTelemetrySignalsSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetrySignalsSettings(SettingsModel):
     traces: OpenTelemetryTracesSettings = Field(
         default_factory=OpenTelemetryTracesSettings
     )
@@ -185,9 +173,7 @@ def _migrate_legacy_opentelemetry(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-class OpenTelemetryPropagationSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryPropagationSettings(SettingsModel):
     propagators: list[Literal["tracecontext", "baggage"]] = Field(
         default_factory=_default_propagators
     )
@@ -209,9 +195,7 @@ class OpenTelemetryPropagationSettings(BaseModel):
         return v
 
 
-class OpenTelemetryInstrumentationSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryInstrumentationSettings(SettingsModel):
     fastapi: bool = True
     httpx: bool = True
     fastmcp: bool = True
@@ -225,9 +209,7 @@ class OpenTelemetryInstrumentationSettings(BaseModel):
     )
 
 
-class OpenTelemetryCaptureSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryCaptureSettings(SettingsModel):
     request_headers_allowlist: list[str] = Field(default_factory=list)
     response_headers_allowlist: list[str] = Field(default_factory=list)
     genai_content: bool = False
@@ -235,9 +217,7 @@ class OpenTelemetryCaptureSettings(BaseModel):
     db_statement: bool = False
 
 
-class OpenTelemetryBatchSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryBatchSettings(SettingsModel):
     max_queue_size: int = 2048
     schedule_delay_millis: int = 5000
     max_export_batch_size: int = 512
@@ -262,9 +242,7 @@ class OpenTelemetryBatchSettings(BaseModel):
         return self
 
 
-class OpenTelemetryLimitsSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetryLimitsSettings(SettingsModel):
     attribute_count: int = 128
     attribute_value_length: int = 4096
     span_event_count: int = 128
@@ -283,9 +261,7 @@ class OpenTelemetryLimitsSettings(BaseModel):
         return v
 
 
-class OpenTelemetrySettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class OpenTelemetrySettings(SettingsModel):
     mode: Literal["managed", "attach", "external"] = "managed"
     service: OpenTelemetryServiceSettings = Field(
         default_factory=OpenTelemetryServiceSettings

--- a/arclith/infrastructure/settings/repositories.py
+++ b/arclith/infrastructure/settings/repositories.py
@@ -4,20 +4,22 @@ import re
 from pathlib import Path
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
 
 _DUCKDB_SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".json", ".arrow"}
 _SQL_IDENTIFIER_RE = r"^[A-Za-z_][A-Za-z0-9_]*$"
 
 
-class MongoDBSettings(BaseModel):
+class MongoDBSettings(SettingsModel):
     uri: str | None = None
     db_name: str
     collection_name: str | None = None
     multitenant: bool = False
 
 
-class DuckDBSettings(BaseModel):
+class DuckDBSettings(SettingsModel):
     path: str
     multitenant: bool = False
 
@@ -36,7 +38,7 @@ class DuckDBSettings(BaseModel):
         return v
 
 
-class _SQLRepositorySettings(BaseModel):
+class _SQLRepositorySettings(SettingsModel):
     url: str | None = None
     host: str = "127.0.0.1"
     port: int

--- a/arclith/infrastructure/settings/storage.py
+++ b/arclith/infrastructure/settings/storage.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import field_validator, model_validator
 
 from arclith.domain.ports.outbound.file_storage import (
     FileStorageInvalidKey,
     normalize_storage_key,
 )
+from arclith.infrastructure.settings._base import SettingsModel
 
 StorageAdapter = Literal["filesystem", "s3", "azure-blob", "gcs"]
 
 
-class StorageSettings(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
+class StorageSettings(SettingsModel):
     adapter: StorageAdapter
     prefix: str = ""
     multitenant: bool = False

--- a/docs/deep-dives/configuration.md
+++ b/docs/deep-dives/configuration.md
@@ -42,7 +42,7 @@ ou par Vault, mais ne doit pas contenir la vraie valeur.
 
 ```yaml
 # config/secrets.yaml
-provider: env
+resolver: env
 ```
 
 Les mappings de secret permettent de remplir des champs comme
@@ -84,7 +84,9 @@ PY
 ```
 
 La validation doit échouer tôt si un secret requis manque ou si un adapter est
-mal configuré.
+mal configuré. Toutes les sections refusent aussi les clés inconnues : une faute
+de frappe comme `database_name` à la place de `db_name` provoque une erreur
+Pydantic explicite au démarrage, au lieu d'être ignorée.
 
 ## Erreurs Fréquentes
 
@@ -93,6 +95,7 @@ mal configuré.
 | vraie clé API dans YAML | utiliser `secrets.yaml` et `.env` |
 | config différente par environnement | garder la même structure |
 | fichier géant | découper par capability |
+| clé YAML inconnue | corriger le nom indiqué dans l'erreur Pydantic |
 | valeur par défaut dangereuse | expliciter la valeur de production |
 | doc oubliée après ajout capability | documenter la capability dans la même PR |
 

--- a/journal/2026-08-31-strict-settings-validation.md
+++ b/journal/2026-08-31-strict-settings-validation.md
@@ -1,0 +1,23 @@
+# Validation stricte des settings
+
+## Contexte
+
+La review de la refactorisation structurelle a relevé que certaines sections de `config.yaml`
+ignoraient encore les clés inconnues, tandis que les settings OpenTelemetry, LangSmith et stockage
+les refusaient déjà. Une faute de frappe pouvait donc produire une configuration valide mais
+inefficace.
+
+## Décision
+
+- partager une base Pydantic interne avec `extra="forbid"` entre tous les modèles de settings ;
+- conserver les options spécifiques de PostgreSQL pour les alias de champs ;
+- retirer la directive de chargement `secrets` après résolution et avant la validation d'`AppConfig` ;
+- vérifier les erreurs aux niveaux racine, adaptateurs et repositories imbriqués.
+
+## Impact
+
+Les configurations valides sont inchangées. Une clé YAML inconnue échoue désormais tôt avec une
+erreur de validation explicite au lieu d'être ignorée silencieusement.
+
+La page `docs/deep-dives/configuration.md` documente ce comportement et corrige le nom de la clé
+`resolver` utilisée par `secrets.yaml`.

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -48,6 +48,25 @@ def test_unknown_logger_adapter_is_rejected():
         AppConfig.model_validate({"adapters": {"logger": "custom"}})
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"unknown_section": {}},
+        {"adapters": {"unknown_adapter": {}}},
+        {"adapters": {"mongodb": {"db_name": "test", "database_name": "typo"}}},
+        {
+            "adapters": {
+                "postgresql": {"database": "test", "schema_nam": "typo"}
+            }
+        },
+    ],
+    ids=["root", "adapters", "mongodb", "postgresql-alias"],
+)
+def test_unknown_configuration_keys_are_rejected(data):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AppConfig.model_validate(data)
+
+
 def test_default_retention_is_none():
     assert AppConfig().soft_delete.retention_days is None
 
@@ -1054,11 +1073,14 @@ def test_export_config_yaml_round_trip():
             "adapters/inbound/fastapi.yaml": {"port": 8765},
         }
     )
-    out = config_dir / "config.yaml"
+    out = config_dir.parent / f"{config_dir.name}-config.yaml"
     export_config_yaml(config_dir, out)
 
-    from_dir = load_config_dir(config_dir)
-    from_file = load_config_file(out)
+    try:
+        from_dir = load_config_dir(config_dir)
+        from_file = load_config_file(out)
+    finally:
+        out.unlink(missing_ok=True)
 
     assert from_dir.app.name == from_file.app.name
     assert from_dir.soft_delete.retention_days == from_file.soft_delete.retention_days

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -63,8 +63,11 @@ def test_unknown_logger_adapter_is_rejected():
     ids=["root", "adapters", "mongodb", "postgresql-alias"],
 )
 def test_unknown_configuration_keys_are_rejected(data):
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError) as exc_info:
         AppConfig.model_validate(data)
+    assert {error["type"] for error in exc_info.value.errors()} == {
+        "extra_forbidden"
+    }
 
 
 def test_default_retention_is_none():


### PR DESCRIPTION
## Contexte

Correctif de suivi de #190 pour traiter les deux remarques Copilot apparues après le merge : plusieurs sections de configuration ignoraient encore silencieusement les clés YAML inconnues.

## Changements

- centralise `extra="forbid"` dans une base Pydantic commune à tous les settings ;
- rend stricts `AppConfig`, les adapters et les repositories sans dupliquer leur configuration ;
- résout puis retire la directive de chargement `secrets` avant validation d’`AppConfig` ;
- ajoute des tests pour les typos racine, adapters, MongoDB et PostgreSQL ;
- documente la validation stricte et corrige la clé `resolver` de `secrets.yaml`.

## Impact

- API, domaine, données, RabbitMQ, MCP et ports : aucun changement ;
- configuration : une clé inconnue échoue désormais tôt au lieu d’être ignorée ; les configurations valides et les mappings de secrets restent compatibles ;
- migration/déploiement : aucune action, hormis corriger d’éventuelles clés YAML invalides désormais signalées ;
- release : correctif patch publiable via le processus de release manuel du dépôt.

## Validation

- `make precommit` ;
- `make coverage` — 1 617 passés, 4 ignorés, couverture 90,80 % ;
- `cd cli && uv run --frozen pytest -q` — 119 passés, 1 ignoré ;
- `uv run --frozen --group docs mkdocs build --strict`.

## Documentation

- `docs/deep-dives/configuration.md` ;
- `journal/2026-08-31-strict-settings-validation.md` ;
- ADR non applicable : aucun choix architectural public nouveau.