### PR TITLE
feat: add replayable CLI recipes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -307,6 +307,34 @@ arclith = Arclith("config.yaml")
 
 ---
 
+### `history` et `replay` — Relire et rejouer les décisions CLI
+
+`init`, `new`, `add-entity`, `add-usecase`, `add-intent-interpreter` et
+`add-adapter` ajoutent une étape à `arclith.recipe.yaml` uniquement après leur
+succès complet. La recette est un historique fonctionnel rejouable ; Git reste
+l'historique du code et `export-config` reste la configuration consolidée de
+déploiement.
+
+```bash
+arclith-cli history
+arclith-cli replay arclith.recipe.yaml --dir ../rebuilt-service --dry-run
+arclith-cli replay arclith.recipe.yaml --dir ../rebuilt-service
+```
+
+Sélectionner une plage avec `--from-step 0003` et `--to-step 0008`. Utiliser
+`--strict` pour refuser une commande non supportée.
+
+Les paramètres secrets sont remplacés par `<redacted>` et référencent une
+variable d'environnement. Le dry-run liste les variables requises sans lire
+leur valeur ; le replay réel exige qu'elles soient définies. Les chemins de
+fichiers générés restent relatifs à la racine du projet et les étapes rejouées
+ne sont pas enregistrées une seconde fois.
+
+Voir la documentation complète :
+[Recettes Arclith CLI](https://karned-rekipe.github.io/arclith/cli-recipe/).
+
+---
+
 ### `update` — Mettre à jour le CLI
 
 ```bash

--- a/cli/arclith_cli/add_adapter.py
+++ b/cli/arclith_cli/add_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,19 @@ from arclith_cli.project_paths import ProjectPaths, detect_project_paths
 console = Console()
 
 
+@dataclass(frozen=True)
+class AdapterCommandResult:
+    """Resolved inputs that produced one successful adapter generation."""
+
+    project_dir: Path
+    capability: CapabilitySpec
+    adapter: AdapterSpec
+    entities: tuple[EntityInfo, ...]
+    params: dict[str, Any]
+    activate: bool
+    profile: str | None
+
+
 def add_adapter_cmd(
     *,
     project_dir: Path | None = None,
@@ -45,7 +59,7 @@ def add_adapter_cmd(
     adapter_params: dict[str, str] | None = None,
     profile: str | None = None,
     yes: bool = False,
-) -> None:
+) -> AdapterCommandResult:
     """Wizard interactif pour scaffolder un adapter du catalogue."""
     project_dir = project_dir or Path.cwd()
 
@@ -95,6 +109,19 @@ def add_adapter_cmd(
             activate=activate,
             explicit_params=explicit_params,
         )
+    )
+    recorded_params = {
+        parameter.name: params.get(parameter.name)
+        for parameter in adapter_spec.parameters
+    }
+    return AdapterCommandResult(
+        project_dir=project_dir,
+        capability=capability,
+        adapter=adapter_spec,
+        entities=tuple(entities),
+        params=recorded_params,
+        activate=activate,
+        profile=profile,
     )
 
 

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -16,13 +16,20 @@ console = Console()
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 
 
-def init_project_cmd(*, project_name: str, directory: Path | None = None) -> Path:
+def init_project_cmd(
+    *,
+    project_name: str,
+    directory: Path | None = None,
+    target_path: Path | None = None,
+) -> Path:
     """Create a minimal Arclith project without a starter entity."""
     project_name = project_name.strip()
     _assert_valid_project_name(project_name)
 
     parent_dir = (directory or Path(".")).resolve()
-    target_dir = parent_dir / project_name
+    target_dir = (
+        target_path.resolve() if target_path is not None else parent_dir / project_name
+    )
     if target_dir.exists():
         console.print(f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]")
         raise typer.Exit(1)

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, Mapping, Never
 
 import typer
 from rich.console import Console
-from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.table import Table
-from rich.tree import Tree
 
 from . import __version__
 from .add_adapter import add_adapter_cmd
@@ -18,13 +16,15 @@ from .capabilities import CAPABILITY_CATALOG, capability_catalog_as_dict
 from .core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .init_project import init_project_cmd
-from .rename import EntityNames, apply_rename
-from .runtime_templates import (
-    DOCKERIGNORE_TEMPLATE,
-    render_arclith_run,
-    render_dockerfile,
+from .new_project import new_project_cmd as _new_project_cmd
+from .recipe import (
+    RecipeError,
+    RecipeSecretRef,
+    adapter_secret_metadata,
+    record_successful_step,
+    snapshot_project_files,
 )
-from .scaffold import download_and_extract
+from .recipe_cli import history_command, replay_command
 from .updater import run_update
 
 app = typer.Typer(
@@ -34,6 +34,8 @@ app = typer.Typer(
     rich_markup_mode="rich",
 )
 console = Console()
+app.command(name="history")(history_command)
+app.command(name="replay")(replay_command)
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -49,11 +51,25 @@ def init(
         Path,
         typer.Option("--dir", "-d", help="Répertoire parent où le projet sera créé"),
     ] = Path("."),
+    no_record: Annotated[
+        bool,
+        typer.Option(
+            "--no-record",
+            help="Ne pas écrire la recette CLI (usage interne).",
+            hidden=True,
+        ),
+    ] = False,
 ) -> None:
     """Initialiser un projet arclith minimal sans entité métier."""
-    init_project_cmd(
-        project_name=project_name or _prompt_project(), directory=directory
-    )
+    resolved_name = project_name or _prompt_project()
+    target_dir = init_project_cmd(project_name=resolved_name, directory=directory)
+    if not no_record:
+        _record_success(
+            target_dir,
+            command="init",
+            args={"project_name": resolved_name, "directory": "."},
+            before={},
+        )
 
 
 @app.command()
@@ -88,48 +104,39 @@ def new(
             "--template-dir", help="Répertoire local du template _sample", hidden=True
         ),
     ] = None,
+    no_record: Annotated[
+        bool,
+        typer.Option(
+            "--no-record",
+            help="Ne pas écrire la recette CLI (usage interne).",
+            hidden=True,
+        ),
+    ] = False,
 ) -> None:
     """Créer un nouveau projet [bold]arclith[/bold] scaffoldé depuis le template officiel [dim]_sample[/dim]."""
     entity = entity or _prompt_entity()
     project_name = project_name or _prompt_project()
-    _validate_runtime_ports(api_port=port, mcp_port=port + 1)
-
-    names = EntityNames.from_input(entity)
-    target_dir = directory.resolve() / project_name
-
-    if target_dir.exists():
-        console.print(
-            f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]"
-        )
-        raise typer.Exit(1)
-
-    console.print(
-        Panel.fit(
-            f"[bold blue]arclith-cli[/bold blue] [dim]v{__version__}[/dim]\n\n"
-            f"  Entité   [bold green]{names.pascal}[/bold green]  [dim]({names.snake} / {names.upper})[/dim]\n"
-            f"  Projet   [bold]{project_name}[/bold]\n"
-            f"  Cible    [dim]{target_dir}[/dim]\n"
-            f"  Ports    REST [bold]{port}[/bold]  ·  MCP [bold]{port + 1}[/bold]",
-            border_style="blue",
-            title="[bold]Nouveau projet[/bold]",
-        )
+    target_dir = _new_project_cmd(
+        entity=entity,
+        project_name=project_name,
+        directory=directory,
+        port=port,
+        repo_ref=repo_ref,
+        template_dir=template_dir,
     )
-
-    with console.status("[bold]Préparation du template…[/bold]"):
-        try:
-            download_and_extract(target_dir, ref=repo_ref, template_dir=template_dir)
-        except Exception as exc:
-            console.print(f"[red]✗ Téléchargement échoué :[/red] {exc}")
-            raise typer.Exit(1) from exc
-
-    console.print("[green]✓[/green] Template extrait")
-
-    with console.status("[bold]Renommage de l'entité…[/bold]"):
-        apply_rename(target_dir, names, project_name=project_name, port=port)
-        _write_runtime_files(target_dir, api_port=port, mcp_port=port + 1)
-
-    console.print("[green]✓[/green] Renommage terminé")
-    _print_summary(target_dir, project_name, port)
+    if not no_record:
+        _record_success(
+            target_dir,
+            command="new",
+            args={
+                "entity": entity,
+                "project_name": project_name,
+                "directory": ".",
+                "port": port,
+                "repo_ref": repo_ref,
+            },
+            before={},
+        )
 
 
 @app.command()
@@ -219,9 +226,20 @@ def add_adapter(
             help="Utiliser les valeurs fournies ou par défaut sans confirmation",
         ),
     ] = False,
+    no_record: Annotated[
+        bool,
+        typer.Option(
+            "--no-record",
+            help="Ne pas écrire la recette CLI (usage interne).",
+            hidden=True,
+        ),
+    ] = False,
 ) -> None:
     """Wizard ou mode direct pour scaffolder un nouvel [bold]adapter[/bold] dans le projet courant."""
-    add_adapter_cmd(
+    project_dir = Path.cwd()
+    before = snapshot_project_files(project_dir) if not no_record else {}
+    result = add_adapter_cmd(
+        project_dir=project_dir,
         capability_name=capability,
         adapter=adapter,
         entity_names=_split_entity_option(entity),
@@ -234,6 +252,23 @@ def add_adapter(
         profile=profile,
         yes=yes,
     )
+    if not no_record:
+        secret_fields, secret_references = adapter_secret_metadata(result.adapter)
+        _record_success(
+            project_dir,
+            command="add-adapter",
+            args={
+                "capability": result.capability.name,
+                "adapter": result.adapter.name,
+                "entities": [entity.pascal for entity in result.entities],
+                "activate": result.activate,
+                "profile": result.profile,
+                "params": result.params,
+            },
+            before=before,
+            secret_fields=secret_fields,
+            secret_references=secret_references,
+        )
 
 
 @app.command(name="add-entity")
@@ -244,9 +279,23 @@ def add_entity(
             help="Nom de l'entité métier au singulier. Exemple : Recipe, recipe_step, meal-plan",
         ),
     ] = None,
+    no_record: Annotated[
+        bool,
+        typer.Option("--no-record", hidden=True),
+    ] = False,
 ) -> None:
     """Créer uniquement le fichier minimal d'une entité métier dans domain/models."""
-    add_entity_cmd(entity_name=entity or _prompt_entity())
+    resolved_name = entity or _prompt_entity()
+    project_dir = Path.cwd()
+    before = snapshot_project_files(project_dir) if not no_record else {}
+    add_entity_cmd(project_dir=project_dir, entity_name=resolved_name)
+    if not no_record:
+        _record_success(
+            project_dir,
+            command="add-entity",
+            args={"entity": resolved_name},
+            before=before,
+        )
 
 
 @app.command(name="add-usecase")
@@ -257,9 +306,23 @@ def add_usecase(
             help="Nom du cas d'usage. Exemple : PlanShoppingList, find_by_name, import-catalog",
         ),
     ] = None,
+    no_record: Annotated[
+        bool,
+        typer.Option("--no-record", hidden=True),
+    ] = False,
 ) -> None:
     """Créer uniquement le fichier minimal d'un cas d'usage dans application/use_cases."""
-    add_usecase_cmd(usecase_name=usecase or _prompt_usecase())
+    resolved_name = usecase or _prompt_usecase()
+    project_dir = Path.cwd()
+    before = snapshot_project_files(project_dir) if not no_record else {}
+    add_usecase_cmd(project_dir=project_dir, usecase_name=resolved_name)
+    if not no_record:
+        _record_success(
+            project_dir,
+            command="add-usecase",
+            args={"usecase": resolved_name},
+            before=before,
+        )
 
 
 @app.command(name="add-intent-interpreter")
@@ -270,9 +333,23 @@ def add_intent_interpreter(
             help="Nom de l'interpréteur d'intention. Exemple : IngredientIntent, todo-intent, command-router",
         ),
     ] = None,
+    no_record: Annotated[
+        bool,
+        typer.Option("--no-record", hidden=True),
+    ] = False,
 ) -> None:
     """Créer uniquement le fichier minimal d'un interpréteur d'intention."""
-    add_intent_interpreter_cmd(intent_name=intent or _prompt_intent_interpreter())
+    resolved_name = intent or _prompt_intent_interpreter()
+    project_dir = Path.cwd()
+    before = snapshot_project_files(project_dir) if not no_record else {}
+    add_intent_interpreter_cmd(project_dir=project_dir, intent_name=resolved_name)
+    if not no_record:
+        _record_success(
+            project_dir,
+            command="add-intent-interpreter",
+            args={"intent": resolved_name},
+            before=before,
+        )
 
 
 @app.command(name="capabilities")
@@ -393,6 +470,33 @@ def _prompt_intent_interpreter() -> str:
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
+def _record_success(
+    project_dir: Path,
+    *,
+    command: str,
+    args: Mapping[str, Any],
+    before: Mapping[str, str],
+    secret_fields: Mapping[str, str] | None = None,
+    secret_references: tuple[RecipeSecretRef, ...] = (),
+) -> None:
+    try:
+        record_successful_step(
+            project_dir,
+            command=command,
+            args=args,
+            before=before,
+            secret_fields=secret_fields,
+            secret_references=secret_references,
+        )
+    except (OSError, RecipeError) as exc:
+        _recipe_error(exc)
+
+
+def _recipe_error(exc: Exception) -> Never:
+    console.print(f"[red]✗ Recette CLI invalide :[/red] {exc}")
+    raise typer.Exit(1)
+
+
 def _split_entity_option(value: str | None) -> list[str] | None:
     if value is None:
         return None
@@ -412,60 +516,3 @@ def _parse_param_options(values: list[str] | None) -> dict[str, str]:
             raise typer.Exit(1)
         result[key] = value.strip()
     return result
-
-
-def _write_runtime_files(target_dir: Path, *, api_port: int, mcp_port: int) -> None:
-    _validate_runtime_ports(api_port=api_port, mcp_port=mcp_port)
-    (target_dir / "Dockerfile").write_text(
-        render_dockerfile(api_port=str(api_port), mcp_port=str(mcp_port)),
-        encoding="utf-8",
-    )
-    (target_dir / ".dockerignore").write_text(DOCKERIGNORE_TEMPLATE, encoding="utf-8")
-    entrypoint = target_dir / "arclith-run"
-    entrypoint.write_text(render_arclith_run(), encoding="utf-8")
-    entrypoint.chmod(0o755)
-
-
-def _validate_runtime_ports(*, api_port: int, mcp_port: int) -> None:
-    for label, value in (("REST", api_port), ("MCP", mcp_port)):
-        if value <= 0 or value > 65535:
-            console.print(
-                f"[red]✗[/red] Port {label} invalide: [bold]{value}[/bold]. "
-                "Utilisez une valeur entre 1 et 65535."
-            )
-            raise typer.Exit(1)
-
-
-def _print_summary(target_dir: Path, project_name: str, port: int) -> None:
-    tree = Tree(f"[bold green]{project_name}/[/bold green]")
-    _build_tree(tree, target_dir, depth=0, max_depth=3)
-    console.print()
-    console.print(tree)
-    console.print(
-        Panel(
-            f"[bold cyan]cd[/bold cyan] {target_dir}\n"
-            f"[bold cyan]uv sync[/bold cyan]\n\n"
-            f"[bold cyan]uv run python main.py[/bold cyan]"
-            f"  [dim]# MODE=api → REST :{port}[/dim]\n"
-            f"[bold cyan]MODE=mcp_http uv run python main.py[/bold cyan]"
-            f"  [dim]# MCP :{port + 1}[/dim]",
-            title="[bold blue]Next steps[/bold blue]",
-            border_style="green",
-        )
-    )
-
-
-def _build_tree(node: Tree, path: Path, depth: int, max_depth: int) -> None:
-    if depth >= max_depth:
-        return
-    try:
-        children = sorted(path.iterdir(), key=lambda p: (p.is_file(), p.name))
-    except PermissionError:
-        return
-    for child in children:
-        if child.name.startswith("."):
-            continue
-        label = f"[blue]{child.name}/[/blue]" if child.is_dir() else child.name
-        branch = node.add(label)
-        if child.is_dir():
-            _build_tree(branch, child, depth + 1, max_depth)

--- a/cli/arclith_cli/new_project.py
+++ b/cli/arclith_cli/new_project.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.tree import Tree
+
+from arclith_cli import __version__
+from arclith_cli.rename import EntityNames, apply_rename
+from arclith_cli.runtime_templates import (
+    DOCKERIGNORE_TEMPLATE,
+    render_arclith_run,
+    render_dockerfile,
+)
+from arclith_cli.scaffold import download_and_extract
+
+console = Console()
+
+
+def new_project_cmd(
+    *,
+    entity: str,
+    project_name: str,
+    directory: Path,
+    port: int,
+    repo_ref: str,
+    template_dir: Path | None,
+    target_path: Path | None = None,
+) -> Path:
+    """Create a template-based project and return its root for recipe recording."""
+    _validate_runtime_ports(api_port=port, mcp_port=port + 1)
+
+    names = EntityNames.from_input(entity)
+    target_dir = (
+        target_path.resolve()
+        if target_path is not None
+        else directory.resolve() / project_name
+    )
+
+    if target_dir.exists():
+        console.print(
+            f"[red]✗[/red] Le répertoire existe déjà : [bold]{target_dir}[/bold]"
+        )
+        raise typer.Exit(1)
+
+    console.print(
+        Panel.fit(
+            f"[bold blue]arclith-cli[/bold blue] [dim]v{__version__}[/dim]\n\n"
+            f"  Entité   [bold green]{names.pascal}[/bold green]  "
+            f"[dim]({names.snake} / {names.upper})[/dim]\n"
+            f"  Projet   [bold]{project_name}[/bold]\n"
+            f"  Cible    [dim]{target_dir}[/dim]\n"
+            f"  Ports    REST [bold]{port}[/bold]  ·  MCP [bold]{port + 1}[/bold]",
+            border_style="blue",
+            title="[bold]Nouveau projet[/bold]",
+        )
+    )
+
+    with console.status("[bold]Préparation du template…[/bold]"):
+        try:
+            download_and_extract(target_dir, ref=repo_ref, template_dir=template_dir)
+        except Exception as exc:
+            console.print(f"[red]✗ Téléchargement échoué :[/red] {exc}")
+            raise typer.Exit(1) from exc
+
+    console.print("[green]✓[/green] Template extrait")
+
+    with console.status("[bold]Renommage de l'entité…[/bold]"):
+        apply_rename(target_dir, names, project_name=project_name, port=port)
+        _write_runtime_files(target_dir, api_port=port, mcp_port=port + 1)
+
+    console.print("[green]✓[/green] Renommage terminé")
+    _print_summary(target_dir, project_name, port)
+    return target_dir
+
+
+def _write_runtime_files(target_dir: Path, *, api_port: int, mcp_port: int) -> None:
+    _validate_runtime_ports(api_port=api_port, mcp_port=mcp_port)
+    (target_dir / "Dockerfile").write_text(
+        render_dockerfile(api_port=str(api_port), mcp_port=str(mcp_port)),
+        encoding="utf-8",
+    )
+    (target_dir / ".dockerignore").write_text(DOCKERIGNORE_TEMPLATE, encoding="utf-8")
+    entrypoint = target_dir / "arclith-run"
+    entrypoint.write_text(render_arclith_run(), encoding="utf-8")
+    entrypoint.chmod(0o755)
+
+
+def _validate_runtime_ports(*, api_port: int, mcp_port: int) -> None:
+    for label, value in (("REST", api_port), ("MCP", mcp_port)):
+        if value <= 0 or value > 65535:
+            console.print(
+                f"[red]✗[/red] Port {label} invalide: [bold]{value}[/bold]. "
+                "Utilisez une valeur entre 1 et 65535."
+            )
+            raise typer.Exit(1)
+
+
+def _print_summary(target_dir: Path, project_name: str, port: int) -> None:
+    tree = Tree(f"[bold green]{project_name}/[/bold green]")
+    _build_tree(tree, target_dir, depth=0, max_depth=3)
+    console.print()
+    console.print(tree)
+    console.print(
+        Panel(
+            f"[bold cyan]cd[/bold cyan] {target_dir}\n"
+            f"[bold cyan]uv sync[/bold cyan]\n\n"
+            f"[bold cyan]uv run python main.py[/bold cyan]"
+            f"  [dim]# MODE=api → REST :{port}[/dim]\n"
+            f"[bold cyan]MODE=mcp_http uv run python main.py[/bold cyan]"
+            f"  [dim]# MCP :{port + 1}[/dim]",
+            title="[bold blue]Next steps[/bold blue]",
+            border_style="green",
+        )
+    )
+
+
+def _build_tree(node: Tree, path: Path, depth: int, max_depth: int) -> None:
+    if depth >= max_depth:
+        return
+    try:
+        children = sorted(path.iterdir(), key=lambda item: (item.is_file(), item.name))
+    except PermissionError:
+        return
+    for child in children:
+        if child.name.startswith("."):
+            continue
+        label = f"[blue]{child.name}/[/blue]" if child.is_dir() else child.name
+        branch = node.add(label)
+        if child.is_dir():
+            _build_tree(branch, child, depth + 1, max_depth)

--- a/cli/arclith_cli/recipe.py
+++ b/cli/arclith_cli/recipe.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import os
+import re
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+from arclith_cli import __version__
+from arclith_cli.capability_models import AdapterSpec
+from arclith_cli.project_paths import detect_project_paths
+from arclith_cli.recipe_models import (
+    EXTERNAL_PATH,
+    RECIPE_FILENAME,
+    RECIPE_SCHEMA_VERSION,
+    REDACTED,
+    Recipe,
+    RecipeError,
+    RecipeFileChange,
+    RecipeProject,
+    RecipeResult,
+    RecipeSecretRef,
+    RecipeStep,
+    load_recipe,
+    save_recipe,
+)
+
+_SUPPORTED_COMMANDS = {
+    "init",
+    "new",
+    "add-adapter",
+    "add-entity",
+    "add-usecase",
+    "add-intent-interpreter",
+}
+_SENSITIVE_NAME_RE = re.compile(
+    r"(?:^|_)(?:password|passwd|secret|token|api_key|apikey|credential)(?:$|_)",
+    re.IGNORECASE,
+)
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_PATH_FIELD_RE = re.compile(r"(?:^|_)(?:directory|dir|path|output|file)$")
+_IGNORED_SNAPSHOT_PARTS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "htmlcov",
+    "node_modules",
+}
+
+
+def snapshot_project_files(project_dir: Path) -> dict[str, str]:
+    """Return content fingerprints for files that a CLI command may mutate."""
+    if not project_dir.exists():
+        return {}
+    snapshot: dict[str, str] = {}
+    for path in sorted(project_dir.rglob("*")):
+        relative = path.relative_to(project_dir)
+        if _ignore_snapshot_path(relative) or not (path.is_file() or path.is_symlink()):
+            continue
+        if path.is_symlink():
+            digest = hashlib.sha256(b"symlink").hexdigest()
+        else:
+            try:
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            except OSError as exc:
+                raise RecipeError(
+                    f"Unable to inspect generated file {relative}: {exc}"
+                ) from exc
+        snapshot[relative.as_posix()] = digest
+    return snapshot
+
+
+def record_successful_step(
+    project_dir: Path,
+    *,
+    command: str,
+    args: Mapping[str, Any],
+    before: Mapping[str, str],
+    secret_fields: Mapping[str, str] | None = None,
+    secret_references: tuple[RecipeSecretRef, ...] = (),
+) -> RecipeStep:
+    """Append one successful mutation after its complete filesystem change."""
+    project_dir = project_dir.resolve()
+    recipe_path = project_dir / RECIPE_FILENAME
+    recipe = (
+        load_recipe(recipe_path)
+        if recipe_path.exists()
+        else _new_recipe_for_project(project_dir)
+    )
+    safe_args, detected_secrets = redact_recipe_args(
+        args,
+        secret_fields=secret_fields or {},
+    )
+    all_secrets = _deduplicate_secret_refs((*secret_references, *detected_secrets))
+    after = snapshot_project_files(project_dir)
+    result = RecipeResult(generated_files=_diff_snapshots(before, after))
+    now = _now_iso()
+    step = RecipeStep(
+        id=_next_step_id(recipe.steps),
+        at=now,
+        cli_version=__version__,
+        command=command,
+        status="success",
+        args=safe_args,
+        secrets=all_secrets,
+        result=result,
+    )
+    save_recipe(
+        Recipe(
+            version=recipe.version,
+            project=recipe.project,
+            created_at=recipe.created_at,
+            updated_at=now,
+            steps=(*recipe.steps, step),
+        ),
+        recipe_path,
+    )
+    return step
+
+
+def adapter_secret_metadata(
+    adapter: AdapterSpec,
+) -> tuple[dict[str, str], tuple[RecipeSecretRef, ...]]:
+    """Build replayable secret metadata from the capability catalogue."""
+    secret_fields: dict[str, str] = {}
+    for parameter in adapter.parameters:
+        if parameter.secret:
+            secret_fields[f"params.{parameter.name}"] = _parameter_env_key(
+                adapter, parameter.name, parameter.prompt
+            )
+    references = tuple(
+        RecipeSecretRef(
+            field_path=mapping.field_path,
+            source="env",
+            key=mapping.secret_key,
+        )
+        for mapping in adapter.secret_mappings
+    )
+    return secret_fields, references
+
+
+def redact_recipe_args(
+    args: Mapping[str, Any],
+    *,
+    secret_fields: Mapping[str, str] | None = None,
+) -> tuple[dict[str, Any], tuple[RecipeSecretRef, ...]]:
+    """Normalize arguments and replace secret values with replayable references."""
+    refs: list[RecipeSecretRef] = []
+    safe = _sanitize_value(
+        dict(args),
+        path=(),
+        secret_fields=secret_fields or {},
+        refs=refs,
+    )
+    if not isinstance(safe, dict):  # pragma: no cover - defensive type guard
+        raise RecipeError("Recipe arguments must be a mapping.")
+    return safe, _deduplicate_secret_refs(tuple(refs))
+
+
+def select_recipe_steps(
+    recipe: Recipe,
+    *,
+    from_step: str | None = None,
+    to_step: str | None = None,
+) -> tuple[RecipeStep, ...]:
+    """Select an inclusive, ordered replay range by stable step id."""
+    if not recipe.steps:
+        return ()
+    ids = [step.id for step in recipe.steps]
+    if from_step is not None and from_step not in ids:
+        raise RecipeError(f"Unknown --from-step id: {from_step}")
+    if to_step is not None and to_step not in ids:
+        raise RecipeError(f"Unknown --to-step id: {to_step}")
+    start = ids.index(from_step) if from_step is not None else 0
+    end = ids.index(to_step) + 1 if to_step is not None else len(ids)
+    if start >= end:
+        raise RecipeError("--from-step must not come after --to-step.")
+    return recipe.steps[start:end]
+
+
+def replay_recipe(
+    recipe: Recipe,
+    steps: tuple[RecipeStep, ...],
+    *,
+    target_dir: Path,
+    strict: bool = False,
+) -> tuple[str, ...]:
+    """Replay selected recipe actions through the existing Python command helpers."""
+    target_dir = target_dir.resolve()
+    target_recipe_existed = (target_dir / RECIPE_FILENAME).is_file()
+    validate_replay_steps(steps, strict=strict)
+    prepared: list[tuple[RecipeStep, dict[str, Any]]] = []
+    for step in steps:
+        if step.command not in _SUPPORTED_COMMANDS:
+            if strict:
+                raise RecipeError(
+                    f"Step {step.id} uses unsupported command {step.command!r}."
+                )
+            continue
+        prepared.append((step, _hydrate_step_args(step)))
+
+    executed: list[str] = []
+    for step, args in prepared:
+        _execute_step(step, args=args, target_dir=target_dir)
+        executed.append(step.id)
+
+    if executed and target_dir.is_dir() and not target_recipe_existed:
+        selected = tuple(step for step in steps if step.id in executed)
+        copied = Recipe(
+            version=recipe.version,
+            project=recipe.project,
+            created_at=selected[0].at,
+            updated_at=selected[-1].at,
+            steps=selected,
+        )
+        save_recipe(copied, target_dir / RECIPE_FILENAME)
+    return tuple(executed)
+
+
+def validate_replay_steps(
+    steps: tuple[RecipeStep, ...],
+    *,
+    strict: bool,
+) -> None:
+    """Preflight command compatibility without reading secret values or writing files."""
+    if not strict:
+        return
+    unsupported = [
+        f"{step.id}:{step.command}"
+        for step in steps
+        if step.command not in _SUPPORTED_COMMANDS
+    ]
+    if unsupported:
+        raise RecipeError(
+            "Unsupported recipe commands in strict mode: " + ", ".join(unsupported)
+        )
+
+
+def step_summary(step: RecipeStep) -> str:
+    """Return a compact, secret-free human summary for history and dry-run."""
+    args = step.args
+    if step.command in {"init", "new"}:
+        return str(args.get("project_name") or "project")
+    if step.command == "add-adapter":
+        capability = args.get("capability", "repository")
+        adapter = args.get("adapter", "?")
+        entities = args.get("entities") or []
+        suffix = f" ({', '.join(map(str, entities))})" if entities else ""
+        return f"{capability}/{adapter}{suffix}"
+    for key in ("entity", "usecase", "intent"):
+        if key in args:
+            return str(args[key])
+    return ""
+
+
+def required_replay_env(steps: tuple[RecipeStep, ...]) -> tuple[str, ...]:
+    """List environment variables needed to hydrate redacted replay arguments."""
+    return tuple(
+        sorted(
+            {
+                secret.key
+                for step in steps
+                for secret in step.secrets
+                if secret.source == "env" and secret.field_path.startswith("args.")
+            }
+        )
+    )
+
+
+def _execute_step(
+    step: RecipeStep,
+    *,
+    args: dict[str, Any],
+    target_dir: Path,
+) -> None:
+    if step.command == "init":
+        from arclith_cli.init_project import init_project_cmd
+
+        init_project_cmd(
+            project_name=str(args.get("project_name") or target_dir.name),
+            directory=target_dir.parent,
+            target_path=target_dir,
+        )
+        return
+    if step.command == "new":
+        from arclith_cli.new_project import new_project_cmd
+
+        new_project_cmd(
+            entity=str(args["entity"]),
+            project_name=str(args.get("project_name") or target_dir.name),
+            directory=target_dir.parent,
+            port=int(args.get("port", 8000)),
+            repo_ref=str(args.get("repo_ref", "main")),
+            template_dir=None,
+            target_path=target_dir,
+        )
+        return
+    if not target_dir.is_dir():
+        raise RecipeError(
+            f"Replay target does not exist before step {step.id}: {target_dir}"
+        )
+    if step.command == "add-entity":
+        from arclith_cli.core_scaffold import add_entity_cmd
+
+        add_entity_cmd(project_dir=target_dir, entity_name=str(args["entity"]))
+        return
+    if step.command == "add-usecase":
+        from arclith_cli.core_scaffold import add_usecase_cmd
+
+        add_usecase_cmd(project_dir=target_dir, usecase_name=str(args["usecase"]))
+        return
+    if step.command == "add-intent-interpreter":
+        from arclith_cli.core_scaffold import add_intent_interpreter_cmd
+
+        add_intent_interpreter_cmd(
+            project_dir=target_dir,
+            intent_name=str(args["intent"]),
+        )
+        return
+    if step.command == "add-adapter":
+        from arclith_cli.add_adapter import add_adapter_cmd
+
+        raw_params = args.get("params") or {}
+        if not isinstance(raw_params, dict):
+            raise RecipeError(f"Step {step.id} add-adapter params must be a mapping.")
+        raw_entities = args.get("entities") or []
+        if not isinstance(raw_entities, list):
+            raise RecipeError(f"Step {step.id} add-adapter entities must be a list.")
+        add_adapter_cmd(
+            project_dir=target_dir,
+            capability_name=str(args.get("capability", "repository")),
+            adapter=str(args["adapter"]),
+            entity_names=[str(item) for item in raw_entities] or None,
+            activate=bool(args.get("activate", True)),
+            adapter_params=dict(raw_params),
+            yes=True,
+        )
+
+
+def _hydrate_step_args(step: RecipeStep) -> dict[str, Any]:
+    args = copy.deepcopy(step.args)
+    for secret in step.secrets:
+        if not secret.field_path.startswith("args."):
+            continue
+        if secret.source != "env":
+            raise RecipeError(
+                f"Step {step.id} secret source {secret.source!r} is not supported."
+            )
+        value = os.getenv(secret.key)
+        if value is None:
+            raise RecipeError(
+                f"Step {step.id} requires environment variable {secret.key} for replay."
+            )
+        _set_nested_value(args, secret.field_path.removeprefix("args."), value)
+    if _contains_placeholder(args, REDACTED):
+        raise RecipeError(
+            f"Step {step.id} contains a redacted value without a secret reference."
+        )
+    if _contains_placeholder(args, EXTERNAL_PATH):
+        raise RecipeError(
+            f"Step {step.id} contains a non-portable external path and cannot be replayed."
+        )
+    return args
+
+
+def _set_nested_value(data: dict[str, Any], field_path: str, value: str) -> None:
+    parts = field_path.split(".")
+    current = data
+    for part in parts[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            current[part] = child
+        current = child
+    current[parts[-1]] = value
+
+
+def _contains_placeholder(value: Any, placeholder: str) -> bool:
+    if value == placeholder:
+        return True
+    if isinstance(value, dict):
+        return any(_contains_placeholder(item, placeholder) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_placeholder(item, placeholder) for item in value)
+    return False
+
+
+def _new_recipe_for_project(project_dir: Path) -> Recipe:
+    project = _read_project_identity(project_dir)
+    now = _now_iso()
+    return Recipe(
+        version=RECIPE_SCHEMA_VERSION,
+        project=project,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _read_project_identity(project_dir: Path) -> RecipeProject:
+    name = project_dir.name
+    pyproject = project_dir / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            configured_name = data.get("project", {}).get("name")
+            if isinstance(configured_name, str) and configured_name.strip():
+                name = configured_name.strip()
+        except (OSError, UnicodeError, tomllib.TOMLDecodeError):
+            pass
+    paths = detect_project_paths(project_dir)
+    package = paths.package_name or name.replace("-", "_")
+    return RecipeProject(name=name, package=package)
+
+
+def _sanitize_value(
+    value: Any,
+    *,
+    path: tuple[str, ...],
+    secret_fields: Mapping[str, str],
+    refs: list[RecipeSecretRef],
+) -> Any:
+    if isinstance(value, Mapping):
+        sanitized: dict[str, Any] = {}
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            item_path = (*path, key)
+            dotted = ".".join(item_path)
+            secret_key = secret_fields.get(dotted)
+            if _is_external_path_value(key, item):
+                sanitized[key] = EXTERNAL_PATH
+            elif secret_key is not None or _is_sensitive_value(key, item):
+                replay_key = secret_key or _fallback_env_key(item_path)
+                sanitized[key] = REDACTED
+                refs.append(
+                    RecipeSecretRef(
+                        field_path=f"args.{dotted}",
+                        source="env",
+                        key=replay_key,
+                    )
+                )
+            else:
+                sanitized[key] = _sanitize_value(
+                    item,
+                    path=item_path,
+                    secret_fields=secret_fields,
+                    refs=refs,
+                )
+        return sanitized
+    if isinstance(value, (list, tuple)):
+        return [
+            _sanitize_value(
+                item,
+                path=(*path, str(index)),
+                secret_fields=secret_fields,
+                refs=refs,
+            )
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, Path):
+        return _portable_path(value)
+    if isinstance(value, datetime):
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise RecipeError("Recipe timestamps must be timezone-aware.")
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _is_sensitive_value(key: str, value: Any) -> bool:
+    if _SENSITIVE_NAME_RE.search(key):
+        return True
+    if not isinstance(value, str) or (
+        "uri" not in key.lower() and "url" not in key.lower()
+    ):
+        return False
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return parsed.username is not None or parsed.password is not None
+
+
+def _is_external_path_value(key: str, value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(_PATH_FIELD_RE.search(key.lower()))
+        and Path(value).is_absolute()
+    )
+
+
+def _portable_path(path: Path) -> str:
+    if path.is_absolute():
+        return EXTERNAL_PATH
+    normalized = path.as_posix()
+    return normalized or "."
+
+
+def _fallback_env_key(path: tuple[str, ...]) -> str:
+    normalized = "_".join(path).upper()
+    normalized = re.sub(r"[^A-Z0-9]+", "_", normalized).strip("_")
+    return f"ARCLITH_REPLAY_{normalized}"
+
+
+def _parameter_env_key(adapter: AdapterSpec, name: str, prompt: str) -> str:
+    candidates = [
+        mapping.secret_key
+        for mapping in adapter.secret_mappings
+        if name.upper() in mapping.secret_key
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    if _ENV_NAME_RE.fullmatch(prompt):
+        return prompt
+    if len(adapter.secret_mappings) == 1:
+        return adapter.secret_mappings[0].secret_key
+    raw = f"ARCLITH_{adapter.capability}_{adapter.name}_{name}".upper()
+    return re.sub(r"[^A-Z0-9]+", "_", raw)
+
+
+def _deduplicate_secret_refs(
+    refs: tuple[RecipeSecretRef, ...],
+) -> tuple[RecipeSecretRef, ...]:
+    unique: dict[tuple[str, str, str], RecipeSecretRef] = {}
+    for ref in refs:
+        unique[(ref.field_path, ref.source, ref.key)] = ref
+    return tuple(unique.values())
+
+
+def _diff_snapshots(
+    before: Mapping[str, str], after: Mapping[str, str]
+) -> tuple[RecipeFileChange, ...]:
+    changes: list[RecipeFileChange] = []
+    for path in sorted(after):
+        if path not in before:
+            changes.append(RecipeFileChange(path=path, action="created"))
+        elif before[path] != after[path]:
+            changes.append(RecipeFileChange(path=path, action="updated"))
+    return tuple(changes)
+
+
+def _next_step_id(steps: tuple[RecipeStep, ...]) -> str:
+    next_id = max((int(step.id) for step in steps), default=0) + 1
+    if next_id > 9999:
+        raise RecipeError("A version 1 recipe cannot contain more than 9999 steps.")
+    return f"{next_id:04d}"
+
+
+def _ignore_snapshot_path(path: Path) -> bool:
+    return path.name == RECIPE_FILENAME or any(
+        part in _IGNORED_SNAPSHOT_PARTS for part in path.parts
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/cli/arclith_cli/recipe.py
+++ b/cli/arclith_cli/recipe.py
@@ -410,11 +410,12 @@ def _read_project_identity(project_dir: Path) -> RecipeProject:
     if pyproject.is_file():
         try:
             data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-            configured_name = data.get("project", {}).get("name")
-            if isinstance(configured_name, str) and configured_name.strip():
-                name = configured_name.strip()
         except (OSError, UnicodeError, tomllib.TOMLDecodeError):
-            pass
+            configured_name = None
+        else:
+            configured_name = data.get("project", {}).get("name")
+        if isinstance(configured_name, str) and configured_name.strip():
+            name = configured_name.strip()
     paths = detect_project_paths(project_dir)
     package = paths.package_name or name.replace("-", "_")
     return RecipeProject(name=name, package=package)

--- a/cli/arclith_cli/recipe.py
+++ b/cli/arclith_cli/recipe.py
@@ -66,14 +66,21 @@ def snapshot_project_files(project_dir: Path) -> dict[str, str]:
         if _ignore_snapshot_path(relative) or not (path.is_file() or path.is_symlink()):
             continue
         if path.is_symlink():
-            digest = hashlib.sha256(b"symlink").hexdigest()
+            try:
+                target = os.readlink(path)
+            except OSError as exc:
+                raise RecipeError(
+                    f"Unable to inspect generated symlink {relative}: {exc}"
+                ) from exc
+            payload = b"symlink\0" + os.fsencode(target)
         else:
             try:
-                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                payload = b"file\0" + path.read_bytes()
             except OSError as exc:
                 raise RecipeError(
                     f"Unable to inspect generated file {relative}: {exc}"
                 ) from exc
+        digest = hashlib.sha256(payload).hexdigest()
         snapshot[relative.as_posix()] = digest
     return snapshot
 
@@ -196,15 +203,9 @@ def replay_recipe(
     """Replay selected recipe actions through the existing Python command helpers."""
     target_dir = target_dir.resolve()
     target_recipe_existed = (target_dir / RECIPE_FILENAME).is_file()
-    validate_replay_steps(steps, strict=strict)
+    planned_steps = plan_replay_steps(steps, strict=strict)
     prepared: list[tuple[RecipeStep, dict[str, Any]]] = []
-    for step in steps:
-        if step.command not in _SUPPORTED_COMMANDS:
-            if strict:
-                raise RecipeError(
-                    f"Step {step.id} uses unsupported command {step.command!r}."
-                )
-            continue
+    for step in planned_steps:
         prepared.append((step, _hydrate_step_args(step)))
 
     executed: list[str] = []
@@ -213,16 +214,25 @@ def replay_recipe(
         executed.append(step.id)
 
     if executed and target_dir.is_dir() and not target_recipe_existed:
-        selected = tuple(step for step in steps if step.id in executed)
         copied = Recipe(
             version=recipe.version,
             project=recipe.project,
-            created_at=selected[0].at,
-            updated_at=selected[-1].at,
-            steps=selected,
+            created_at=planned_steps[0].at,
+            updated_at=planned_steps[-1].at,
+            steps=planned_steps,
         )
         save_recipe(copied, target_dir / RECIPE_FILENAME)
     return tuple(executed)
+
+
+def plan_replay_steps(
+    steps: tuple[RecipeStep, ...],
+    *,
+    strict: bool,
+) -> tuple[RecipeStep, ...]:
+    """Return the steps that replay will execute after compatibility checks."""
+    validate_replay_steps(steps, strict=strict)
+    return tuple(step for step in steps if step.command in _SUPPORTED_COMMANDS)
 
 
 def validate_replay_steps(

--- a/cli/arclith_cli/recipe_cli.py
+++ b/cli/arclith_cli/recipe_cli.py
@@ -11,11 +11,11 @@ from arclith_cli.recipe import (
     RECIPE_FILENAME,
     RecipeError,
     load_recipe,
+    plan_replay_steps,
     replay_recipe,
     required_replay_env,
     select_recipe_steps,
     step_summary,
-    validate_replay_steps,
 )
 
 console = Console()
@@ -83,7 +83,7 @@ def replay_command(
             from_step=from_step,
             to_step=to_step,
         )
-        validate_replay_steps(steps, strict=strict)
+        planned_steps = plan_replay_steps(steps, strict=strict)
     except RecipeError as exc:
         _recipe_error(exc)
 
@@ -91,24 +91,29 @@ def replay_command(
     table.add_column("ID", style="cyan")
     table.add_column("Commande", style="green")
     table.add_column("Résumé")
+    table.add_column("Action")
+    planned_ids = {step.id for step in planned_steps}
     for step in steps:
-        table.add_row(step.id, step.command, step_summary(step))
+        action = "rejouer" if step.id in planned_ids else "ignorer (non supportée)"
+        table.add_row(step.id, step.command, step_summary(step), action)
     console.print(table)
 
-    required_env = required_replay_env(steps)
+    required_env = required_replay_env(planned_steps)
     if required_env:
         console.print(
             "[yellow]Secrets requis via l'environnement :[/yellow] "
             + ", ".join(required_env)
         )
     if dry_run:
+        skipped_count = len(steps) - len(planned_steps)
         console.print(
-            f"[bold cyan]Dry-run :[/bold cyan] {len(steps)} étape(s), "
-            f"aucune écriture dans {directory}."
+            f"[bold cyan]Dry-run :[/bold cyan] {len(planned_steps)} étape(s) "
+            f"à exécuter, {skipped_count} ignorée(s), aucune écriture dans "
+            f"{directory}."
         )
         return
-    if not steps:
-        console.print("[yellow]Aucune étape à rejouer.[/yellow]")
+    if not planned_steps:
+        console.print("[yellow]Aucune étape supportée à rejouer.[/yellow]")
         return
 
     try:

--- a/cli/arclith_cli/recipe_cli.py
+++ b/cli/arclith_cli/recipe_cli.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Never
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from arclith_cli.recipe import (
+    RECIPE_FILENAME,
+    RecipeError,
+    load_recipe,
+    replay_recipe,
+    required_replay_env,
+    select_recipe_steps,
+    step_summary,
+    validate_replay_steps,
+)
+
+console = Console()
+
+
+def history_command(
+    recipe_path: Annotated[
+        Path,
+        typer.Option(
+            "--recipe",
+            help="Recette à afficher (défaut: arclith.recipe.yaml).",
+        ),
+    ] = Path(RECIPE_FILENAME),
+) -> None:
+    """Afficher la timeline des mutations enregistrées par [bold]arclith-cli[/bold]."""
+    try:
+        recipe = load_recipe(recipe_path)
+    except RecipeError as exc:
+        _recipe_error(exc)
+
+    table = Table(show_header=True, header_style="bold blue", box=None, padding=(0, 2))
+    table.add_column("ID", style="cyan")
+    table.add_column("Date")
+    table.add_column("Commande", style="green")
+    table.add_column("Résumé")
+    for step in recipe.steps:
+        table.add_row(step.id, step.at, step.command, step_summary(step))
+    console.print(table)
+
+
+def replay_command(
+    recipe_path: Annotated[
+        Path,
+        typer.Argument(help="Chemin du fichier arclith.recipe.yaml à rejouer."),
+    ],
+    directory: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Répertoire projet cible."),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Afficher le plan sans modifier le disque."),
+    ] = False,
+    from_step: Annotated[
+        str | None,
+        typer.Option("--from-step", help="Premier id de step à rejouer (inclus)."),
+    ] = None,
+    to_step: Annotated[
+        str | None,
+        typer.Option("--to-step", help="Dernier id de step à rejouer (inclus)."),
+    ] = None,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="Échouer si une commande de la recette n'est pas supportée.",
+        ),
+    ] = False,
+) -> None:
+    """Rejouer une recette via les fonctions Python existantes de la CLI."""
+    try:
+        recipe = load_recipe(recipe_path)
+        steps = select_recipe_steps(
+            recipe,
+            from_step=from_step,
+            to_step=to_step,
+        )
+        validate_replay_steps(steps, strict=strict)
+    except RecipeError as exc:
+        _recipe_error(exc)
+
+    table = Table(show_header=True, header_style="bold blue", box=None, padding=(0, 2))
+    table.add_column("ID", style="cyan")
+    table.add_column("Commande", style="green")
+    table.add_column("Résumé")
+    for step in steps:
+        table.add_row(step.id, step.command, step_summary(step))
+    console.print(table)
+
+    required_env = required_replay_env(steps)
+    if required_env:
+        console.print(
+            "[yellow]Secrets requis via l'environnement :[/yellow] "
+            + ", ".join(required_env)
+        )
+    if dry_run:
+        console.print(
+            f"[bold cyan]Dry-run :[/bold cyan] {len(steps)} étape(s), "
+            f"aucune écriture dans {directory}."
+        )
+        return
+    if not steps:
+        console.print("[yellow]Aucune étape à rejouer.[/yellow]")
+        return
+
+    try:
+        executed = replay_recipe(
+            recipe,
+            steps,
+            target_dir=directory,
+            strict=strict,
+        )
+    except RecipeError as exc:
+        _recipe_error(exc)
+    console.print(
+        f"[bold green]✓ Replay terminé : {len(executed)} étape(s) exécutée(s) "
+        f"dans {directory.resolve()}.[/bold green]"
+    )
+
+
+def _recipe_error(exc: Exception) -> Never:
+    console.print(f"[red]✗ Recette CLI invalide :[/red] {exc}")
+    raise typer.Exit(1)

--- a/cli/arclith_cli/recipe_models.py
+++ b/cli/arclith_cli/recipe_models.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+RECIPE_FILENAME = "arclith.recipe.yaml"
+RECIPE_SCHEMA_VERSION = 1
+REDACTED = "<redacted>"
+EXTERNAL_PATH = "<external-path>"
+
+
+class RecipeError(ValueError):
+    """Raised when a CLI recipe is missing, invalid, or cannot be replayed."""
+
+
+@dataclass(frozen=True)
+class RecipeProject:
+    name: str
+    package: str
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> RecipeProject:
+        data = _require_mapping(raw, "project")
+        return cls(
+            name=_require_string(data.get("name"), "project.name"),
+            package=_require_string(data.get("package"), "project.package"),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "package": self.package}
+
+
+@dataclass(frozen=True)
+class RecipeSecretRef:
+    field_path: str
+    source: str
+    key: str
+    value: str = REDACTED
+
+    @classmethod
+    def from_dict(cls, raw: Any, *, index: int) -> RecipeSecretRef:
+        data = _require_mapping(raw, f"steps[].secrets[{index}]")
+        value = _require_string(data.get("value"), "secret.value")
+        if value != REDACTED:
+            raise RecipeError("A recipe secret reference must contain '<redacted>'.")
+        return cls(
+            field_path=_require_string(data.get("field_path"), "secret.field_path"),
+            source=_require_string(data.get("source"), "secret.source"),
+            key=_require_string(data.get("key"), "secret.key"),
+            value=value,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "field_path": self.field_path,
+            "source": self.source,
+            "key": self.key,
+            "value": self.value,
+        }
+
+
+@dataclass(frozen=True)
+class RecipeFileChange:
+    path: str
+    action: str
+
+    @classmethod
+    def from_dict(cls, raw: Any, *, index: int) -> RecipeFileChange:
+        data = _require_mapping(raw, f"result.generated_files[{index}]")
+        path = _require_relative_path(data.get("path"), "generated file path")
+        action = _require_string(data.get("action"), "generated file action")
+        if action not in {"created", "updated"}:
+            raise RecipeError(
+                f"Unsupported generated file action {action!r}; expected created or updated."
+            )
+        return cls(path=path, action=action)
+
+    def to_dict(self) -> dict[str, str]:
+        return {"path": self.path, "action": self.action}
+
+
+@dataclass(frozen=True)
+class RecipeResult:
+    generated_files: tuple[RecipeFileChange, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> RecipeResult:
+        data = _require_mapping(raw, "step.result")
+        files = data.get("generated_files", [])
+        if not isinstance(files, list):
+            raise RecipeError("step.result.generated_files must be a list.")
+        return cls(
+            generated_files=tuple(
+                RecipeFileChange.from_dict(item, index=index)
+                for index, item in enumerate(files)
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"generated_files": [item.to_dict() for item in self.generated_files]}
+
+
+@dataclass(frozen=True)
+class RecipeStep:
+    id: str
+    at: str
+    cli_version: str
+    command: str
+    status: str
+    args: dict[str, Any]
+    secrets: tuple[RecipeSecretRef, ...] = ()
+    result: RecipeResult = field(default_factory=RecipeResult)
+
+    @classmethod
+    def from_dict(cls, raw: Any, *, index: int) -> RecipeStep:
+        data = _require_mapping(raw, f"steps[{index}]")
+        step_id = _require_string(data.get("id"), f"steps[{index}].id")
+        if not re.fullmatch(r"\d{4}", step_id):
+            raise RecipeError(
+                f"Invalid recipe step id {step_id!r}; expected four digits."
+            )
+        status = _require_string(data.get("status"), f"steps[{index}].status")
+        if status != "success":
+            raise RecipeError(
+                f"Unsupported recipe step status {status!r}; only successful steps are replayable."
+            )
+        at = _require_aware_timestamp(data.get("at"), f"steps[{index}].at")
+        args = _require_mapping(data.get("args", {}), f"steps[{index}].args")
+        secrets_raw = data.get("secrets", [])
+        if not isinstance(secrets_raw, list):
+            raise RecipeError(f"steps[{index}].secrets must be a list.")
+        return cls(
+            id=step_id,
+            at=at,
+            cli_version=_require_string(
+                data.get("cli_version"), f"steps[{index}].cli_version"
+            ),
+            command=_require_string(data.get("command"), f"steps[{index}].command"),
+            status=status,
+            args=dict(args),
+            secrets=tuple(
+                RecipeSecretRef.from_dict(item, index=secret_index)
+                for secret_index, item in enumerate(secrets_raw)
+            ),
+            result=RecipeResult.from_dict(data.get("result", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "id": self.id,
+            "at": self.at,
+            "cli_version": self.cli_version,
+            "command": self.command,
+            "status": self.status,
+            "args": self.args,
+        }
+        if self.secrets:
+            data["secrets"] = [secret.to_dict() for secret in self.secrets]
+        data["result"] = self.result.to_dict()
+        return data
+
+
+@dataclass(frozen=True)
+class Recipe:
+    version: int
+    project: RecipeProject
+    created_at: str
+    updated_at: str
+    steps: tuple[RecipeStep, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> Recipe:
+        data = _require_mapping(raw, "recipe")
+        version = data.get("version")
+        if (
+            isinstance(version, bool)
+            or not isinstance(version, int)
+            or version != RECIPE_SCHEMA_VERSION
+        ):
+            raise RecipeError(
+                f"Unsupported recipe schema version {version!r}; "
+                f"this CLI supports version {RECIPE_SCHEMA_VERSION}."
+            )
+        steps_raw = data.get("steps", [])
+        if not isinstance(steps_raw, list):
+            raise RecipeError("recipe.steps must be a list.")
+        steps = tuple(
+            RecipeStep.from_dict(item, index=index)
+            for index, item in enumerate(steps_raw)
+        )
+        ids = [step.id for step in steps]
+        if len(ids) != len(set(ids)):
+            raise RecipeError("Recipe step ids must be unique.")
+        if ids != sorted(ids):
+            raise RecipeError("Recipe steps must be ordered by id.")
+        return cls(
+            version=version,
+            project=RecipeProject.from_dict(data.get("project")),
+            created_at=_require_aware_timestamp(data.get("created_at"), "created_at"),
+            updated_at=_require_aware_timestamp(data.get("updated_at"), "updated_at"),
+            steps=steps,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "project": self.project.to_dict(),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "steps": [step.to_dict() for step in self.steps],
+        }
+
+
+def load_recipe(path: Path) -> Recipe:
+    """Load and validate a versioned CLI recipe."""
+    if not path.is_file():
+        raise RecipeError(f"Recipe file not found: {path}")
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise RecipeError(f"Unable to read recipe {path}: {exc}") from exc
+    if raw is None:
+        raise RecipeError(f"Recipe file is empty: {path}")
+    return Recipe.from_dict(raw)
+
+
+def save_recipe(recipe: Recipe, path: Path) -> None:
+    """Validate and atomically write a recipe in its project directory."""
+    validated = Recipe.from_dict(recipe.to_dict())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = yaml.safe_dump(
+        validated.to_dict(),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(rendered)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.chmod(0o644)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _require_mapping(raw: Any, label: str) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise RecipeError(f"{label} must be a mapping.")
+    if not all(isinstance(key, str) for key in raw):
+        raise RecipeError(f"{label} keys must be strings.")
+    return raw
+
+
+def _require_string(raw: Any, label: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise RecipeError(f"{label} must be a non-empty string.")
+    return raw
+
+
+def _require_aware_timestamp(raw: Any, label: str) -> str:
+    value = _require_string(raw, label)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise RecipeError(f"{label} must be an ISO 8601 timestamp.") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RecipeError(f"{label} must include a timezone offset.")
+    return value
+
+
+def _require_relative_path(raw: Any, label: str) -> str:
+    value = _require_string(raw, label)
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise RecipeError(f"{label} must be relative to the project root: {value}")
+    return path.as_posix()

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+from arclith_cli.recipe import RECIPE_FILENAME, load_recipe
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -73,6 +75,9 @@ def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Pat
     assert "repository: memory" in (project_dir / "config" / "adapters" / "adapters.yaml").read_text(
         encoding="utf-8"
     )
+    assert [
+        step.command for step in load_recipe(project_dir / RECIPE_FILENAME).steps
+    ] == ["init"]
 
     result = subprocess.run(
         ["arclith-cli", "add-entity", "Todo"],
@@ -151,6 +156,9 @@ def test_scaffold_and_run(temp_workspace: Path):
     assert (project_dir / "pyproject.toml").exists()
     assert (project_dir / "main.py").exists()
     assert (project_dir / "config").is_dir()
+    assert [
+        step.command for step in load_recipe(project_dir / RECIPE_FILENAME).steps
+    ] == ["new"]
     
     # Step 2 — verify no [tool.uv.sources] in generated pyproject.toml
     pyproject_content = (project_dir / "pyproject.toml").read_text()

--- a/cli/tests/test_recipe.py
+++ b/cli/tests/test_recipe.py
@@ -12,6 +12,7 @@ from arclith_cli.recipe import (
     REDACTED,
     RecipeError,
     load_recipe,
+    record_successful_step,
 )
 
 runner = CliRunner()
@@ -442,3 +443,20 @@ def test_history_reports_missing_recipe(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Recipe file not found" in result.output
+
+
+def test_recipe_identity_falls_back_when_pyproject_is_malformed(tmp_path: Path) -> None:
+    project_dir = tmp_path / "fallback-service"
+    (project_dir / "src" / "fallback_service").mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text("[invalid", encoding="utf-8")
+
+    record_successful_step(
+        project_dir,
+        command="add-entity",
+        args={"entity": "Widget"},
+        before={},
+    )
+
+    recipe = load_recipe(project_dir / RECIPE_FILENAME)
+    assert recipe.project.name == "fallback-service"
+    assert recipe.project.package == "fallback_service"

--- a/cli/tests/test_recipe.py
+++ b/cli/tests/test_recipe.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from arclith_cli.main import app
+from arclith_cli.recipe import (
+    RECIPE_FILENAME,
+    REDACTED,
+    RecipeError,
+    load_recipe,
+)
+
+runner = CliRunner()
+
+
+def _init_project(tmp_path: Path, name: str = "demo-service") -> Path:
+    result = runner.invoke(app, ["init", name, "--dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    return tmp_path / name
+
+
+def _invoke_in_project(
+    monkeypatch: pytest.MonkeyPatch,
+    project_dir: Path,
+    arguments: list[str],
+):
+    monkeypatch.chdir(project_dir)
+    return runner.invoke(app, arguments)
+
+
+def test_init_creates_versioned_recipe_with_relative_files(tmp_path: Path) -> None:
+    project_dir = _init_project(tmp_path)
+
+    recipe = load_recipe(project_dir / RECIPE_FILENAME)
+
+    assert recipe.version == 1
+    assert recipe.project.name == "demo-service"
+    assert recipe.project.package == "demo_service"
+    assert [step.command for step in recipe.steps] == ["init"]
+    assert recipe.steps[0].args == {
+        "project_name": "demo-service",
+        "directory": ".",
+    }
+    assert recipe.steps[0].result.generated_files
+    assert all(
+        not Path(change.path).is_absolute()
+        for change in recipe.steps[0].result.generated_files
+    )
+    assert all(
+        RECIPE_FILENAME != change.path
+        for change in recipe.steps[0].result.generated_files
+    )
+
+
+def test_new_creates_recipe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_new_project_cmd(**kwargs: object) -> Path:
+        target = Path(str(kwargs["directory"])) / str(kwargs["project_name"])
+        package = str(kwargs["project_name"]).replace("-", "_")
+        (target / "src" / package).mkdir(parents=True)
+        (target / "src" / package / "__init__.py").write_text("", encoding="utf-8")
+        (target / "pyproject.toml").write_text(
+            f'[project]\nname = "{kwargs["project_name"]}"\n',
+            encoding="utf-8",
+        )
+        return target
+
+    monkeypatch.setattr("arclith_cli.main._new_project_cmd", fake_new_project_cmd)
+
+    result = runner.invoke(
+        app,
+        [
+            "new",
+            "Widget",
+            "template-service",
+            "--dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    recipe = load_recipe(tmp_path / "template-service" / RECIPE_FILENAME)
+    assert [step.command for step in recipe.steps] == ["new"]
+    assert recipe.steps[0].args == {
+        "entity": "Widget",
+        "project_name": "template-service",
+        "directory": ".",
+        "port": 8000,
+        "repo_ref": "main",
+    }
+
+
+def test_core_commands_append_only_after_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+
+    for arguments in (
+        ["add-entity", "ShoppingItem"],
+        ["add-usecase", "PlanShoppingList"],
+        ["add-intent-interpreter", "ShoppingIntent"],
+    ):
+        result = _invoke_in_project(monkeypatch, project_dir, arguments)
+        assert result.exit_code == 0, result.output
+
+    recipe = load_recipe(project_dir / RECIPE_FILENAME)
+    assert [step.command for step in recipe.steps] == [
+        "init",
+        "add-entity",
+        "add-usecase",
+        "add-intent-interpreter",
+    ]
+    assert [step.id for step in recipe.steps] == ["0001", "0002", "0003", "0004"]
+
+    failed = _invoke_in_project(
+        monkeypatch,
+        project_dir,
+        ["add-entity", "ShoppingItem"],
+    )
+    assert failed.exit_code == 1
+    assert len(load_recipe(project_dir / RECIPE_FILENAME).steps) == 4
+
+
+def test_add_adapter_records_resolved_params_and_generated_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    assert (
+        _invoke_in_project(monkeypatch, project_dir, ["add-entity", "Widget"]).exit_code
+        == 0
+    )
+
+    result = _invoke_in_project(
+        monkeypatch,
+        project_dir,
+        [
+            "add-adapter",
+            "--capability",
+            "repository",
+            "--adapter",
+            "memory",
+            "--entity",
+            "Widget",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    step = load_recipe(project_dir / RECIPE_FILENAME).steps[-1]
+    assert step.command == "add-adapter"
+    assert step.args == {
+        "capability": "repository",
+        "adapter": "memory",
+        "entities": ["Widget"],
+        "activate": True,
+        "profile": None,
+        "params": {},
+    }
+    changed_paths = {change.path for change in step.result.generated_files}
+    assert (
+        "src/demo_service/adapters/outbound/memory/repositories/widget_repository.py"
+        in changed_paths
+    )
+    assert "config/adapters/adapters.yaml" not in changed_paths
+
+
+def test_interactive_and_direct_adapter_inputs_record_the_same_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    direct_project = _init_project(tmp_path, "direct-service")
+    interactive_project = _init_project(tmp_path, "interactive-service")
+    for project_dir in (direct_project, interactive_project):
+        assert (
+            _invoke_in_project(
+                monkeypatch, project_dir, ["add-entity", "Widget"]
+            ).exit_code
+            == 0
+        )
+
+    direct = _invoke_in_project(
+        monkeypatch,
+        direct_project,
+        ["add-adapter", "--adapter", "memory", "--entity", "Widget", "--yes"],
+    )
+    assert direct.exit_code == 0, direct.output
+    monkeypatch.chdir(interactive_project)
+    interactive = runner.invoke(
+        app,
+        ["add-adapter", "--adapter", "memory"],
+        input="\n\n",
+    )
+    assert interactive.exit_code == 0, interactive.output
+
+    direct_args = load_recipe(direct_project / RECIPE_FILENAME).steps[-1].args
+    interactive_args = load_recipe(interactive_project / RECIPE_FILENAME).steps[-1].args
+    assert direct_args == interactive_args
+
+
+def test_add_adapter_redacts_catalog_and_uri_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    secret_uri = "redis://recipe-user:never-write-me@redis:6379/0"
+
+    result = _invoke_in_project(
+        monkeypatch,
+        project_dir,
+        [
+            "add-adapter",
+            "--capability",
+            "cache",
+            "--adapter",
+            "redis",
+            "--param",
+            f"redis_url={secret_uri}",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    recipe_path = project_dir / RECIPE_FILENAME
+    raw = recipe_path.read_text(encoding="utf-8")
+    step = load_recipe(recipe_path).steps[-1]
+    assert "never-write-me" not in raw
+    assert step.args["params"]["redis_url"] == REDACTED
+    assert {
+        (secret.field_path, secret.source, secret.key) for secret in step.secrets
+    } == {
+        ("args.params.redis_url", "env", "REDIS_URL"),
+        ("cache.redis_url", "env", "REDIS_URL"),
+    }
+
+
+def test_history_displays_ordered_timeline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    assert (
+        _invoke_in_project(monkeypatch, project_dir, ["add-entity", "Widget"]).exit_code
+        == 0
+    )
+
+    result = _invoke_in_project(monkeypatch, project_dir, ["history"])
+
+    assert result.exit_code == 0, result.output
+    assert "0001" in result.output
+    assert "init" in result.output
+    assert "0002" in result.output
+    assert "add-entity" in result.output
+    assert "Widget" in result.output
+
+
+def test_replay_dry_run_does_not_touch_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    assert (
+        _invoke_in_project(monkeypatch, project_dir, ["add-entity", "Widget"]).exit_code
+        == 0
+    )
+    target = tmp_path / "dry-run-target"
+
+    result = runner.invoke(
+        app,
+        [
+            "replay",
+            str(project_dir / RECIPE_FILENAME),
+            "--dir",
+            str(target),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Dry-run" in result.output
+    assert "add-entity" in result.output
+    assert not target.exists()
+
+
+def test_strict_dry_run_rejects_unknown_command_without_writing(
+    tmp_path: Path,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    recipe_path = project_dir / RECIPE_FILENAME
+    raw = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
+    unknown = dict(raw["steps"][0])
+    unknown.update({"id": "0002", "command": "add-blueprint"})
+    raw["steps"].append(unknown)
+    recipe_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    target = tmp_path / "strict-target"
+
+    result = runner.invoke(
+        app,
+        [
+            "replay",
+            str(recipe_path),
+            "--dir",
+            str(target),
+            "--dry-run",
+            "--strict",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported recipe commands" in result.output
+    assert not target.exists()
+
+
+def test_replay_preflights_missing_secrets_before_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    result = _invoke_in_project(
+        monkeypatch,
+        project_dir,
+        [
+            "add-adapter",
+            "--capability",
+            "cache",
+            "--adapter",
+            "redis",
+            "--param",
+            "redis_url=redis://user:password@redis:6379/0",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    target = tmp_path / "missing-secret-target"
+
+    replayed = runner.invoke(
+        app,
+        [
+            "replay",
+            str(project_dir / RECIPE_FILENAME),
+            "--dir",
+            str(target),
+        ],
+    )
+
+    assert replayed.exit_code == 1
+    assert "requires environment variable REDIS_URL" in replayed.output
+    assert not target.exists()
+
+
+def test_replay_rebuilds_minimal_project_without_duplicate_steps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _init_project(tmp_path, "source-service")
+    for arguments in (
+        ["add-entity", "Widget"],
+        ["add-usecase", "CreateWidget"],
+        [
+            "add-adapter",
+            "--capability",
+            "repository",
+            "--adapter",
+            "memory",
+            "--entity",
+            "Widget",
+            "--yes",
+        ],
+    ):
+        result = _invoke_in_project(monkeypatch, project_dir, arguments)
+        assert result.exit_code == 0, result.output
+
+    recipe_path = project_dir / RECIPE_FILENAME
+    target = tmp_path / "rebuilt-project"
+    result = runner.invoke(
+        app,
+        ["replay", str(recipe_path), "--dir", str(target)],
+    )
+
+    assert result.exit_code == 0, result.output
+    package_root = target / "src" / "source_service"
+    assert (package_root / "domain" / "models" / "widget.py").is_file()
+    assert (package_root / "application" / "use_cases" / "create_widget.py").is_file()
+    assert (
+        package_root
+        / "adapters"
+        / "outbound"
+        / "memory"
+        / "repositories"
+        / "widget_repository.py"
+    ).is_file()
+    source = load_recipe(recipe_path)
+    replayed = load_recipe(target / RECIPE_FILENAME)
+    assert [step.id for step in replayed.steps] == [step.id for step in source.steps]
+    assert [step.command for step in replayed.steps] == [
+        step.command for step in source.steps
+    ]
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("", "empty"),
+        (
+            yaml.safe_dump(
+                {
+                    "version": 999,
+                    "project": {"name": "demo", "package": "demo"},
+                    "created_at": "2026-09-01T00:00:00+00:00",
+                    "updated_at": "2026-09-01T00:00:00+00:00",
+                    "steps": [],
+                }
+            ),
+            "Unsupported recipe schema version",
+        ),
+    ],
+)
+def test_load_recipe_rejects_empty_or_unsupported_schema(
+    tmp_path: Path,
+    content: str,
+    message: str,
+) -> None:
+    recipe_path = tmp_path / RECIPE_FILENAME
+    recipe_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(RecipeError, match=message):
+        load_recipe(recipe_path)
+
+
+def test_history_reports_missing_recipe(tmp_path: Path) -> None:
+    missing = tmp_path / RECIPE_FILENAME
+
+    result = runner.invoke(app, ["history", "--recipe", str(missing)])
+
+    assert result.exit_code == 1
+    assert "Recipe file not found" in result.output

--- a/cli/tests/test_recipe.py
+++ b/cli/tests/test_recipe.py
@@ -13,6 +13,7 @@ from arclith_cli.recipe import (
     RecipeError,
     load_recipe,
     record_successful_step,
+    snapshot_project_files,
 )
 
 runner = CliRunner()
@@ -287,6 +288,79 @@ def test_replay_dry_run_does_not_touch_target(
     assert result.exit_code == 0, result.output
     assert "Dry-run" in result.output
     assert "add-entity" in result.output
+    assert not target.exists()
+
+
+def test_snapshot_detects_symlink_target_changes(tmp_path: Path) -> None:
+    link = tmp_path / "current-config"
+    link.symlink_to("config-v1.yaml")
+    before = snapshot_project_files(tmp_path)
+
+    link.unlink()
+    link.symlink_to("config-v2.yaml")
+    after = snapshot_project_files(tmp_path)
+
+    assert before[link.name] != after[link.name]
+
+
+def test_snapshot_reports_unreadable_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    link = tmp_path / "current-config"
+    link.symlink_to("config-v1.yaml")
+
+    def fail_readlink(path: Path) -> str:
+        raise OSError("readlink denied")
+
+    monkeypatch.setattr("arclith_cli.recipe.os.readlink", fail_readlink)
+
+    with pytest.raises(RecipeError, match="Unable to inspect generated symlink"):
+        snapshot_project_files(tmp_path)
+
+
+def test_non_strict_dry_run_marks_unsupported_steps_as_ignored(
+    tmp_path: Path,
+) -> None:
+    project_dir = _init_project(tmp_path)
+    recipe_path = project_dir / RECIPE_FILENAME
+    raw = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
+    unknown = dict(raw["steps"][0])
+    unknown.update(
+        {
+            "id": "0002",
+            "command": "add-blueprint",
+            "args": {"token": REDACTED},
+            "secrets": [
+                {
+                    "field_path": "args.token",
+                    "source": "env",
+                    "key": "IGNORED_BLUEPRINT_TOKEN",
+                    "value": REDACTED,
+                }
+            ],
+        }
+    )
+    raw["steps"].append(unknown)
+    recipe_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    target = tmp_path / "non-strict-target"
+
+    result = runner.invoke(
+        app,
+        [
+            "replay",
+            str(recipe_path),
+            "--dir",
+            str(target),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "add-blueprint" in result.output
+    assert "ignorer (non supportée)" in result.output
+    assert "1 étape(s) à exécuter, 1 ignorée(s)" in result.output
+    assert "IGNORED_BLUEPRINT_TOKEN" not in result.output
     assert not target.exists()
 
 

--- a/docs/cli-recipe.md
+++ b/docs/cli-recipe.md
@@ -1,0 +1,195 @@
+# Recettes Arclith CLI
+
+Une recette CLI conserve la suite des décisions de scaffolding prises avec
+`arclith-cli`. Chaque projet créé par `init` ou `new` reçoit un fichier
+`arclith.recipe.yaml` à sa racine.
+
+La recette répond à trois besoins :
+
+- relire l'ordre des commandes mutantes réussies ;
+- revoir les paramètres résolus après un wizard ou des options directes ;
+- reconstruire un projet équivalent sans rejouer des commandes shell.
+
+## Recette, Git et configuration exportée
+
+Ces trois artefacts sont complémentaires :
+
+| Artefact | Source de vérité pour | Ne contient pas |
+|---|---|---|
+| Git | l'historique exact du code et des modifications manuelles | une intention fonctionnelle rejouable hors des commits |
+| `arclith.recipe.yaml` | les mutations réussies réalisées par la CLI | les modifications manuelles, les échecs ou les secrets |
+| `arclith-cli export-config` | la configuration consolidée à déployer | l'ordre de construction du projet |
+
+La recette ne remplace donc jamais Git. Elle décrit uniquement les opérations
+Arclith connues de la CLI.
+
+## Commandes enregistrées
+
+La version 1 enregistre :
+
+- `init` et `new` ;
+- `add-entity` ;
+- `add-usecase` ;
+- `add-intent-interpreter` ;
+- `add-adapter`.
+
+Une étape est ajoutée uniquement après le succès complet de la commande. Une
+confirmation refusée, une erreur de validation ou une génération échouée ne
+modifie pas la recette.
+
+Les fichiers créés ou mis à jour sont détectés après la commande. Leurs chemins
+sont toujours relatifs à la racine du projet. Les environnements virtuels,
+caches, métadonnées Git et la recette elle-même ne font pas partie du résultat.
+
+## Format versionné
+
+Le fichier est du YAML structuré, écrit atomiquement et validé au chargement.
+La version initiale du schéma est `1` :
+
+```yaml
+version: 1
+project:
+  name: todo-service
+  package: todo_service
+created_at: "2026-09-01T10:00:00+00:00"
+updated_at: "2026-09-01T10:04:00+00:00"
+steps:
+  - id: "0001"
+    at: "2026-09-01T10:00:00+00:00"
+    cli_version: "0.17.0"
+    command: init
+    status: success
+    args:
+      project_name: todo-service
+      directory: .
+    result:
+      generated_files:
+        - path: pyproject.toml
+          action: created
+  - id: "0002"
+    at: "2026-09-01T10:04:00+00:00"
+    cli_version: "0.17.0"
+    command: add-entity
+    status: success
+    args:
+      entity: Todo
+    result:
+      generated_files:
+        - path: src/todo_service/domain/models/todo.py
+          action: created
+```
+
+Les timestamps ISO 8601 incluent toujours leur fuseau. Les identifiants à
+quatre chiffres restent stables pour sélectionner une plage de replay.
+
+## Lire l'historique
+
+Depuis la racine du projet :
+
+```bash
+arclith-cli history
+```
+
+Pour inspecter un autre fichier :
+
+```bash
+arclith-cli history --recipe ../service/arclith.recipe.yaml
+```
+
+La timeline affiche l'id, la date, la commande et un résumé sans secret.
+
+## Prévisualiser un replay
+
+Le dry-run valide la recette et affiche les actions sans créer le dossier cible :
+
+```bash
+arclith-cli replay arclith.recipe.yaml \
+  --dir ../todo-service-rebuilt \
+  --dry-run
+```
+
+La valeur de `--dir` désigne la racine exacte du projet cible. Le nom et le
+package fonctionnels restent ceux de la recette, même si le dossier cible porte
+un autre nom.
+
+Une plage inclusive peut être sélectionnée :
+
+```bash
+arclith-cli replay arclith.recipe.yaml \
+  --dir ../existing-service \
+  --from-step 0003 \
+  --to-step 0008 \
+  --dry-run
+```
+
+Si la plage ne contient pas `init` ou `new`, la cible doit déjà être un projet
+compatible. `--strict` refuse toute commande que la version courante de la CLI
+ne sait pas rejouer.
+
+## Exécuter un replay
+
+Retirer `--dry-run` pour reconstruire le projet :
+
+```bash
+arclith-cli replay arclith.recipe.yaml --dir ../todo-service-rebuilt
+```
+
+Le replay appelle directement `init_project_cmd`, `add_entity_cmd`,
+`add_usecase_cmd`, `add_intent_interpreter_cmd` et `add_adapter_cmd`. Il ne
+construit pas une ligne de commande shell, ce qui évite les différences de
+quoting et garde les erreurs testables.
+
+Les étapes rejouées ne sont pas enregistrées une seconde fois. Pour une cible
+nouvelle, la recette sélectionnée est copiée une seule fois après le succès du
+replay. Pour un projet existant qui possède déjà sa recette, celle-ci n'est pas
+modifiée implicitement.
+
+## Secrets
+
+Une recette ne stocke jamais de secret en clair. La CLI combine :
+
+- les paramètres `secret` du catalogue d'adapters ;
+- les mappings vers les variables d'environnement déjà déclarés par les
+  adapters ;
+- une heuristique défensive sur `password`, `passwd`, `secret`, `token`,
+  `api_key`, `apikey`, `credential` et les URI/URL avec credentials.
+
+Une valeur sensible est remplacée par `<redacted>` et accompagnée d'une
+référence :
+
+```yaml
+args:
+  capability: cache
+  adapter: redis
+  params:
+    redis_url: <redacted>
+secrets:
+  - field_path: args.params.redis_url
+    source: env
+    key: REDIS_URL
+    value: <redacted>
+```
+
+Le dry-run liste les variables nécessaires sans lire ni afficher leur valeur.
+Le replay réel exige leur présence dans l'environnement :
+
+```bash
+REDIS_URL='redis://redis:6379/0' \
+  arclith-cli replay arclith.recipe.yaml --dir ../service-rebuilt
+```
+
+Une référence de secret de configuration, par exemple
+`adapters.mongodb.uri -> MONGODB_URI`, reste informative lorsque la génération
+produit déjà `config/secrets.yaml`. Seuls les champs `args.*` sont injectés dans
+les paramètres du replay.
+
+Les chemins absolus externes ne sont pas portables : ils sont remplacés par
+`<external-path>` et doivent être corrigés avant un replay réel.
+
+## Limites de la version 1
+
+- les changements manuels ne sont ni détectés comme commandes ni rejoués ;
+- les échecs et annulations ne forment pas un audit log ;
+- une version de schéma inconnue est refusée plutôt que devinée ;
+- `new` recharge le template depuis le `repo_ref` enregistré : pour des
+  reconstructions durables, utiliser un tag ou une référence Git stable.

--- a/docs/cli-recipe.md
+++ b/docs/cli-recipe.md
@@ -123,8 +123,11 @@ arclith-cli replay arclith.recipe.yaml \
 ```
 
 Si la plage ne contient pas `init` ou `new`, la cible doit déjà être un projet
-compatible. `--strict` refuse toute commande que la version courante de la CLI
-ne sait pas rejouer.
+compatible. Le plan affiche chaque étape comme `rejouer` ou
+`ignorer (non supportée)` et compte uniquement les étapes réellement
+exécutables. Les secrets d'une étape ignorée ne sont pas demandés. `--strict`
+refuse au contraire toute commande que la version courante de la CLI ne sait
+pas rejouer.
 
 ## Exécuter un replay
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,6 +33,11 @@ arclith-cli add-entity Todo
 arclith-cli add-usecase CreateTodo
 ```
 
+Chaque commande mutante réussie enrichit `arclith.recipe.yaml`. Ce fichier
+versionné conserve les décisions de scaffolding sans remplacer Git et sans
+stocker de secret. Consulter la timeline avec `arclith-cli history`, puis lire
+le guide [Recettes Arclith CLI](cli-recipe.md) pour le dry-run et le replay.
+
 Pour tester une branche de développement avant merge:
 
 ```bash

--- a/journal/2026-09-01-cli-recipe.md
+++ b/journal/2026-09-01-cli-recipe.md
@@ -1,0 +1,35 @@
+# CLI recipe : historique et replay des mutations
+
+## Contexte
+
+L'issue #175 demande une trace lisible, versionnée et rejouable des décisions
+prises via `arclith-cli`, distincte de Git et de `export-config`.
+
+## Changements
+
+- ajout du schéma YAML `version: 1` et des modèles `Recipe`, `RecipeStep`,
+  `RecipeSecretRef` et `RecipeResult` ;
+- séparation SRP entre modèles/validation YAML, enregistrement/replay, handlers
+  Typer et scaffolding du projet `new` ;
+- écriture atomique de `arclith.recipe.yaml` après chaque mutation réussie ;
+- capture des paramètres résolus et des fichiers créés ou mis à jour avec des
+  chemins relatifs ;
+- redaction des secrets par métadonnées du catalogue et heuristique défensive ;
+- ajout des commandes `history` et `replay`, du dry-run, des bornes de steps et
+  du mode strict ;
+- replay direct des fonctions Python existantes, sans shell et sans double
+  enregistrement ;
+- documentation Pages, README CLI et quickstart mis à jour.
+
+## Validation prévue
+
+- tests ciblés du module recipe et des commandes mutantes ;
+- suite CLI complète ;
+- `make precommit`, `make coverage` et `make docs` à la racine ;
+- vérification des lockfiles racine et CLI.
+
+## Compatibilité et risques
+
+Le runtime `arclith` et le catalogue de capabilities ne changent pas. La
+recette est une utilité CLI KISS. Le schéma inconnu est refusé explicitement et
+les chemins absolus externes ne sont jamais persistés tels quels.

--- a/journal/2026-09-01-cli-recipe.md
+++ b/journal/2026-09-01-cli-recipe.md
@@ -17,6 +17,10 @@ prises via `arclith-cli`, distincte de Git et de `export-config`.
 - redaction des secrets par métadonnées du catalogue et heuristique défensive ;
 - ajout des commandes `history` et `replay`, du dry-run, des bornes de steps et
   du mode strict ;
+- alignement du plan de dry-run sur les étapes réellement rejouables et
+  signalement explicite des commandes ignorées hors mode strict ;
+- empreinte des liens symboliques fondée sur leur cible pour détecter leurs
+  mises à jour ;
 - replay direct des fonctions Python existantes, sans shell et sans double
   enregistrement ;
 - documentation Pages, README CLI et quickstart mis à jour.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Comprendre le modèle: learning/foundations.md
       - Le chemin hexagonal: foundations/hexagonal-flow.md
       - Modes runtime: foundations/runtime-modes.md
+      - Recettes CLI: cli-recipe.md
   - Formation:
       - Parcours: learning/training-path.md
       - Quickstarts essentiels: learning/quickstarts.md


### PR DESCRIPTION
## Context

Closes #175.

Target: `karned-rekipe/arclith` `main`. This adds a versioned functional recipe for successful Arclith CLI mutations, distinct from Git history and `export-config`.

## Main changes

- create and atomically update `arclith.recipe.yaml` for `init`, `new`, `add-entity`, `add-usecase`, `add-intent-interpreter`, and `add-adapter`;
- record resolved adapter parameters and relative created/updated file paths only after complete success;
- redact catalogue secrets and defensive sensitive-name or credentialed-URI matches into replayable environment references;
- add `history` and Python-native `replay` with dry-run, inclusive step ranges, strict compatibility, secret preflight, and no duplicate recording;
- keep modules focused by separating recipe models, engine, Typer handlers, and template project scaffolding.

## Impact

- CLI behavior and generated project artifact only;
- no runtime Arclith API, domain model, persistent data, RabbitMQ/MCP contract, port, or deployment configuration change;
- no migration or deployment action required;
- no production dependency added and both lockfiles remain unchanged.

## Validation

- `make precommit`;
- `make coverage`: 1,633 passed, 4 skipped, 90.80%;
- `make docs` with MkDocs strict;
- `cd cli && uv run --frozen pytest -q`: 133 passed, 1 skipped;
- targeted CLI Ruff and mypy checks;
- root and CLI `uv lock --check`.

## Documentation

- new Pages guide `docs/cli-recipe.md`;
- CLI README, quickstart, MkDocs navigation, and `journal/2026-09-01-cli-recipe.md` updated;
- ADR not required: this is a scoped CLI utility and does not change runtime architecture.

## Remaining risks

- `new` replay resolves the recorded `repo_ref`; durable recipes should use a stable tag or commit reference;
- real external adapters and services are not contacted by replay tests; replay reconstructs their generated configuration and code.