### PR TITLE
Propager le contexte de trace dans le runtime LangGraph durable

### DIFF
--- a/arclith/adapters/inbound/langgraph_runtime/api.py
+++ b/arclith/adapters/inbound/langgraph_runtime/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Literal
 from uuid import UUID
 
@@ -66,7 +67,11 @@ class RunPayload(BaseModel):
     on_disconnect: Literal["cancel", "continue"] = "cancel"
     multitask_strategy: Literal["reject"] = "reject"
 
-    def as_runtime_request(self) -> RunRequest:
+    def as_runtime_request(
+        self,
+        *,
+        trace_context: Mapping[str, str] | None = None,
+    ) -> RunRequest:
         return RunRequest(
             assistant_id=self.assistant_id,
             input=self.input,
@@ -77,6 +82,7 @@ class RunPayload(BaseModel):
             stream_mode=self.stream_mode,
             on_disconnect=self.on_disconnect,
             multitask_strategy=self.multitask_strategy,
+            trace_context=trace_context,
         )
 
 
@@ -86,6 +92,7 @@ def create_langgraph_runtime_app(runtime: LangGraphRuntime) -> FastAPI:
         version="1.0.0",
     )
     app.state.langgraph_runtime = runtime
+    app.state.observability_runtime = runtime.observability_runtime
     _RuntimeEndpoints(runtime).register(app)
     _register_exception_handlers(app)
     return app
@@ -269,20 +276,35 @@ class _RuntimeEndpoints:
     ) -> list[dict[str, Any]]:
         return await self.runtime.history(str(thread_id), limit=payload.limit)
 
-    async def wait_for_run(self, thread_id: UUID, payload: RunPayload) -> Any:
+    async def wait_for_run(
+        self,
+        thread_id: UUID,
+        payload: RunPayload,
+        request: Request,
+    ) -> Any:
         return await self.runtime.wait(
             str(thread_id),
-            payload.as_runtime_request(),
+            payload.as_runtime_request(
+                trace_context=self.runtime.extract_trace_context(request.headers)
+            ),
         )
 
     async def stream_run(
-        self, thread_id: UUID, payload: RunPayload
+        self,
+        thread_id: UUID,
+        payload: RunPayload,
+        request: Request,
     ) -> StreamingResponse:
         resolved_thread = str(thread_id)
         await self.runtime.get_thread(resolved_thread)
         self.runtime.assistant(payload.assistant_id)
         return StreamingResponse(
-            self.runtime.stream(resolved_thread, payload.as_runtime_request()),
+            self.runtime.stream(
+                resolved_thread,
+                payload.as_runtime_request(
+                    trace_context=self.runtime.extract_trace_context(request.headers)
+                ),
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache, no-store",

--- a/arclith/adapters/inbound/langgraph_runtime/runtime.py
+++ b/arclith/adapters/inbound/langgraph_runtime/runtime.py
@@ -451,7 +451,14 @@ class LangGraphRuntime:
                 metadata=metadata,
             ) as span,
         ):
-            yield span
+            try:
+                yield span
+            except (asyncio.CancelledError, RunCancelledError):
+                span.set_metadata({"langgraph.run.status": "interrupted"})
+                raise
+            except BaseException:
+                span.set_metadata({"langgraph.run.status": "error"})
+                raise
 
     def _graph(self, assistant_id: str) -> Any:
         graph = self.graphs.get(assistant_id)

--- a/arclith/adapters/inbound/langgraph_runtime/runtime.py
+++ b/arclith/adapters/inbound/langgraph_runtime/runtime.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Mapping
-from contextlib import asynccontextmanager, suppress
+from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager, contextmanager, suppress
 from dataclasses import dataclass
 from typing import Any
 
@@ -22,6 +22,11 @@ from arclith.adapters.inbound.langgraph_runtime.serialization import (
     safe_error,
     snapshot_to_dict,
     sse_event,
+)
+from arclith.adapters.outbound.noop.observability import NoOpObservabilityRuntime
+from arclith.domain.ports.outbound.observability import (
+    ObservabilityRuntimePort,
+    TraceSpan,
 )
 
 
@@ -56,6 +61,7 @@ class RunRequest:
     stream_mode: str | list[str] | None = None
     on_disconnect: str = "cancel"
     multitask_strategy: str = "reject"
+    trace_context: Mapping[str, str] | None = None
 
 
 class LangGraphRuntime:
@@ -67,6 +73,7 @@ class LangGraphRuntime:
         *,
         run_timeout_seconds: int = 900,
         cancel_poll_seconds: float = 0.2,
+        observability_runtime: ObservabilityRuntimePort | None = None,
     ) -> None:
         if not graphs:
             raise ValueError("Le runtime LangGraph exige au moins un graphe")
@@ -79,6 +86,14 @@ class LangGraphRuntime:
         self.coordinator = coordinator
         self.run_timeout_seconds = run_timeout_seconds
         self.cancel_poll_seconds = cancel_poll_seconds
+        self.observability_runtime = (
+            observability_runtime
+            if observability_runtime is not None
+            else NoOpObservabilityRuntime()
+        )
+
+    def extract_trace_context(self, carrier: Mapping[str, str]) -> dict[str, str]:
+        return dict(self.observability_runtime.propagator.extract(carrier))
 
     async def setup(self) -> None:
         await self.catalog.setup()
@@ -177,20 +192,22 @@ class LangGraphRuntime:
         await self.get_thread(thread_id)
         graph = self._graph(request.assistant_id)
         async with self._run_session(thread_id, request) as run:
-            async with asyncio.timeout(self.run_timeout_seconds):
-                output = await self._invoke(
-                    graph,
-                    thread_id,
+            with self._trace_execution(thread_id, run.run_id, request) as span:
+                async with asyncio.timeout(self.run_timeout_seconds):
+                    output = await self._invoke(
+                        graph,
+                        thread_id,
+                        run.run_id,
+                        request,
+                    )
+                encoded = jsonable(output)
+                await self.catalog.finish_run(
                     run.run_id,
-                    request,
+                    status="success",
+                    output=encoded,
                 )
-            encoded = jsonable(output)
-            await self.catalog.finish_run(
-                run.run_id,
-                status="success",
-                output=encoded,
-            )
-            return encoded
+                span.set_metadata({"langgraph.run.status": "success"})
+                return encoded
 
     async def stream(
         self,
@@ -202,30 +219,32 @@ class LangGraphRuntime:
         stream = None
         try:
             async with self._run_session(thread_id, request) as run:
-                async with asyncio.timeout(self.run_timeout_seconds):
-                    modes = _stream_modes(request.stream_mode)
-                    stream = graph.astream(
-                        _run_input(request),
-                        _graph_config(thread_id, request),
-                        stream_mode=modes,
-                    )
-                    yield sse_event(
-                        "metadata",
-                        {"run_id": run.run_id, "thread_id": thread_id},
-                    )
-                    async for mode, chunk in self._cancel_aware_stream(
-                        stream,
+                with self._trace_execution(thread_id, run.run_id, request) as span:
+                    async with asyncio.timeout(self.run_timeout_seconds):
+                        modes = _stream_modes(request.stream_mode)
+                        stream = graph.astream(
+                            _run_input(request),
+                            _graph_config(thread_id, request),
+                            stream_mode=modes,
+                        )
+                        yield sse_event(
+                            "metadata",
+                            {"run_id": run.run_id, "thread_id": thread_id},
+                        )
+                        async for mode, chunk in self._cancel_aware_stream(
+                            stream,
+                            run.run_id,
+                            modes,
+                        ):
+                            yield sse_event(mode, chunk)
+                    state = await graph.aget_state(_graph_config(thread_id, None))
+                    output = jsonable(state.values) if state.config else None
+                    await self.catalog.finish_run(
                         run.run_id,
-                        modes,
-                    ):
-                        yield sse_event(mode, chunk)
-                state = await graph.aget_state(_graph_config(thread_id, None))
-                output = jsonable(state.values) if state.config else None
-                await self.catalog.finish_run(
-                    run.run_id,
-                    status="success",
-                    output=output,
-                )
+                        status="success",
+                        output=output,
+                    )
+                    span.set_metadata({"langgraph.run.status": "success"})
         except asyncio.CancelledError:
             raise
         except RunBusyError:
@@ -409,6 +428,30 @@ class LangGraphRuntime:
     async def _wait_for_cancel(self, run_id: str) -> None:
         while not await self.coordinator.is_cancelled(run_id):
             await asyncio.sleep(self.cancel_poll_seconds)
+
+    @contextmanager
+    def _trace_execution(
+        self,
+        thread_id: str,
+        run_id: str,
+        request: RunRequest,
+    ) -> Iterator[TraceSpan]:
+        metadata = {
+            "langgraph.thread_id": thread_id,
+            "langgraph.run_id": run_id,
+            "langgraph.assistant_id": request.assistant_id,
+        }
+        parent = self.extract_trace_context(request.trace_context or {})
+        with (
+            self.observability_runtime.propagator.context(parent),
+            self.observability_runtime.tracer.span(
+                "langgraph.runtime.run",
+                kind="server",
+                tags=("langgraph-runtime",),
+                metadata=metadata,
+            ) as span,
+        ):
+            yield span
 
     def _graph(self, assistant_id: str) -> Any:
         graph = self.graphs.get(assistant_id)

--- a/arclith/adapters/inbound/langgraph_runtime/server.py
+++ b/arclith/adapters/inbound/langgraph_runtime/server.py
@@ -20,6 +20,11 @@ from arclith.adapters.inbound.langgraph_runtime.coordination import (
 )
 from arclith.adapters.inbound.langgraph_runtime.loader import load_graphs
 from arclith.adapters.inbound.langgraph_runtime.runtime import LangGraphRuntime
+from arclith.adapters.outbound.noop.observability import NoOpObservabilityRuntime
+from arclith.domain.ports.outbound.observability import ObservabilityRuntimePort
+from arclith.infrastructure.langgraph_bootstrap import (
+    LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR,
+)
 
 
 def create_durable_langgraph_runtime_app(
@@ -29,6 +34,7 @@ def create_durable_langgraph_runtime_app(
     redis_uri: str | None = None,
     redis_prefix: str | None = None,
     run_timeout_seconds: int | None = None,
+    observability_runtime: ObservabilityRuntimePort | None = None,
 ) -> FastAPI:
     resolved_database_uri = _required_uri(
         database_uri,
@@ -41,6 +47,11 @@ def create_durable_langgraph_runtime_app(
         fallback_env="REDIS_URL",
     )
     graphs = load_graphs(config_path)
+    resolved_observability = (
+        observability_runtime
+        if observability_runtime is not None
+        else _graph_observability_runtime(graphs.values())
+    )
 
     pool, catalog = _postgres_catalog(resolved_database_uri)
     redis_client = _redis_client(resolved_redis_uri)
@@ -60,14 +71,17 @@ def create_durable_langgraph_runtime_app(
         coordinator,
         run_timeout_seconds=run_timeout_seconds
         or _positive_int_env("ARCLITH_LANGGRAPH_RUN_TIMEOUT_SECONDS", 900),
+        observability_runtime=resolved_observability,
     )
     app = create_langgraph_runtime_app(runtime)
+    resolved_observability.instrument_fastapi(app)
     auto_setup = _boolean_env("ARCLITH_LANGGRAPH_AUTO_SETUP", True)
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
-        await pool.open()
+        resolved_observability.start()
         try:
+            await pool.open()
             saver, store = await _build_langgraph_persistence(
                 pool,
                 setup=auto_setup,
@@ -79,11 +93,38 @@ def create_durable_langgraph_runtime_app(
                 raise RuntimeError("Redis coordination is unavailable")
             yield
         finally:
-            await coordinator.close()
-            await pool.close()
+            try:
+                await coordinator.close()
+            finally:
+                try:
+                    await pool.close()
+                finally:
+                    try:
+                        resolved_observability.force_flush()
+                    finally:
+                        resolved_observability.shutdown()
 
     app.router.lifespan_context = lifespan
     return app
+
+
+def _graph_observability_runtime(graphs: Any) -> ObservabilityRuntimePort:
+    runtimes: dict[int, ObservabilityRuntimePort] = {}
+    for graph in graphs:
+        candidate = getattr(graph, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, None)
+        if candidate is None:
+            continue
+        if not isinstance(candidate, ObservabilityRuntimePort):
+            raise TypeError("Le runtime d'observabilite attache au graphe est invalide")
+        runtimes[id(candidate)] = candidate
+    if not runtimes:
+        return NoOpObservabilityRuntime()
+    if len(runtimes) > 1:
+        raise RuntimeError(
+            "Tous les graphes du runtime durable doivent partager la meme instance "
+            "Arclith ou fournir observability_runtime explicitement"
+        )
+    return next(iter(runtimes.values()))
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/arclith/adapters/outbound/langsmith/fastapi.py
+++ b/arclith/adapters/outbound/langsmith/fastapi.py
@@ -21,7 +21,8 @@ def instrument_fastapi_app(app: "FastAPI", tracer: "TracePort") -> None:
             parent = {
                 key.lower(): value
                 for key, value in request.headers.items()
-                if key.lower() in {"langsmith-trace", "traceparent", "baggage"}
+                if key.lower()
+                in {"langsmith-trace", "traceparent", "tracestate", "baggage"}
             }
             with (
                 tracer.context(parent=parent),

--- a/arclith/adapters/outbound/langsmith/fastapi.py
+++ b/arclith/adapters/outbound/langsmith/fastapi.py
@@ -2,13 +2,23 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from arclith.adapters.outbound.langsmith.propagation import (
+    normalized_parent_headers,
+)
+from arclith.infrastructure.config import LangSmithPropagationSettings
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
     from arclith.domain.ports.outbound.observability import TracePort
 
 
-def instrument_fastapi_app(app: "FastAPI", tracer: "TracePort") -> None:
+def instrument_fastapi_app(
+    app: "FastAPI",
+    tracer: "TracePort",
+    *,
+    propagation: LangSmithPropagationSettings | None = None,
+) -> None:
     try:
         from starlette.middleware.base import BaseHTTPMiddleware
     except ImportError as exc:
@@ -16,14 +26,20 @@ def instrument_fastapi_app(app: "FastAPI", tracer: "TracePort") -> None:
             'L\'instrumentation FastAPI LangSmith requiert "arclith[fastapi,langsmith]".'
         ) from exc
 
+    settings = propagation or LangSmithPropagationSettings()
+
     class LangSmithTracingMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Any, call_next: Any) -> Any:
-            parent = {
-                key.lower(): value
-                for key, value in request.headers.items()
-                if key.lower()
-                in {"langsmith-trace", "traceparent", "tracestate", "baggage"}
-            }
+            parent = (
+                normalized_parent_headers(
+                    request.headers,
+                    allowlist=set(settings.baggage_allowlist),
+                    langsmith_headers=settings.langsmith_headers,
+                    traceparent=settings.traceparent,
+                )
+                if settings.enabled
+                else {}
+            )
             with (
                 tracer.context(parent=parent),
                 tracer.span(

--- a/arclith/adapters/outbound/langsmith/integration.py
+++ b/arclith/adapters/outbound/langsmith/integration.py
@@ -82,9 +82,9 @@ class LangSmithIntegrationMixin:
 
             carrier: dict[str, str] = {}
             propagate.inject(carrier)
-            traceparent = carrier.get("traceparent")
-            if traceparent:
-                headers.setdefault("traceparent", traceparent)
+            for key in ("traceparent", "tracestate"):
+                if value := carrier.get(key):
+                    headers.setdefault(key, value)
             return filter_baggage(carrier.get("baggage", ""), allowlist=allowlist)
         except ImportError:
             return ""

--- a/arclith/adapters/outbound/langsmith/propagation.py
+++ b/arclith/adapters/outbound/langsmith/propagation.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 _LANGSMITH_TRACE = "langsmith-trace"
 _BAGGAGE = "baggage"
 _TRACEPARENT = "traceparent"
+_TRACESTATE = "tracestate"
 
 
 def normalized_parent_headers(
@@ -24,6 +25,8 @@ def normalized_parent_headers(
         result[_LANGSMITH_TRACE] = normalized[_LANGSMITH_TRACE]
     if traceparent and normalized.get(_TRACEPARENT):
         result[_TRACEPARENT] = normalized[_TRACEPARENT]
+        if normalized.get(_TRACESTATE):
+            result[_TRACESTATE] = normalized[_TRACESTATE]
     baggage = filter_baggage(normalized.get(_BAGGAGE, ""), allowlist=allowlist)
     if baggage:
         result[_BAGGAGE] = baggage

--- a/arclith/adapters/outbound/noop/observability.py
+++ b/arclith/adapters/outbound/noop/observability.py
@@ -97,6 +97,9 @@ class NoOpCorrelationContext(CorrelationContextPort):
 
 
 class NoOpContextPropagator(ContextPropagatorPort):
+    def extract(self, carrier: Mapping[str, str]) -> Mapping[str, str]:
+        return {}
+
     def inject(self, carrier: MutableMapping[str, str]) -> None:
         return None
 

--- a/arclith/adapters/outbound/opentelemetry/propagation.py
+++ b/arclith/adapters/outbound/opentelemetry/propagation.py
@@ -17,6 +17,9 @@ class OpenTelemetryContextPropagator(ContextPropagatorPort):
         self._settings = settings
         self._propagator = None
 
+    def extract(self, carrier: Mapping[str, str]) -> Mapping[str, str]:
+        return _safe_carrier(carrier, self._settings)
+
     def inject(self, carrier: MutableMapping[str, str]) -> None:
         propagated: dict[str, str] = {}
         self._get_propagator().inject(propagated)
@@ -64,10 +67,15 @@ class OpenTelemetryContextPropagator(ContextPropagatorPort):
 def _safe_carrier(
     carrier: Mapping[str, str], settings: OpenTelemetryPropagationSettings
 ) -> dict[str, str]:
+    allowed: set[str] = set()
+    if "tracecontext" in settings.propagators:
+        allowed.update({"traceparent", "tracestate"})
+    if "baggage" in settings.propagators:
+        allowed.add("baggage")
     safe = {
-        key: str(value)
+        key.lower(): str(value)
         for key, value in carrier.items()
-        if key.lower() in {"traceparent", "tracestate", "baggage"}
+        if key.lower() in allowed
     }
     baggage = _filter_baggage(
         safe.get("baggage", ""),

--- a/arclith/domain/ports/outbound/observability.py
+++ b/arclith/domain/ports/outbound/observability.py
@@ -111,6 +111,11 @@ class CorrelationContextPort(ABC):
 class ContextPropagatorPort(ABC):
     """Inject and attach distributed context for transport adapters."""
 
+    def extract(self, carrier: Mapping[str, str]) -> Mapping[str, str]:
+        """Return a sanitized carrier or nothing for custom/no-op propagators."""
+
+        return {}
+
     @abstractmethod
     def inject(self, carrier: MutableMapping[str, str]) -> None:
         raise NotImplementedError  # pragma: no cover

--- a/arclith/infrastructure/langgraph_bootstrap.py
+++ b/arclith/infrastructure/langgraph_bootstrap.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     )
 
 LANGGRAPH_UNSET = object()
+LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR = "_arclith_observability_runtime"
 
 
 def _normalize_langgraph_stream_mode(
@@ -128,6 +129,11 @@ class LangGraphBootstrap:
             raise
         compiled = self._owner._observability_runtime.instrument_langgraph(
             compiled, name=name
+        )
+        setattr(
+            compiled,
+            LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR,
+            self._owner._observability_runtime,
         )
         if persistence_components is not None:
             self._remember_langgraph_persistence(persistence_components)

--- a/arclith/infrastructure/observability_factory.py
+++ b/arclith/infrastructure/observability_factory.py
@@ -203,7 +203,11 @@ class LangSmithObservabilityRuntime(ObservabilityRuntimePort):
             return
         from arclith.adapters.outbound.langsmith.fastapi import instrument_fastapi_app
 
-        instrument_fastapi_app(app, self._runtime)
+        instrument_fastapi_app(
+            app,
+            self._runtime,
+            propagation=self._runtime.settings.propagation,
+        )
 
     def pydantic_ai_instrumentation(self) -> Any | None:
         return self._runtime.pydantic_ai_capability()

--- a/arclith/infrastructure/observability_factory.py
+++ b/arclith/infrastructure/observability_factory.py
@@ -20,7 +20,7 @@ from arclith.domain.ports.outbound.observability import (
     TraceAnonymizer,
     TracePort,
 )
-from arclith.infrastructure.config import AppConfig
+from arclith.infrastructure.config import AppConfig, LangSmithPropagationSettings
 
 
 def build_observability_runtime(
@@ -133,11 +133,30 @@ def _configure_shared_opentelemetry(config: AppConfig) -> None:
 
 
 class _TraceContextPropagator(ContextPropagatorPort):
-    def __init__(self, tracer: TracePort) -> None:
+    def __init__(
+        self,
+        tracer: TracePort,
+        settings: LangSmithPropagationSettings,
+    ) -> None:
         self._tracer = tracer
+        self._settings = settings
 
     def inject(self, carrier: MutableMapping[str, str]) -> None:
         self._tracer.inject(carrier)
+
+    def extract(self, carrier: Mapping[str, str]) -> Mapping[str, str]:
+        from arclith.adapters.outbound.langsmith.propagation import (
+            normalized_parent_headers,
+        )
+
+        if not self._settings.enabled:
+            return {}
+        return normalized_parent_headers(
+            carrier,
+            allowlist=set(self._settings.baggage_allowlist),
+            langsmith_headers=self._settings.langsmith_headers,
+            traceparent=self._settings.traceparent,
+        )
 
     @contextmanager
     def context(self, carrier: Mapping[str, str] | None = None) -> Iterator[None]:
@@ -150,7 +169,10 @@ class LangSmithObservabilityRuntime(ObservabilityRuntimePort):
         self._runtime = runtime
         self._metrics = NoOpMetricAdapter()
         self._correlation = NoOpCorrelationContext()
-        self._propagator = _TraceContextPropagator(runtime)
+        self._propagator = _TraceContextPropagator(
+            runtime,
+            runtime.settings.propagation,
+        )
         self._logs = NoOpLogRecordAdapter()
 
     @property

--- a/docs/capabilities/observability.md
+++ b/docs/capabilities/observability.md
@@ -223,6 +223,35 @@ FastAPI, FastMCP et les runners Arclith ferment automatiquement le runtime à l'
 Les metadata de transport sont bornées: méthode/route HTTP, nom du tool, type de commande,
 destination et statut. Les payloads métier ne sont jamais ajoutés automatiquement.
 
+### Runtime LangGraph durable
+
+Un graphe compilé par `Arclith.langgraph()` conserve une référence en mémoire vers son
+`ObservabilityRuntimePort`. Lorsque `arclith-agent-runtime` charge ce graphe, il réutilise ce même
+runtime pour la propagation entrante et son cycle de vie. Cette référence n'est ni sérialisée ni
+placée dans le catalogue PostgreSQL.
+
+Pour `/threads/{thread_id}/runs/wait` et `/threads/{thread_id}/runs/stream`, le propagateur actif
+extrait uniquement:
+
+- `langsmith-trace` lorsque le backend LangSmith l'autorise;
+- `traceparent` et `tracestate` lorsque la propagation W3C est active;
+- les membres de `baggage` présents dans la `baggage_allowlist` du backend.
+
+`Authorization`, `Cookie`, clés API, JWT et tout header arbitraire sont éliminés avant l'exécution.
+Le contexte filtré reste éphémère: il n'est ajouté ni à `RunRecord`, ni à `input`, ni à la
+configuration LangGraph persistée.
+
+Le runtime ouvre une span serveur `langgraph.runtime.run` pendant toute la durée du graphe, y
+compris les itérations SSE, erreurs et annulations. Ses seules métadonnées automatiques sont
+`langgraph.thread_id`, `langgraph.run_id`, `langgraph.assistant_id` et le statut technique
+`langgraph.run.status`; aucun payload métier n'est capturé. Le graphe et ses instrumentations créent
+leurs spans sous ce parent distribué.
+
+Au démarrage, le serveur durable appelle `start()` et compose l'instrumentation FastAPI configurée.
+À l'arrêt, il exécute `force_flush()` puis `shutdown()`. `/ready` continue de vérifier uniquement le
+catalogue et la coordination: une panne d'export LangSmith ou OTLP ne devient pas une dépendance de
+readiness. Sans adapter actif, le runtime utilise le propagateur et le tracer no-op.
+
 ## LangSmith et OpenTelemetry ensemble
 
 Les deux adapters partagent un seul `TracerProvider` et plusieurs processors/exporters. Lorsque les

--- a/docs/capabilities/runtime.md
+++ b/docs/capabilities/runtime.md
@@ -53,6 +53,36 @@ Le profil `durable` lance `arclith-agent-runtime` et requiert l'extra
 de licence LangGraph Cloud. Voir [Agent Persistence](agent-persistence.md) pour le contrat et les
 limites de compatibilité.
 
+## Propagation de trace du runtime durable
+
+Les graphes construits avec `Arclith.langgraph()` transmettent automatiquement leur runtime
+d'observabilité au serveur durable. Le même contrat fonctionne avec LangSmith, OpenTelemetry ou le
+backend no-op; le runtime LangGraph n'importe aucun SDK fournisseur.
+
+Les endpoints `runs/wait` et `runs/stream` filtrent le carrier HTTP par le propagateur configuré,
+puis gardent ce contexte actif jusqu'à la fin réelle du graphe ou du flux SSE. Seuls
+`langsmith-trace`, `traceparent`, `tracestate` et le baggage explicitement allowlisté peuvent entrer.
+Les credentials, cookies et headers arbitraires sont ignorés et ne sont jamais écrits dans le
+catalogue des runs.
+
+Une span `langgraph.runtime.run` relie les deux services et expose seulement les identifiants
+techniques `thread_id`, `run_id`, `assistant_id` et le statut du run. Les chemins succès, erreur,
+déconnexion et annulation ferment tous le contexte dans un `finally`.
+
+Le cycle de vie du serveur démarre, flush et ferme le runtime d'observabilité autour des ressources
+PostgreSQL/Redis. Les probes `/health` et `/ready` restent indépendantes des exporters. Un graphe
+compilé directement hors `Arclith.langgraph()` conserve le comportement no-op, sauf si un
+`observability_runtime` explicite est fourni à `create_durable_langgraph_runtime_app()`.
+
+Pour activer les traces avec le runtime durable, installer les extras séparément et sélectionner
+l'adapter dans la configuration:
+
+```bash
+uv add "arclith[langgraph-runtime,langsmith]"
+```
+
+Voir [Observability](observability.md) pour la politique de capture, les allowlists et les profils.
+
 ## Règles
 
 - Une image par service, plusieurs modes de lancement.

--- a/tests/integration/test_langsmith.py
+++ b/tests/integration/test_langsmith.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import time
+from collections.abc import AsyncIterator
+from typing import Any
 from uuid import uuid4
 
 import pytest
 
 from arclith.adapters.outbound.langsmith.runtime import LangSmithRuntime
-from arclith.infrastructure.config import LangSmithSettings
+from arclith.adapters.inbound.langgraph_runtime import (
+    InMemoryRunCoordinator,
+    InMemoryRuntimeCatalog,
+    LangGraphRuntime,
+    RunRequest,
+)
+from arclith.infrastructure.observability_factory import LangSmithObservabilityRuntime
+from arclith.infrastructure.config import (
+    LangSmithCaptureSettings,
+    LangSmithSettings,
+    LangSmithTracingSettings,
+)
 
 pytestmark = pytest.mark.skipif(
     os.getenv("ARCLITH_LANGSMITH_INTEGRATION") != "1",
@@ -24,8 +38,12 @@ def test_langsmith_live_trace_is_queryable(logger) -> None:
     runtime = LangSmithRuntime(
         LangSmithSettings(
             project=project,
-            tracing={"mode": "langsmith"},
-            capture={"inputs": False, "outputs": False, "metadata": True},
+            tracing=LangSmithTracingSettings(mode="langsmith"),
+            capture=LangSmithCaptureSettings(
+                inputs=False,
+                outputs=False,
+                metadata=True,
+            ),
         ),
         logger,
         service_metadata={"service.name": "arclith-integration"},
@@ -53,3 +71,110 @@ def test_langsmith_live_trace_is_queryable(logger) -> None:
             pytest.fail(f"run LangSmith introuvable apres flush: {run_name}")
     finally:
         runtime.close(timeout=10.0)
+
+
+@pytest.mark.asyncio
+async def test_langsmith_live_runtime_preserves_distributed_parent(logger) -> None:
+    if not os.getenv("LANGSMITH_API_KEY"):
+        pytest.fail("LANGSMITH_API_KEY est requis pour le test live LangSmith")
+
+    project = os.getenv("LANGSMITH_PROJECT", "arclith-integration")
+    parent_name = f"arclith-distributed-parent-{uuid4().hex}"
+    producer = LangSmithRuntime(
+        LangSmithSettings(
+            project=project,
+            tracing=LangSmithTracingSettings(mode="langsmith"),
+            capture=LangSmithCaptureSettings(
+                inputs=False,
+                outputs=False,
+                metadata=True,
+            ),
+        ),
+        logger,
+        service_metadata={"service.name": "arclith-producer-integration"},
+    )
+    consumer = LangSmithRuntime(
+        LangSmithSettings(
+            project=project,
+            tracing=LangSmithTracingSettings(mode="langsmith"),
+            capture=LangSmithCaptureSettings(
+                inputs=False,
+                outputs=False,
+                metadata=True,
+            ),
+        ),
+        logger,
+        service_metadata={"service.name": "arclith-consumer-integration"},
+    )
+
+    class Graph:
+        async def ainvoke(self, _value: Any, _config: Any) -> dict[str, str]:
+            return {"status": "ok"}
+
+        async def astream(
+            self,
+            value: Any,
+            _config: Any,
+            **_kwargs: Any,
+        ) -> AsyncIterator[Any]:
+            if False:
+                yield value
+
+    runtime = LangGraphRuntime(
+        {"integration_agent": Graph()},
+        InMemoryRuntimeCatalog(),
+        InMemoryRunCoordinator(),
+        observability_runtime=LangSmithObservabilityRuntime(consumer),
+    )
+    thread_id = str(uuid4())
+
+    try:
+        await runtime.create_thread(
+            thread_id=thread_id,
+            metadata=None,
+            if_exists=None,
+        )
+        with producer.span(parent_name, metadata={"test.kind": "distributed"}):
+            carrier: dict[str, str] = {}
+            producer.inject(carrier)
+            await runtime.wait(
+                thread_id,
+                RunRequest(
+                    assistant_id="integration_agent",
+                    trace_context=carrier,
+                ),
+            )
+        producer.flush(timeout=10.0)
+        consumer.flush(timeout=10.0)
+
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            parents = list(
+                producer.client().list_runs(
+                    project_name=project,
+                    filter=f'eq(name, "{parent_name}")',
+                    limit=1,
+                )
+            )
+            if parents:
+                children = list(
+                    producer.client().list_runs(
+                        project_name=project,
+                        parent_run_id=parents[0].id,
+                        limit=10,
+                    )
+                )
+                boundary = next(
+                    (run for run in children if run.name == "langgraph.runtime.run"),
+                    None,
+                )
+                if boundary is not None:
+                    assert boundary.trace_id == parents[0].trace_id
+                    assert boundary.parent_run_id == parents[0].id
+                    break
+            await asyncio.sleep(1.0)
+        else:
+            pytest.fail("hierarchie LangSmith distribuee introuvable apres flush")
+    finally:
+        consumer.close(timeout=10.0)
+        producer.close(timeout=10.0)

--- a/tests/units/adapters/inbound/langgraph_runtime_observability_fakes.py
+++ b/tests/units/adapters/inbound/langgraph_runtime_observability_fakes.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from types import SimpleNamespace
+from typing import Any
+
+from arclith.adapters.inbound.langgraph_runtime import (
+    InMemoryRunCoordinator,
+    InMemoryRuntimeCatalog,
+    LangGraphRuntime,
+)
+from arclith.adapters.outbound.noop.observability import NoOpObservabilityRuntime
+from arclith.domain.ports.outbound.observability import (
+    ContextPropagatorPort,
+    TracePort,
+    TraceSpan,
+)
+
+
+class RecordingSpan(TraceSpan):
+    def __init__(self, events: list[tuple[str, Any]]) -> None:
+        self._events = events
+
+    def set_outputs(self, outputs: object | None) -> None:
+        self._events.append(("span.outputs", outputs))
+
+    def set_metadata(self, metadata: Mapping[str, object]) -> None:
+        self._events.append(("span.metadata", dict(metadata)))
+
+    def record_exception(self, error: BaseException) -> None:
+        self._events.append(("span.exception", type(error).__name__))
+
+    def set_status(self, status: str, description: str | None = None) -> None:
+        self._events.append(("span.status", (status, description)))
+
+
+class RecordingPropagator(ContextPropagatorPort):
+    def __init__(
+        self,
+        events: list[tuple[str, Any]],
+        current: ContextVar[Mapping[str, str] | None],
+    ) -> None:
+        self._events = events
+        self._current = current
+
+    def extract(self, carrier: Mapping[str, str]) -> Mapping[str, str]:
+        normalized = {str(key).lower(): str(value) for key, value in carrier.items()}
+        safe = {
+            key: normalized[key]
+            for key in ("langsmith-trace", "traceparent", "tracestate")
+            if normalized.get(key)
+        }
+        baggage = ",".join(
+            member.strip()
+            for member in normalized.get("baggage", "").split(",")
+            if member.strip().partition("=")[0] == "safe"
+        )
+        if baggage:
+            safe["baggage"] = baggage
+        self._events.append(("extract", safe))
+        return safe
+
+    def inject(self, carrier: MutableMapping[str, str]) -> None:
+        carrier.update(self._current.get() or {})
+
+    @contextmanager
+    def context(self, carrier: Mapping[str, str] | None = None) -> Iterator[None]:
+        safe = self.extract(carrier or {})
+        token = self._current.set(safe)
+        self._events.append(("context.enter", safe))
+        try:
+            yield
+        finally:
+            self._events.append(("context.exit", safe))
+            self._current.reset(token)
+
+
+class RecordingTracer(TracePort):
+    def __init__(
+        self,
+        events: list[tuple[str, Any]],
+        current: ContextVar[Mapping[str, str] | None],
+    ) -> None:
+        self._events = events
+        self._current = current
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: str = "chain",
+        inputs: object | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+    ) -> Iterator[TraceSpan]:
+        self._events.append(
+            (
+                "span.enter",
+                {
+                    "name": name,
+                    "kind": kind,
+                    "inputs": inputs,
+                    "tags": tuple(tags),
+                    "metadata": dict(metadata or {}),
+                    "parent": dict(self._current.get() or {}),
+                },
+            )
+        )
+        span = RecordingSpan(self._events)
+        try:
+            yield span
+        except BaseException as error:
+            span.record_exception(error)
+            span.set_status("error", type(error).__name__)
+            raise
+        finally:
+            self._events.append(("span.exit", name))
+
+    @contextmanager
+    def context(
+        self,
+        *,
+        enabled: bool | None = None,
+        project: str | None = None,
+        tags: Sequence[str] = (),
+        metadata: Mapping[str, object] | None = None,
+        parent: Mapping[str, str] | None = None,
+    ) -> Iterator[None]:
+        token = self._current.set(parent)
+        try:
+            yield
+        finally:
+            self._current.reset(token)
+
+    def inject(self, headers: MutableMapping[str, str]) -> None:
+        headers.update(self._current.get() or {})
+
+    def flush(self, timeout: float | None = None) -> None:
+        return None
+
+    def close(self, timeout: float | None = None) -> None:
+        return None
+
+
+class RecordingObservability(NoOpObservabilityRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[tuple[str, Any]] = []
+        self.current: ContextVar[Mapping[str, str] | None] = ContextVar(
+            "runtime_test_trace_context",
+            default=None,
+        )
+        self._recording_propagator = RecordingPropagator(self.events, self.current)
+        self._recording_tracer = RecordingTracer(self.events, self.current)
+
+    @property
+    def propagator(self) -> ContextPropagatorPort:
+        return self._recording_propagator
+
+    @property
+    def tracer(self) -> TracePort:
+        return self._recording_tracer
+
+
+class RecordingGraph:
+    def __init__(
+        self,
+        current: ContextVar[Mapping[str, str] | None],
+        *,
+        delay: float = 0,
+        fail: bool = False,
+    ) -> None:
+        self._current = current
+        self._delay = delay
+        self._fail = fail
+        self.parents: list[dict[str, str]] = []
+
+    async def ainvoke(self, value: Any, config: Any) -> Any:
+        self.parents.append(dict(self._current.get() or {}))
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._fail:
+            raise ValueError("graph failed")
+        return {"status": "ok"}
+
+    async def astream(self, value: Any, config: Any, **kwargs: Any) -> Any:
+        self.parents.append(dict(self._current.get() or {}))
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._fail:
+            raise ValueError("graph failed")
+        yield {"status": "ok"}
+
+    async def aget_state(self, config: Any) -> Any:
+        return SimpleNamespace(config={"configurable": {}}, values={"status": "ok"})
+
+
+def build_runtime(
+    observability: RecordingObservability,
+    graph: RecordingGraph,
+) -> LangGraphRuntime:
+    return LangGraphRuntime(
+        {"test_agent": graph},
+        InMemoryRuntimeCatalog(),
+        InMemoryRunCoordinator(),
+        cancel_poll_seconds=0.01,
+        observability_runtime=observability,
+    )
+
+
+async def create_thread(runtime: LangGraphRuntime, thread_id: str) -> None:
+    await runtime.create_thread(thread_id=thread_id, metadata=None, if_exists=None)
+
+
+async def wait_for_run(runtime: LangGraphRuntime, thread_id: str) -> str:
+    while not (
+        runs := await runtime.list_runs(
+            thread_id,
+            status=None,
+            limit=10,
+            offset=0,
+        )
+    ):
+        await asyncio.sleep(0)
+    return runs[0].run_id

--- a/tests/units/adapters/inbound/test_langgraph_runtime_observability.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_observability.py
@@ -127,6 +127,10 @@ async def test_wait_and_stream_release_trace_context_after_errors() -> None:
 
     assert (await wait_runtime.get_thread(THREAD_ID)).status == "error"
     assert ("span.exception", "ValueError") in wait_observability.events
+    assert (
+        "span.metadata",
+        {"langgraph.run.status": "error"},
+    ) in wait_observability.events
     assert any(event == "context.exit" for event, _value in wait_observability.events)
 
     stream_observability = RecordingObservability()
@@ -149,6 +153,10 @@ async def test_wait_and_stream_release_trace_context_after_errors() -> None:
     assert b"GraphExecutionError" in b"".join(chunks)
     assert (await stream_runtime.get_thread(SECOND_THREAD_ID)).status == "error"
     assert ("span.exception", "ValueError") in stream_observability.events
+    assert (
+        "span.metadata",
+        {"langgraph.run.status": "error"},
+    ) in stream_observability.events
     assert any(event == "context.exit" for event, _value in stream_observability.events)
 
 
@@ -176,6 +184,10 @@ async def test_wait_and_stream_release_trace_context_after_cancellation() -> Non
         await asyncio.wait_for(wait_task, timeout=1)
 
     assert ("span.exception", "RunCancelledError") in wait_observability.events
+    assert (
+        "span.metadata",
+        {"langgraph.run.status": "interrupted"},
+    ) in wait_observability.events
     assert any(event == "context.exit" for event, _value in wait_observability.events)
 
     stream_observability = RecordingObservability()
@@ -204,4 +216,35 @@ async def test_wait_and_stream_release_trace_context_after_cancellation() -> Non
 
     assert b"RunCancelledError" in b"".join(chunks)
     assert ("span.exception", "RunCancelledError") in stream_observability.events
+    assert (
+        "span.metadata",
+        {"langgraph.run.status": "interrupted"},
+    ) in stream_observability.events
     assert any(event == "context.exit" for event, _value in stream_observability.events)
+
+
+@pytest.mark.asyncio
+async def test_wait_records_error_status_after_timeout() -> None:
+    observability = RecordingObservability()
+    runtime = build_runtime(
+        observability,
+        RecordingGraph(observability.current, delay=30),
+    )
+    runtime.run_timeout_seconds = 0.01
+    await create_thread(runtime, THREAD_ID)
+
+    with pytest.raises(TimeoutError):
+        await runtime.wait(
+            THREAD_ID,
+            RunRequest(
+                assistant_id="test_agent",
+                trace_context={"traceparent": "wait-parent"},
+            ),
+        )
+
+    assert (await runtime.get_thread(THREAD_ID)).status == "error"
+    assert ("span.exception", "TimeoutError") in observability.events
+    assert (
+        "span.metadata",
+        {"langgraph.run.status": "error"},
+    ) in observability.events

--- a/tests/units/adapters/inbound/test_langgraph_runtime_observability.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_observability.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from arclith.adapters.inbound.langgraph_runtime import (
+    InMemoryRunCoordinator,
+    InMemoryRuntimeCatalog,
+    LangGraphRuntime,
+    RunRequest,
+    create_langgraph_runtime_app,
+)
+from arclith.adapters.inbound.langgraph_runtime.runtime import RunCancelledError
+from tests.units.adapters.inbound.langgraph_runtime_observability_fakes import (
+    RecordingGraph,
+    RecordingObservability,
+    build_runtime,
+    create_thread,
+    wait_for_run,
+)
+
+THREAD_ID = "01993fb0-7a3d-71a0-9c20-d7abbd755180"
+SECOND_THREAD_ID = "01993fb0-7a3d-71a0-9c20-d7abbd755181"
+
+
+def test_http_wait_and_stream_only_attach_sanitized_trace_context() -> None:
+    observability = RecordingObservability()
+    graph = RecordingGraph(observability.current)
+    runtime = build_runtime(observability, graph)
+    client = TestClient(create_langgraph_runtime_app(runtime))
+    assert client.post("/threads", json={"thread_id": THREAD_ID}).status_code == 200
+    headers = {
+        "LangSmith-Trace": "trace-value",
+        "TraceParent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+        "TraceState": "vendor=value",
+        "Baggage": "safe=yes,secret=no",
+        "Authorization": "Bearer sensitive",
+        "Cookie": "session=sensitive",
+        "X-API-Key": "sensitive",
+    }
+    payload = {"assistant_id": "test_agent", "input": {"status": "requested"}}
+
+    waited = client.post(
+        f"/threads/{THREAD_ID}/runs/wait",
+        json=payload,
+        headers=headers,
+    )
+    streamed = client.post(
+        f"/threads/{THREAD_ID}/runs/stream",
+        json=payload,
+        headers=headers,
+    )
+
+    expected = {
+        "langsmith-trace": "trace-value",
+        "traceparent": headers["TraceParent"],
+        "tracestate": "vendor=value",
+        "baggage": "safe=yes",
+    }
+    assert waited.status_code == 200
+    assert streamed.status_code == 200
+    assert graph.parents == [expected, expected]
+    spans = [value for event, value in observability.events if event == "span.enter"]
+    assert len(spans) == 2
+    assert all(span["name"] == "langgraph.runtime.run" for span in spans)
+    assert all(span["kind"] == "server" for span in spans)
+    assert all(span["inputs"] is None for span in spans)
+    assert all(
+        set(span["metadata"])
+        == {
+            "langgraph.thread_id",
+            "langgraph.run_id",
+            "langgraph.assistant_id",
+        }
+        for span in spans
+    )
+    assert [
+        value for event, value in observability.events if event == "span.metadata"
+    ] == [
+        {"langgraph.run.status": "success"},
+        {"langgraph.run.status": "success"},
+    ]
+    stored = json.dumps(client.get(f"/threads/{THREAD_ID}/runs").json())
+    assert "trace-value" not in stored
+    assert "Bearer sensitive" not in stored
+    assert "session=sensitive" not in stored
+    assert "secret=no" not in stored
+
+
+def test_disabled_observability_extracts_nothing() -> None:
+    runtime = LangGraphRuntime(
+        {"test_agent": object()},
+        InMemoryRuntimeCatalog(),
+        InMemoryRunCoordinator(),
+    )
+
+    assert (
+        runtime.extract_trace_context(
+            {
+                "traceparent": "00-trace-parent-01",
+                "baggage": "safe=yes",
+                "authorization": "Bearer sensitive",
+            }
+        )
+        == {}
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_and_stream_release_trace_context_after_errors() -> None:
+    wait_observability = RecordingObservability()
+    wait_runtime = build_runtime(
+        wait_observability,
+        RecordingGraph(wait_observability.current, fail=True),
+    )
+    await create_thread(wait_runtime, THREAD_ID)
+    request = RunRequest(
+        assistant_id="test_agent",
+        trace_context={"traceparent": "wait-parent", "authorization": "sensitive"},
+    )
+
+    with pytest.raises(ValueError, match="graph failed"):
+        await wait_runtime.wait(THREAD_ID, request)
+
+    assert (await wait_runtime.get_thread(THREAD_ID)).status == "error"
+    assert ("span.exception", "ValueError") in wait_observability.events
+    assert any(event == "context.exit" for event, _value in wait_observability.events)
+
+    stream_observability = RecordingObservability()
+    stream_runtime = build_runtime(
+        stream_observability,
+        RecordingGraph(stream_observability.current, fail=True),
+    )
+    await create_thread(stream_runtime, SECOND_THREAD_ID)
+    chunks = [
+        chunk
+        async for chunk in stream_runtime.stream(
+            SECOND_THREAD_ID,
+            RunRequest(
+                assistant_id="test_agent",
+                trace_context={"traceparent": "stream-parent"},
+            ),
+        )
+    ]
+
+    assert b"GraphExecutionError" in b"".join(chunks)
+    assert (await stream_runtime.get_thread(SECOND_THREAD_ID)).status == "error"
+    assert ("span.exception", "ValueError") in stream_observability.events
+    assert any(event == "context.exit" for event, _value in stream_observability.events)
+
+
+@pytest.mark.asyncio
+async def test_wait_and_stream_release_trace_context_after_cancellation() -> None:
+    wait_observability = RecordingObservability()
+    wait_runtime = build_runtime(
+        wait_observability,
+        RecordingGraph(wait_observability.current, delay=30),
+    )
+    await create_thread(wait_runtime, THREAD_ID)
+    wait_task = asyncio.create_task(
+        wait_runtime.wait(
+            THREAD_ID,
+            RunRequest(
+                assistant_id="test_agent",
+                trace_context={"traceparent": "wait-parent"},
+            ),
+        )
+    )
+    wait_run_id = await wait_for_run(wait_runtime, THREAD_ID)
+    await wait_runtime.cancel_run(THREAD_ID, wait_run_id)
+
+    with pytest.raises(RunCancelledError):
+        await asyncio.wait_for(wait_task, timeout=1)
+
+    assert ("span.exception", "RunCancelledError") in wait_observability.events
+    assert any(event == "context.exit" for event, _value in wait_observability.events)
+
+    stream_observability = RecordingObservability()
+    stream_runtime = build_runtime(
+        stream_observability,
+        RecordingGraph(stream_observability.current, delay=30),
+    )
+    await create_thread(stream_runtime, SECOND_THREAD_ID)
+
+    async def consume_stream() -> list[bytes]:
+        return [
+            chunk
+            async for chunk in stream_runtime.stream(
+                SECOND_THREAD_ID,
+                RunRequest(
+                    assistant_id="test_agent",
+                    trace_context={"traceparent": "stream-parent"},
+                ),
+            )
+        ]
+
+    stream_task = asyncio.create_task(consume_stream())
+    stream_run_id = await wait_for_run(stream_runtime, SECOND_THREAD_ID)
+    await stream_runtime.cancel_run(SECOND_THREAD_ID, stream_run_id)
+    chunks = await asyncio.wait_for(stream_task, timeout=1)
+
+    assert b"RunCancelledError" in b"".join(chunks)
+    assert ("span.exception", "RunCancelledError") in stream_observability.events
+    assert any(event == "context.exit" for event, _value in stream_observability.events)

--- a/tests/units/adapters/inbound/test_langgraph_runtime_server.py
+++ b/tests/units/adapters/inbound/test_langgraph_runtime_server.py
@@ -9,6 +9,10 @@ from fastapi.testclient import TestClient
 
 from arclith.adapters.inbound.langgraph_runtime import server
 from arclith.adapters.inbound.langgraph_runtime.catalog import InMemoryRuntimeCatalog
+from arclith.adapters.outbound.noop.observability import NoOpObservabilityRuntime
+from arclith.infrastructure.langgraph_bootstrap import (
+    LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR,
+)
 
 
 class FakePool:
@@ -55,6 +59,25 @@ class FakePersistence:
         self.setup_called = True
 
 
+class RecordingObservability(NoOpObservabilityRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[str] = []
+
+    def start(self) -> None:
+        self.events.append("start")
+
+    def instrument_fastapi(self, app: Any) -> None:
+        self.events.append("instrument_fastapi")
+
+    def force_flush(self, timeout: float | None = None) -> bool:
+        self.events.append("force_flush")
+        return True
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        self.events.append("shutdown")
+
+
 @pytest.mark.asyncio
 async def test_build_persistence_sets_up_saver_and_store(monkeypatch: Any) -> None:
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
@@ -95,6 +118,8 @@ def test_create_durable_app_owns_resources_and_attaches_persistence(
     pool = FakePool()
     redis = FakeRedis()
     graph = FakeGraph()
+    observability = RecordingObservability()
+    setattr(graph, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, observability)
     saver = FakePersistence()
     store = FakePersistence()
 
@@ -126,6 +151,34 @@ def test_create_durable_app_owns_resources_and_attaches_persistence(
 
     assert pool.closed is True
     assert redis.closed is True
+    assert observability.events == [
+        "instrument_fastapi",
+        "start",
+        "force_flush",
+        "shutdown",
+    ]
+
+
+def test_graph_observability_runtime_requires_one_valid_shared_instance() -> None:
+    first = FakeGraph()
+    second = FakeGraph()
+    shared = RecordingObservability()
+    setattr(first, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, shared)
+    setattr(second, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, shared)
+
+    assert server._graph_observability_runtime([first, second]) is shared
+    assert isinstance(
+        server._graph_observability_runtime([FakeGraph()]),
+        NoOpObservabilityRuntime,
+    )
+
+    setattr(second, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, RecordingObservability())
+    with pytest.raises(RuntimeError, match="meme instance Arclith"):
+        server._graph_observability_runtime([first, second])
+
+    setattr(second, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR, object())
+    with pytest.raises(TypeError, match="invalide"):
+        server._graph_observability_runtime([second])
 
 
 def test_create_durable_app_rejects_unhealthy_redis(

--- a/tests/units/adapters/outbound/langsmith/test_fastapi.py
+++ b/tests/units/adapters/outbound/langsmith/test_fastapi.py
@@ -78,6 +78,8 @@ def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() 
         "/items/42?token=secret",
         headers={
             "langsmith-trace": "trace-value",
+            "traceparent": "00-trace-parent-01",
+            "tracestate": "vendor=value",
             "baggage": "safe=yes",
             "authorization": "Bearer secret",
         },
@@ -85,7 +87,12 @@ def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() 
 
     assert response.status_code == 200
     assert tracer.context_parents == [
-        {"langsmith-trace": "trace-value", "baggage": "safe=yes"}
+        {
+            "langsmith-trace": "trace-value",
+            "traceparent": "00-trace-parent-01",
+            "tracestate": "vendor=value",
+            "baggage": "safe=yes",
+        }
     ]
     name, metadata, span = tracer.spans[0]
     assert name == "http.server.request"

--- a/tests/units/adapters/outbound/langsmith/test_fastapi.py
+++ b/tests/units/adapters/outbound/langsmith/test_fastapi.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from arclith.adapters.outbound.langsmith.fastapi import instrument_fastapi_app
 from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
+from arclith.infrastructure.config import LangSmithPropagationSettings
 
 
 class RecordingSpan(TraceSpan):
@@ -72,7 +73,11 @@ def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() 
         return {"item_id": item_id}
 
     tracer = RecordingTracer()
-    instrument_fastapi_app(app, tracer)
+    instrument_fastapi_app(
+        app,
+        tracer,
+        propagation=LangSmithPropagationSettings(baggage_allowlist=["safe"]),
+    )
 
     response = TestClient(app).get(
         "/items/42?token=secret",
@@ -80,7 +85,7 @@ def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() 
             "langsmith-trace": "trace-value",
             "traceparent": "00-trace-parent-01",
             "tracestate": "vendor=value",
-            "baggage": "safe=yes",
+            "baggage": "safe=yes,secret=no",
             "authorization": "Bearer secret",
         },
     )
@@ -101,3 +106,30 @@ def test_fastapi_instrumentation_propagates_context_without_sensitive_headers() 
     assert span.metadata == [
         {"http.response.status_code": 200, "http.route": "/items/{item_id}"}
     ]
+
+
+def test_fastapi_instrumentation_ignores_parent_when_propagation_is_disabled() -> None:
+    app = FastAPI()
+
+    @app.get("/")
+    async def read_root() -> dict[str, bool]:
+        return {"ok": True}
+
+    tracer = RecordingTracer()
+    instrument_fastapi_app(
+        app,
+        tracer,
+        propagation=LangSmithPropagationSettings(enabled=False),
+    )
+
+    response = TestClient(app).get(
+        "/",
+        headers={
+            "langsmith-trace": "trace-value",
+            "traceparent": "00-trace-parent-01",
+            "baggage": "safe=yes",
+        },
+    )
+
+    assert response.status_code == 200
+    assert tracer.context_parents == [{}]

--- a/tests/units/adapters/outbound/langsmith/test_propagation.py
+++ b/tests/units/adapters/outbound/langsmith/test_propagation.py
@@ -40,6 +40,7 @@ def test_normalized_parent_headers_filters_transport_headers() -> None:
         {
             "LangSmith-Trace": "trace-value",
             "TraceParent": "00-abc-def-01",
+            "TraceState": "vendor=value",
             "Baggage": "safe=yes,secret=no",
             "Authorization": "Bearer secret",
         },
@@ -51,6 +52,7 @@ def test_normalized_parent_headers_filters_transport_headers() -> None:
     assert headers == {
         "langsmith-trace": "trace-value",
         "traceparent": "00-abc-def-01",
+        "tracestate": "vendor=value",
         "baggage": "safe=yes",
     }
     assert (

--- a/tests/units/adapters/outbound/langsmith/test_runtime.py
+++ b/tests/units/adapters/outbound/langsmith/test_runtime.py
@@ -301,11 +301,23 @@ def test_runtime_propagates_only_allowlisted_baggage(
         "langsmith.run_helpers.get_current_run_tree",
         lambda: run_tree,
     )
+    monkeypatch.setattr(
+        "opentelemetry.propagate.inject",
+        lambda carrier: carrier.update(
+            {
+                "traceparent": "00-trace-parent-01",
+                "tracestate": "vendor=value",
+                "baggage": "safe=otel,secret=hidden",
+            }
+        ),
+    )
     headers: dict[str, str] = {"authorization": "Bearer existing"}
 
     runtime.inject(headers)
 
     assert headers["langsmith-trace"] == "trace-value"
+    assert headers["traceparent"] == "00-trace-parent-01"
+    assert headers["tracestate"] == "vendor=value"
     assert "safe" in headers["baggage"]
     assert "secret" not in headers["baggage"]
     assert headers["authorization"] == "Bearer existing"

--- a/tests/units/adapters/outbound/test_opentelemetry_propagation.py
+++ b/tests/units/adapters/outbound/test_opentelemetry_propagation.py
@@ -55,3 +55,34 @@ def test_propagator_attaches_and_detaches_incoming_context() -> None:
 
     with tracer.start_as_current_span("independent") as independent:
         assert independent.get_span_context().trace_id != expected_trace_id
+
+
+def test_propagator_extracts_only_normalized_safe_headers() -> None:
+    propagator = OpenTelemetryContextPropagator(
+        OpenTelemetryPropagationSettings(baggage_allowlist=["safe"])
+    )
+
+    assert propagator.extract(
+        {
+            "TraceParent": "00-trace-parent-01",
+            "TraceState": "vendor=value",
+            "Baggage": "safe=yes,secret=no",
+            "Authorization": "Bearer sensitive",
+            "Cookie": "session=sensitive",
+        }
+    ) == {
+        "traceparent": "00-trace-parent-01",
+        "tracestate": "vendor=value",
+        "baggage": "safe=yes",
+    }
+
+    disabled = OpenTelemetryContextPropagator(
+        OpenTelemetryPropagationSettings(
+            propagators=[],
+            baggage_allowlist=["safe"],
+        )
+    )
+    assert (
+        disabled.extract({"traceparent": "00-trace-parent-01", "baggage": "safe=yes"})
+        == {}
+    )

--- a/tests/units/domain/ports/test_observability.py
+++ b/tests/units/domain/ports/test_observability.py
@@ -57,6 +57,12 @@ def test_noop_runtime_exposes_all_neutral_capabilities() -> None:
     headers: dict[str, str] = {}
 
     assert isinstance(runtime, ObservabilityRuntimePort)
+    assert (
+        runtime.propagator.extract(
+            {"traceparent": "ignored", "authorization": "Bearer sensitive"}
+        )
+        == {}
+    )
     runtime.start()
     runtime.propagator.inject(headers)
     runtime.metrics.add_counter("ignored")

--- a/tests/units/infrastructure/test_observability_factory.py
+++ b/tests/units/infrastructure/test_observability_factory.py
@@ -10,6 +10,7 @@ import pytest
 from arclith.adapters.outbound.noop.observability import NoOpObservabilityRuntime
 from arclith.infrastructure.config import (
     AppConfig,
+    LangSmithPropagationSettings,
     LangSmithSettings,
     OpenTelemetrySettings,
 )
@@ -25,7 +26,13 @@ from arclith.infrastructure.observability_factory import (
 class RecordingLangSmithRuntime:
     def __init__(self, *, fastapi: bool = True) -> None:
         self.settings = SimpleNamespace(
-            instrumentation=SimpleNamespace(fastapi=fastapi)
+            instrumentation=SimpleNamespace(fastapi=fastapi),
+            propagation=LangSmithPropagationSettings(
+                enabled=True,
+                baggage_allowlist=["safe"],
+                langsmith_headers=True,
+                traceparent=True,
+            ),
         )
         self.events: list[tuple[str, Any]] = []
 
@@ -103,6 +110,20 @@ def test_langsmith_runtime_adapts_every_neutral_capability(
     carrier: dict[str, str] = {}
 
     runtime.start()
+    assert runtime.propagator.extract(
+        {
+            "LangSmith-Trace": "parent",
+            "TraceParent": "w3c-parent",
+            "TraceState": "vendor=value",
+            "Baggage": "safe=yes,secret=no",
+            "Authorization": "Bearer sensitive",
+        }
+    ) == {
+        "langsmith-trace": "parent",
+        "traceparent": "w3c-parent",
+        "tracestate": "vendor=value",
+        "baggage": "safe=yes",
+    }
     runtime.propagator.inject(carrier)
     with runtime.propagator.context(carrier):
         pass
@@ -132,6 +153,19 @@ def test_langsmith_fastapi_instrumentation_respects_opt_in(
     )
 
     runtime.instrument_fastapi(object())
+
+
+def test_langsmith_propagator_extract_respects_disabled_propagation() -> None:
+    raw = RecordingLangSmithRuntime()
+    raw.settings.propagation.enabled = False
+    runtime = LangSmithObservabilityRuntime(raw)
+
+    assert (
+        runtime.propagator.extract(
+            {"langsmith-trace": "parent", "traceparent": "w3c-parent"}
+        )
+        == {}
+    )
 
 
 def test_composite_runtime_keeps_one_otel_tree_and_delegates_lifecycle() -> None:

--- a/tests/units/infrastructure/test_observability_factory.py
+++ b/tests/units/infrastructure/test_observability_factory.py
@@ -102,10 +102,12 @@ def test_langsmith_runtime_adapts_every_neutral_capability(
     raw = RecordingLangSmithRuntime()
     runtime = LangSmithObservabilityRuntime(raw)
     app = object()
-    instrumented: list[tuple[Any, Any]] = []
+    instrumented: list[tuple[Any, Any, Any]] = []
     monkeypatch.setattr(
         "arclith.adapters.outbound.langsmith.fastapi.instrument_fastapi_app",
-        lambda target, adapter: instrumented.append((target, adapter)),
+        lambda target, adapter, *, propagation: instrumented.append(
+            (target, adapter, propagation)
+        ),
     )
     carrier: dict[str, str] = {}
 
@@ -134,7 +136,7 @@ def test_langsmith_runtime_adapts_every_neutral_capability(
     assert runtime.correlation.current() == {}
     assert runtime.logs is not None
     assert carrier == {"traceparent": "test"}
-    assert instrumented == [(app, raw)]
+    assert instrumented == [(app, raw, raw.settings.propagation)]
     assert runtime.pydantic_ai_instrumentation() == "pydantic-ai"
     assert runtime.force_flush(1.5) is True
     runtime.shutdown(2.5)

--- a/tests/units/test_arclith_langgraph.py
+++ b/tests/units/test_arclith_langgraph.py
@@ -3,6 +3,9 @@ from typing import Any, TypedDict
 import pytest
 
 from arclith import Arclith
+from arclith.infrastructure.langgraph_bootstrap import (
+    LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR,
+)
 
 langgraph_graph = pytest.importorskip("langgraph.graph")
 END = langgraph_graph.END
@@ -32,6 +35,10 @@ def test_langgraph_builds_compiled_graph(tmp_path):
     agent = arclith.langgraph(AgentState, register_agent, name="test_agent")
 
     assert registered["arclith"] is arclith
+    assert (
+        getattr(agent, LANGGRAPH_OBSERVABILITY_RUNTIME_ATTR)
+        is arclith._observability_runtime
+    )
     assert agent.invoke({"value": "ok"}) == {"value": "ok!"}
 
 
@@ -84,6 +91,8 @@ stream_mode: "updates"
         builder.add_edge(START, "echo")
         builder.add_edge("echo", END)
 
-    agent = arclith.langgraph(AgentState, register_agent, name="test_agent", stream_mode="values")
+    agent = arclith.langgraph(
+        AgentState, register_agent, name="test_agent", stream_mode="values"
+    )
 
     assert agent.stream_mode == "values"

--- a/tests/units/test_arclith_langsmith.py
+++ b/tests/units/test_arclith_langsmith.py
@@ -17,6 +17,7 @@ from arclith.adapters.outbound.noop.observability import (
     NoOpTraceAdapter,
 )
 from arclith.domain.ports.outbound.observability import TracePort, TraceSpan
+from arclith.infrastructure.config import LangSmithPropagationSettings
 
 
 class RecordingSpan(TraceSpan):
@@ -187,10 +188,12 @@ def test_arclith_fastapi_adds_langsmith_instrumentation_when_selected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[tuple[Any, Any]] = []
+    calls: list[tuple[Any, Any, Any]] = []
     monkeypatch.setattr(
         "arclith.adapters.outbound.langsmith.fastapi.instrument_fastapi_app",
-        lambda app, tracer: calls.append((app, tracer)),
+        lambda app, tracer, *, propagation: calls.append(
+            (app, tracer, propagation)
+        ),
     )
     arclith = Arclith(
         _config_dir(
@@ -201,7 +204,7 @@ def test_arclith_fastapi_adds_langsmith_instrumentation_when_selected(
 
     app = arclith.fastapi()
 
-    assert calls == [(app, arclith.tracer())]
+    assert calls == [(app, arclith.tracer(), LangSmithPropagationSettings())]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Résumé

- associe chaque graphe compilé par `Arclith.langgraph()` à son `ObservabilityRuntimePort` en mémoire, puis réutilise ce runtime dans le serveur durable
- ajoute une extraction provider-neutral au port de propagation et filtre case-insensitivement `langsmith-trace`, `traceparent`, `tracestate` et le baggage allowlisté
- entoure `wait` et `stream` par une span serveur `langgraph.runtime.run`, sans input/output métier, pendant les succès, erreurs, timeouts et annulations
- compose instrumentation FastAPI, `start`, `force_flush` et `shutdown` avec le lifecycle PostgreSQL/Redis, sans modifier `/ready`
- documente la propagation entrante dans les pages Observability et Runtime

## Sécurité et confidentialité

- `Authorization`, cookies, clés API, JWT et headers arbitraires sont éliminés avant le graphe
- le carrier filtré reste éphémère et ne rejoint ni `RunRecord`, ni le catalogue PostgreSQL, ni la config LangGraph persistée
- les seules métadonnées automatiques sont `thread_id`, `run_id`, `assistant_id` et le statut technique
- sans observabilité active, le propagateur et le tracer restent no-op, sans import fournisseur
- le middleware FastAPI respecte le flag de propagation et filtre le baggage avec la même allowlist que le runtime durable

## Validation

- `make precommit`
- `make complexity`
- `make coverage` : 1 642 tests réussis, 5 ignorés, couverture 90,93 %
- `make docs` avec `mkdocs build --strict`
- `uv lock --check`
- `cd cli && uv lock --check && uv run --frozen pytest -q` : 137 réussis, 1 ignoré
- tests dédiés wait/stream, activé/désactivé, filtrage des headers et du baggage, erreur, timeout, annulation, lifecycle et association graphe/runtime
- test live optionnel de hiérarchie LangSmith inter-service ajouté, ignoré sans `ARCLITH_LANGSMITH_INTEGRATION=1` et credentials

Closes #193