### PR TITLE
feat: ajouter la capability embedding déterministe

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -5,6 +5,7 @@ from arclith.adapters.outbound.azure_blob import (
     AzureBlobFileStorage,
     AzureBlobStorageConfig,
 )
+from arclith.adapters.outbound.deterministic import DeterministicEmbeddingAdapter
 from arclith.adapters.outbound.filesystem import (
     FilesystemFileStorage,
     FilesystemStorageConfig,
@@ -19,6 +20,20 @@ from arclith.arclith import Arclith
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.inbound.command_bus import CommandHandler
 from arclith.domain.ports.outbound.command_bus import CommandPublisher
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingAuthenticationError,
+    EmbeddingDimensionMismatch,
+    EmbeddingError,
+    EmbeddingInvalidInput,
+    EmbeddingPort,
+    EmbeddingRateLimitError,
+    EmbeddingResponse,
+    EmbeddingResult,
+    EmbeddingText,
+    EmbeddingUnavailable,
+    EmbeddingUsage,
+    validate_embedding_inputs,
+)
 from arclith.domain.ports.outbound.file_storage import (
     FileStorageConflict,
     FileStorageError,
@@ -54,6 +69,11 @@ from arclith.infrastructure.config import (
     load_config_dir,
     load_config_file,
 )
+from arclith.infrastructure.embedding_factory import (
+    EmbeddingRegistry,
+    build_embedding,
+    default_embedding_registry,
+)
 from arclith.infrastructure.file_storage_factory import (
     FileStorageRegistry,
     build_file_storage,
@@ -82,6 +102,19 @@ if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
 __all__ = [
     "Entity",
     "Repository",
+    "EmbeddingPort",
+    "EmbeddingText",
+    "EmbeddingResult",
+    "EmbeddingUsage",
+    "EmbeddingResponse",
+    "EmbeddingError",
+    "EmbeddingUnavailable",
+    "EmbeddingAuthenticationError",
+    "EmbeddingRateLimitError",
+    "EmbeddingInvalidInput",
+    "EmbeddingDimensionMismatch",
+    "validate_embedding_inputs",
+    "DeterministicEmbeddingAdapter",
     "FileStoragePort",
     "StoredObject",
     "StoredObjectMetadata",
@@ -131,6 +164,9 @@ __all__ = [
     "RepositoryRegistry",
     "build_repository",
     "default_repository_registry",
+    "EmbeddingRegistry",
+    "build_embedding",
+    "default_embedding_registry",
     "FileStorageRegistry",
     "build_file_storage",
     "default_file_storage_registry",

--- a/arclith/adapters/outbound/deterministic/__init__.py
+++ b/arclith/adapters/outbound/deterministic/__init__.py
@@ -1,0 +1,5 @@
+from arclith.adapters.outbound.deterministic.embedding import (
+    DeterministicEmbeddingAdapter,
+)
+
+__all__ = ["DeterministicEmbeddingAdapter"]

--- a/arclith/adapters/outbound/deterministic/embedding.py
+++ b/arclith/adapters/outbound/deterministic/embedding.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Sequence
+
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingPort,
+    EmbeddingResponse,
+    EmbeddingResult,
+    EmbeddingText,
+    validate_embedding_inputs,
+)
+from arclith.infrastructure.settings.embedding import EmbeddingSettings
+
+_UINT32_RANGE = float(2**32)
+
+
+class DeterministicEmbeddingAdapter(EmbeddingPort):
+    """Dependency-free deterministic vectors for tests and local smoke runs."""
+
+    def __init__(self, settings: EmbeddingSettings) -> None:
+        self._settings = settings
+
+    async def embed_texts(self, inputs: Sequence[EmbeddingText]) -> EmbeddingResponse:
+        validated = validate_embedding_inputs(inputs)
+        results: list[EmbeddingResult] = []
+
+        for batch_start in range(0, len(validated), self._settings.batch_size):
+            batch = validated[batch_start : batch_start + self._settings.batch_size]
+            results.extend(self._embed_batch(batch, offset=batch_start))
+
+        return EmbeddingResponse(
+            results=results,
+            model_name=self._settings.model_name,
+            dimensions=self._settings.dimensions,
+        )
+
+    def _embed_batch(
+        self,
+        inputs: Sequence[EmbeddingText],
+        *,
+        offset: int,
+    ) -> list[EmbeddingResult]:
+        return [
+            EmbeddingResult(
+                id=item.id,
+                index=offset + index,
+                vector=self._vector_for(item.text),
+                model_name=self._settings.model_name,
+                dimensions=self._settings.dimensions,
+            )
+            for index, item in enumerate(inputs)
+        ]
+
+    def _vector_for(self, text: str) -> list[float]:
+        vector: list[float] = []
+        counter = 0
+        seed = f"{self._settings.model_name}\0{text}".encode()
+
+        while len(vector) < self._settings.dimensions:
+            digest = hashlib.sha256(seed + counter.to_bytes(8, "big")).digest()
+            for position in range(0, len(digest), 4):
+                integer = int.from_bytes(digest[position : position + 4], "big")
+                vector.append(((integer + 0.5) / _UINT32_RANGE) * 2.0 - 1.0)
+                if len(vector) == self._settings.dimensions:
+                    break
+            counter += 1
+
+        if not self._settings.normalize:
+            return vector
+
+        norm = math.sqrt(sum(value * value for value in vector))
+        return [value / norm for value in vector]

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from arclith.domain.models.entity import Entity
+from arclith.domain.ports.outbound.embedding import EmbeddingPort
 from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
 from arclith.domain.ports.outbound.observability import (
@@ -26,6 +27,7 @@ from arclith.infrastructure.config import (
     load_config_dir,
     load_config_file,
 )
+from arclith.infrastructure.embedding_factory import EmbeddingRegistry
 from arclith.infrastructure.file_storage_factory import FileStorageRegistry
 from arclith.infrastructure.langgraph_bootstrap import (
     LANGGRAPH_UNSET as _LANGGRAPH_UNSET,
@@ -175,6 +177,15 @@ class Arclith:
         from arclith.infrastructure.file_storage_factory import build_file_storage
 
         return build_file_storage(self.config, self.logger, registry=registry)
+
+    def embedding(
+        self,
+        *,
+        registry: EmbeddingRegistry | None = None,
+    ) -> EmbeddingPort:
+        from arclith.infrastructure.embedding_factory import build_embedding
+
+        return build_embedding(self.config, self.logger, registry=registry)
 
     def rabbitmq_command_bus(self) -> "RabbitMQCommandBus":
         if not self.config.command_bus.is_enabled("rabbitmq"):

--- a/arclith/domain/ports/outbound/embedding.py
+++ b/arclith/domain/ports/outbound/embedding.py
@@ -143,4 +143,4 @@ class EmbeddingPort(ABC):
     @abstractmethod
     async def embed_texts(self, inputs: Sequence[EmbeddingText]) -> EmbeddingResponse:
         """Embed a non-empty text batch while preserving input order."""
-        ...
+        pass  # pragma: no cover

--- a/arclith/domain/ports/outbound/embedding.py
+++ b/arclith/domain/ports/outbound/embedding.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
+
+
+class EmbeddingError(Exception):
+    """Base error exposed by embedding adapters."""
+
+
+class EmbeddingUnavailable(EmbeddingError):
+    """Raised when the embedding provider is unavailable."""
+
+
+class EmbeddingAuthenticationError(EmbeddingError):
+    """Raised when provider credentials are rejected."""
+
+
+class EmbeddingRateLimitError(EmbeddingError):
+    """Raised when the provider rate-limits a request."""
+
+
+class EmbeddingInvalidInput(EmbeddingError):
+    """Raised before a provider call when an input batch is invalid."""
+
+
+class EmbeddingDimensionMismatch(EmbeddingError):
+    """Raised when provider vectors do not match the configured dimension."""
+
+
+class _EmbeddingModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class EmbeddingText(_EmbeddingModel):
+    """One provider-neutral text input, with an optional caller identifier."""
+
+    id: str | None = None
+    text: str
+
+    @field_validator("text")
+    @classmethod
+    def text_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("embedding text must not be empty")
+        return normalized
+
+
+class EmbeddingResult(_EmbeddingModel):
+    """One vector returned at the same index as its input text."""
+
+    id: str | None = None
+    index: NonNegativeInt
+    vector: list[float] = Field(min_length=1)
+    model_name: str
+    dimensions: PositiveInt
+
+    @field_validator("model_name")
+    @classmethod
+    def model_name_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("embedding model_name must not be empty")
+        return normalized
+
+    @model_validator(mode="after")
+    def vector_must_match_dimensions(self) -> "EmbeddingResult":
+        if len(self.vector) != self.dimensions:
+            raise ValueError(
+                "embedding vector length must match its declared dimensions"
+            )
+        return self
+
+
+class EmbeddingUsage(_EmbeddingModel):
+    """Optional provider usage metadata."""
+
+    prompt_tokens: NonNegativeInt | None = None
+    total_tokens: NonNegativeInt | None = None
+
+
+class EmbeddingResponse(_EmbeddingModel):
+    """Ordered, dimension-consistent response for one input batch."""
+
+    results: list[EmbeddingResult] = Field(min_length=1)
+    model_name: str
+    dimensions: PositiveInt
+    usage: EmbeddingUsage | None = None
+
+    @field_validator("model_name")
+    @classmethod
+    def model_name_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("embedding model_name must not be empty")
+        return normalized
+
+    @model_validator(mode="after")
+    def results_must_be_ordered_and_consistent(self) -> "EmbeddingResponse":
+        actual_indices = [result.index for result in self.results]
+        expected_indices = list(range(len(self.results)))
+        if actual_indices != expected_indices:
+            raise ValueError(
+                "embedding result indices must preserve input order starting at zero"
+            )
+        if any(result.model_name != self.model_name for result in self.results):
+            raise ValueError(
+                "embedding result model_name must match the response model_name"
+            )
+        if any(result.dimensions != self.dimensions for result in self.results):
+            raise ValueError(
+                "embedding result dimensions must match the response dimensions"
+            )
+        return self
+
+
+def validate_embedding_inputs(
+    inputs: Sequence[EmbeddingText],
+) -> tuple[EmbeddingText, ...]:
+    """Materialize and validate a non-empty provider input batch."""
+    validated = tuple(inputs)
+    if not validated:
+        raise EmbeddingInvalidInput("embedding inputs must not be empty")
+    if any(not item.text.strip() for item in validated):
+        raise EmbeddingInvalidInput("embedding text must not be empty")
+    return validated
+
+
+class EmbeddingPort(ABC):
+    """Outbound port that computes vectors without persisting content."""
+
+    @abstractmethod
+    async def embed_texts(self, inputs: Sequence[EmbeddingText]) -> EmbeddingResponse:
+        """Embed a non-empty text batch while preserving input order."""
+        ...

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -14,6 +14,8 @@ from arclith.infrastructure.settings import (  # noqa: F401
     CommandBusAdapter,
     CommandBusSettings,
     DuckDBSettings,
+    EmbeddingAdapter,
+    EmbeddingSettings,
     ETagSettings,
     HttpSettings,
     IdempotencySettings,

--- a/arclith/infrastructure/embedding_factory.py
+++ b/arclith/infrastructure/embedding_factory.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from arclith.domain.ports.outbound.embedding import EmbeddingPort
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.infrastructure.config import AppConfig
+
+EmbeddingFactory = Callable[[AppConfig, Logger], EmbeddingPort]
+
+
+class EmbeddingRegistry:
+    """Registry mapping embedding adapter names to factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, EmbeddingFactory] = {}
+
+    def register(self, name: str, factory: EmbeddingFactory) -> "EmbeddingRegistry":
+        self._factories[name] = factory
+        return self
+
+    def build(self, config: AppConfig, logger: Logger) -> EmbeddingPort:
+        settings = config.adapters.embedding
+        if settings is None:
+            raise ValueError("adapters.embedding is required to build embeddings")
+        if settings.adapter not in self._factories:
+            raise ValueError(
+                f"Embedding adapter '{settings.adapter}' not registered. "
+                f"Available: {sorted(self._factories)}."
+            )
+        return self._factories[settings.adapter](config, logger)
+
+
+def build_embedding(
+    config: AppConfig,
+    logger: Logger,
+    *,
+    registry: EmbeddingRegistry | None = None,
+) -> EmbeddingPort:
+    active_registry = registry or default_embedding_registry()
+    return active_registry.build(config, logger)
+
+
+def default_embedding_registry() -> EmbeddingRegistry:
+    return EmbeddingRegistry().register("deterministic", _build_deterministic)
+
+
+def _build_deterministic(config: AppConfig, _logger: Logger) -> EmbeddingPort:
+    from arclith.adapters.outbound.deterministic import (
+        DeterministicEmbeddingAdapter,
+    )
+
+    settings = config.adapters.embedding
+    if settings is None:
+        raise ValueError("Deterministic embedding settings are required")
+    return DeterministicEmbeddingAdapter(settings)

--- a/arclith/infrastructure/settings/__init__.py
+++ b/arclith/infrastructure/settings/__init__.py
@@ -26,6 +26,10 @@ from arclith.infrastructure.settings.langgraph import (
     LangGraphStoreSettings,
     LangGraphStreamMode,
 )
+from arclith.infrastructure.settings.embedding import (
+    EmbeddingAdapter,
+    EmbeddingSettings,
+)
 from arclith.infrastructure.settings.langsmith import (
     LangSmithCaptureSettings,
     LangSmithDiagnosticsSettings,
@@ -78,6 +82,8 @@ __all__ = [
     "CommandBusAdapter",
     "CommandBusSettings",
     "DuckDBSettings",
+    "EmbeddingAdapter",
+    "EmbeddingSettings",
     "ETagSettings",
     "HttpSettings",
     "IdempotencySettings",

--- a/arclith/infrastructure/settings/app.py
+++ b/arclith/infrastructure/settings/app.py
@@ -6,6 +6,7 @@ from pydantic import Field, field_validator, model_validator
 
 from arclith.infrastructure.settings._base import SettingsModel
 
+from arclith.infrastructure.settings.embedding import EmbeddingSettings
 from arclith.infrastructure.settings.langgraph import LangGraphSettings
 from arclith.infrastructure.settings.langsmith import LangSmithSettings
 from arclith.infrastructure.settings.llm import LMSettings
@@ -55,6 +56,7 @@ class AdaptersSettings(SettingsModel):
     mariadb: MariaDBSettings | None = None
     postgresql: PostgreSQLSettings | None = None
     storage: StorageSettings | None = None
+    embedding: EmbeddingSettings | None = None
     lm: LMSettings | None = None
     langsmith: LangSmithSettings | None = None
     opentelemetry: OpenTelemetrySettings | None = None

--- a/arclith/infrastructure/settings/embedding.py
+++ b/arclith/infrastructure/settings/embedding.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated
 
-from pydantic import PositiveInt, field_validator
+from pydantic import PositiveInt, StringConstraints, field_validator
 
 from arclith.infrastructure.settings._base import SettingsModel
 
-EmbeddingAdapter = Literal["deterministic"]
+EmbeddingAdapter = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
 
 
 class EmbeddingSettings(SettingsModel):

--- a/arclith/infrastructure/settings/embedding.py
+++ b/arclith/infrastructure/settings/embedding.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import PositiveInt, field_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
+
+EmbeddingAdapter = Literal["deterministic"]
+
+
+class EmbeddingSettings(SettingsModel):
+    adapter: EmbeddingAdapter
+    model_name: str
+    dimensions: PositiveInt
+    batch_size: PositiveInt = 64
+    normalize: bool = True
+    multitenant: bool = False
+
+    @field_validator("model_name")
+    @classmethod
+    def model_name_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("embedding model_name must not be empty")
+        return normalized

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -15,6 +15,7 @@ from arclith_cli.capability_models import (
 from arclith_cli.catalogs.ai import (
     AGENT_CAPABILITY,
     AGENT_PERSISTENCE_CAPABILITY,
+    EMBEDDING_CAPABILITY,
     LLM_CAPABILITY,
 )
 from arclith_cli.catalogs.core import (
@@ -49,6 +50,7 @@ __all__ = [
     "CAPABILITY_CATALOG",
     "COMMAND_BUS_CAPABILITY",
     "CapabilitySpec",
+    "EMBEDDING_CAPABILITY",
     "FileTemplateSpec",
     "HTTP_CAPABILITY",
     "LICENSE_CAPABILITY",
@@ -88,6 +90,7 @@ CAPABILITY_CATALOG = (
     TENANT_CAPABILITY,
     LICENSE_CAPABILITY,
     LLM_CAPABILITY,
+    EMBEDDING_CAPABILITY,
     AGENT_CAPABILITY,
     AGENT_PERSISTENCE_CAPABILITY,
     OBSERVABILITY_CAPABILITY,

--- a/cli/arclith_cli/catalogs/ai.py
+++ b/cli/arclith_cli/catalogs/ai.py
@@ -135,6 +135,64 @@ ANTHROPIC_API_KEY={api_key}
     ),
 )
 
+EMBEDDING_CAPABILITY = CapabilitySpec(
+    name="embedding",
+    layer="outbound",
+    description="Calcul de vecteurs texte derrière un port provider-neutral, sans persistance.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="deterministic",
+            capability="embedding",
+            layer="outbound",
+            description="Vecteurs déterministes sans dépendance pour tests et smoke locaux.",
+            config_path="config/adapters/outbound/embedding.yaml",
+            config_template="""\
+adapter: deterministic
+model_name: "{model_name}"
+dimensions: {dimensions}
+batch_size: {batch_size}
+normalize: {normalize}
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="model_name",
+                    kind="string",
+                    prompt="Nom du modèle déterministe",
+                    default="deterministic-test",
+                ),
+                ParameterSpec(
+                    name="dimensions",
+                    kind="string",
+                    prompt="Dimension des vecteurs",
+                    default="1536",
+                ),
+                ParameterSpec(
+                    name="batch_size",
+                    kind="string",
+                    prompt="Taille maximale des sous-batches",
+                    default="64",
+                ),
+                ParameterSpec(
+                    name="normalize",
+                    kind="boolean",
+                    prompt="Normaliser les vecteurs en norme L2",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Réserver la résolution de contexte par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)
+
+
 AGENT_CAPABILITY = CapabilitySpec(
     name="agent",
     layer="inbound",

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -164,8 +164,8 @@ def add_adapter(
             "--capability",
             help=(
                 "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, http, "
-                "command-bus, runtime, auth, tenant, license, llm, agent, agent-persistence "
-                "ou observability"
+                "command-bus, runtime, auth, tenant, license, llm, embedding, agent, "
+                "agent-persistence ou observability"
             ),
         ),
     ] = "repository",

--- a/cli/tests/test_embedding_capability.py
+++ b/cli/tests/test_embedding_capability.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+from arclith_cli.add_adapter import add_adapter_cmd
+from arclith_cli.capabilities import capability_catalog_as_dict, get_capability
+
+
+def _minimal_project(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "demo-service"
+    (project_dir / "src" / "demo_service" / "domain" / "models").mkdir(parents=True)
+    config_dir = project_dir / "config" / "adapters"
+    config_dir.mkdir(parents=True)
+    (config_dir / "adapters.yaml").write_text(
+        "logger: console\nrepository: memory\nobservability:\n  enabled: []\n",
+        encoding="utf-8",
+    )
+    return project_dir
+
+
+def test_embedding_capability_catalog_declares_deterministic_adapter() -> None:
+    capability = get_capability("embedding")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("deterministic",)
+    deterministic = capability.get_adapter("deterministic")
+    assert deterministic is not None
+    assert deterministic.entity_scoped is False
+    assert deterministic.config_path == "config/adapters/outbound/embedding.yaml"
+    assert [parameter.name for parameter in deterministic.parameters] == [
+        "model_name",
+        "dimensions",
+        "batch_size",
+        "normalize",
+        "multitenant",
+    ]
+
+
+def test_embedding_capability_is_exposed_in_json_catalog() -> None:
+    payload_by_name = {
+        capability["name"]: capability for capability in capability_catalog_as_dict()
+    }
+
+    embedding = payload_by_name["embedding"]
+    assert embedding["activation_config_key"] is None
+    assert [adapter["name"] for adapter in embedding["adapters"]] == ["deterministic"]
+
+
+def test_add_deterministic_embedding_generates_loadable_config_idempotently(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    params = {
+        "model_name": "deterministic-smoke",
+        "dimensions": "24",
+        "batch_size": "3",
+        "normalize": "true",
+        "multitenant": "false",
+    }
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="embedding",
+            adapter="deterministic",
+            adapter_params=params,
+            yes=True,
+        )
+
+    from arclith import Arclith, DeterministicEmbeddingAdapter
+
+    config_path = project_dir / "config" / "adapters" / "outbound" / "embedding.yaml"
+    app = Arclith(project_dir / "config")
+
+    assert config_path.read_text(encoding="utf-8") == (
+        "adapter: deterministic\n"
+        'model_name: "deterministic-smoke"\n'
+        "dimensions: 24\n"
+        "batch_size: 3\n"
+        "normalize: true\n"
+        "multitenant: false\n"
+    )
+    assert app.config.adapters.embedding is not None
+    assert app.config.adapters.embedding.dimensions == 24
+    assert isinstance(app.embedding(), DeterministicEmbeddingAdapter)
+    assert "embedding:" not in (
+        project_dir / "config" / "adapters" / "adapters.yaml"
+    ).read_text(encoding="utf-8")

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,6 +36,7 @@ arclith-cli capabilities --json
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |
 | [secrets](capabilities/secrets.md) | outbound | `env`, `yaml`, `vault`, `chain` | résoudre les secrets |
 | [llm](capabilities/llm.md) | outbound | `lmstudio`, `openai`, `anthropic` | configurer les modèles |
+| [embedding](capabilities/embedding.md) | outbound | `deterministic` | calculer des vecteurs texte sans les persister |
 | [observability](capabilities/observability.md) ([OpenTelemetry](capabilities/opentelemetry.md)) | outbound | `langsmith`, `opentelemetry` | traces, métriques, logs et agents |
 | [command-bus](capabilities/command-bus.md) | bidirectional | `rabbitmq` | consommer et publier des commandes |
 | [runtime](capabilities/runtime.md) | runtime | `docker-image` | générer le runtime conteneur |
@@ -48,6 +49,7 @@ arclith-cli capabilities --json
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
 | Agent local | [Quickstart Agent](quickstarts/agent.md), [formation agent](tutorials/todo-list/06-agent.md), puis [agent/langgraph](capabilities/agent.md) et [persistance](capabilities/agent-persistence.md) |
+| Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis la capability vector-store adaptée |
 | Observabilité locale | [OpenTelemetry de bout en bout](capabilities/opentelemetry.md), puis [observabilité production](production/observability.md) |
 | Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -108,6 +108,18 @@ assert len(response.results[0].vector) == 1536
 
 Une application peut fournir un `EmbeddingRegistry` à `app.embedding()` pour
 enregistrer un backend propre au projet sans importer son SDK dans le domaine.
+Dans ce cas, `adapter` accepte le nom non vide déclaré par l'application ; le
+registry valide ce nom à l'assemblage et retourne une erreur claire s'il n'est
+pas enregistré :
+
+```python
+from arclith import EmbeddingRegistry
+
+registry = EmbeddingRegistry().register("project", build_project_embedding)
+embedding = app.embedding(registry=registry)
+```
+
+La configuration scoped associée contient alors `adapter: project`.
 
 ## Dimension Et Normalisation
 

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -1,0 +1,146 @@
+# Capability Embedding
+
+`embedding` transforme des textes en vecteurs numériques derrière un port
+outbound provider-neutral. Le port calcule seulement les vecteurs : il ne
+stocke ni document, ni chunk, ni conversation.
+
+## Choisir La Bonne Primitive
+
+| Besoin | Primitive Arclith | Responsabilité |
+|---|---|---|
+| produire une réponse ou une structure | `llm` | complétion et raisonnement |
+| transformer du texte en vecteur | `embedding` | calcul numérique sans persistance |
+| rechercher les vecteurs voisins | `vector-store` | indexation et recherche vectorielle |
+| conserver l'entité et ses métadonnées | `repository` | source de vérité métier |
+| conserver le contenu binaire | `storage` | fichiers et blobs |
+
+Un pipeline RAG assemble donc explicitement les responsabilités :
+
+```text
+document source -> chunks -> EmbeddingPort -> vector-store
+       |                                      |
+       +-> repository/storage (source)        +-> index dérivé
+```
+
+L'index vectoriel reste reconstruisible. Le service consommateur doit conserver
+avec chaque entrée au moins le modèle, la dimension, le hash du contenu et la
+stratégie de chunking afin de pouvoir détecter puis réindexer un contenu obsolète.
+
+## Contrat Commun
+
+```python
+from arclith import EmbeddingPort, EmbeddingText
+
+
+async def embed_titles(embedding: EmbeddingPort) -> list[list[float]]:
+    response = await embedding.embed_texts(
+        [
+            EmbeddingText(id="doc-1", text="Architecture hexagonale"),
+            EmbeddingText(id="doc-2", text="Recherche vectorielle"),
+        ]
+    )
+    return [result.vector for result in response.results]
+```
+
+`EmbeddingResponse` garantit :
+
+- au moins un résultat ;
+- des indices continus `0..n-1`, dans l'ordre des entrées ;
+- un seul `model_name` et une seule dimension pour tout le batch ;
+- un vecteur non vide dont la longueur égale `dimensions` ;
+- des métriques de tokens optionnelles via `EmbeddingUsage`.
+
+Les entrées vides ou composées uniquement d'espaces sont rejetées avant tout
+appel provider. Les adapters concrets traduisent leurs erreurs en
+`EmbeddingUnavailable`, `EmbeddingAuthenticationError`,
+`EmbeddingRateLimitError`, `EmbeddingInvalidInput` ou
+`EmbeddingDimensionMismatch`. Les messages ne doivent jamais inclure de secret
+ou d'URL contenant des credentials.
+
+## Adapter Deterministic
+
+`deterministic` ne requiert aucune dépendance externe. Pour un même
+`model_name`, un même texte et une même dimension, il produit le même vecteur
+entre deux processus. Il sert aux tests, aux POC et aux smokes locaux ; il ne
+modélise aucune proximité sémantique réelle et ne doit pas être utilisé comme
+moteur de recherche en production.
+
+```bash
+arclith-cli add-adapter \
+  --capability embedding \
+  --adapter deterministic \
+  --param model_name=deterministic-test \
+  --param dimensions=1536 \
+  --param batch_size=64 \
+  --param normalize=true \
+  --yes
+```
+
+La commande est idempotente et écrit
+`config/adapters/outbound/embedding.yaml` :
+
+```yaml
+adapter: deterministic
+model_name: deterministic-test
+dimensions: 1536
+batch_size: 64
+normalize: true
+multitenant: false
+```
+
+Le fichier scoped contient son propre sélecteur `adapter`. Il n'ajoute aucune
+clé à `config/adapters/adapters.yaml`.
+
+## Assemblage
+
+```python
+from arclith import Arclith, EmbeddingText
+
+app = Arclith("config")
+embedding = app.embedding()
+
+response = await embedding.embed_texts(
+    [EmbeddingText(id="smoke", text="bonjour")]
+)
+assert response.dimensions == 1536
+assert len(response.results[0].vector) == 1536
+```
+
+Une application peut fournir un `EmbeddingRegistry` à `app.embedding()` pour
+enregistrer un backend propre au projet sans importer son SDK dans le domaine.
+
+## Dimension Et Normalisation
+
+La dimension configurée doit être identique à celle de la collection du
+vector-store. Cette vérification doit avoir lieu à l'assemblage ou avant la
+première écriture ; tronquer ou compléter silencieusement un vecteur rendrait
+l'index incohérent.
+
+Avec `normalize: true`, l'adapter déterministe applique une normalisation L2.
+Les futurs providers peuvent déjà retourner des vecteurs normalisés ou proposer
+leur propre option. Le service doit documenter la métrique de distance choisie
+avec le vector-store et ne pas supposer que tous les providers ont la même
+stratégie.
+
+## Conversations Et Vie Privée
+
+L'historique de chat ne doit pas être vectorisé automatiquement. Une telle
+indexation dupliquerait des données potentiellement personnelles, changerait
+leur durée de rétention et créerait un nouvel usage de recherche. Elle exige un
+use case explicite, une politique de consentement/rétention, un filtrage des
+données sensibles et une procédure de suppression cohérente entre source et
+index.
+
+## Validation Locale
+
+```bash
+uv run pytest tests/units/domain/ports/test_embedding.py \
+  tests/units/adapters/outbound/test_deterministic_embedding.py \
+  tests/units/infrastructure/test_embedding_factory.py
+uv run --project cli pytest cli/tests/test_embedding_capability.py
+make docs
+```
+
+Le smoke doit vérifier la dimension, l'ordre des résultats et la stabilité du
+vecteur. Une recherche sémantique pertinente reste hors scope de l'adapter
+`deterministic`.

--- a/journal/2026-09-01-embedding-capability.md
+++ b/journal/2026-09-01-embedding-capability.md
@@ -32,7 +32,7 @@ le contrat commun et vérifier explicitement la compatibilité des dimensions.
 
 ## Validation
 
-- `make quality` : 1 683 tests passés, 5 ignorés, couverture 91 % ;
+- `make quality` : 1 684 tests passés, 5 ignorés, couverture 91 % ;
 - `make precommit` : lint, mypy et Bandit passés ;
 - tests CLI : 140 passés, 1 ignoré ;
 - `make docs` : build MkDocs strict passé.

--- a/journal/2026-09-01-embedding-capability.md
+++ b/journal/2026-09-01-embedding-capability.md
@@ -1,0 +1,38 @@
+# Capability embedding provider-neutral
+
+## Contexte
+
+La roadmap CLI distinguait déjà les LLM, le stockage de fichiers et les
+repositories, mais ne fournissait pas de contrat commun pour calculer des
+embeddings texte. Les futurs adapters OpenAI-compatible et OpenAI avaient besoin
+d'un socle qui ne couple ni le domaine à un SDK, ni le calcul à la persistance.
+
+## Décision
+
+- ajouter `EmbeddingPort` et des modèles Pydantic stricts qui valident les
+  entrées, l'ordre, le modèle et la dimension des résultats ;
+- exposer des erreurs provider-neutral sans données sensibles ;
+- assembler les adapters avec `EmbeddingRegistry`, `build_embedding()` et
+  `Arclith.embedding()` ;
+- fournir `deterministic`, un adapter sans dépendance, stable entre processus et
+  normalisable, réservé aux tests et smokes ;
+- charger la configuration depuis
+  `config/adapters/outbound/embedding.yaml`, sans sélecteur global ;
+- déclarer la capability dans le catalogue CLI et documenter sa frontière avec
+  `llm`, `vector-store`, `repository` et `storage`.
+
+## Impact
+
+Un service peut désormais tester localement la partie embedding d'un pipeline
+RAG sans provider externe. L'index vectoriel demeure une projection dérivée :
+la source reste dans le repository ou le storage du service consommateur.
+
+Les adapters OpenAI-compatible, OpenAI et les vector-stores pourront réutiliser
+le contrat commun et vérifier explicitement la compatibilité des dimensions.
+
+## Validation
+
+- `make quality` : 1 683 tests passés, 5 ignorés, couverture 91 % ;
+- `make precommit` : lint, mypy et Bandit passés ;
+- tests CLI : 140 passés, 1 ignoré ;
+- `make docs` : build MkDocs strict passé.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - License: capabilities/license.md
       - HTTP: capabilities/http.md
       - LLM: capabilities/llm.md
+      - Embedding: capabilities/embedding.md
       - Observability:
           - Vue d'ensemble: capabilities/observability.md
           - OpenTelemetry: capabilities/opentelemetry.md

--- a/tests/units/adapters/outbound/test_deterministic_embedding.py
+++ b/tests/units/adapters/outbound/test_deterministic_embedding.py
@@ -1,0 +1,64 @@
+import math
+
+import pytest
+
+from arclith.adapters.outbound.deterministic import DeterministicEmbeddingAdapter
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingInvalidInput,
+    EmbeddingText,
+)
+from arclith.infrastructure.settings.embedding import EmbeddingSettings
+
+
+def _adapter(*, dimensions: int = 8, batch_size: int = 2, normalize: bool = True):
+    return DeterministicEmbeddingAdapter(
+        EmbeddingSettings(
+            adapter="deterministic",
+            model_name="deterministic-test",
+            dimensions=dimensions,
+            batch_size=batch_size,
+            normalize=normalize,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_deterministic_embedding_is_stable_across_instances() -> None:
+    inputs = [EmbeddingText(id="doc-1", text="stable text")]
+
+    first = await _adapter().embed_texts(inputs)
+    second = await _adapter().embed_texts(inputs)
+
+    assert first == second
+    assert first.results[0].id == "doc-1"
+    assert len(first.results[0].vector) == 8
+
+
+@pytest.mark.asyncio
+async def test_deterministic_embedding_preserves_order_across_sub_batches() -> None:
+    inputs = [
+        EmbeddingText(id=f"doc-{index}", text=f"text {index}") for index in range(5)
+    ]
+
+    response = await _adapter(batch_size=2).embed_texts(inputs)
+
+    assert [result.index for result in response.results] == list(range(5))
+    assert [result.id for result in response.results] == [
+        f"doc-{index}" for index in range(5)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deterministic_embedding_normalizes_vectors_when_enabled() -> None:
+    response = await _adapter(dimensions=16).embed_texts(
+        [EmbeddingText(text="normalized")]
+    )
+
+    norm = math.sqrt(sum(value * value for value in response.results[0].vector))
+    assert norm == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_deterministic_embedding_rejects_empty_batch() -> None:
+    with pytest.raises(EmbeddingInvalidInput, match="inputs must not be empty"):
+        await _adapter().embed_texts([])

--- a/tests/units/domain/ports/test_embedding.py
+++ b/tests/units/domain/ports/test_embedding.py
@@ -1,0 +1,76 @@
+import pytest
+from pydantic import ValidationError
+
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingInvalidInput,
+    EmbeddingResponse,
+    EmbeddingResult,
+    EmbeddingText,
+    validate_embedding_inputs,
+)
+
+
+def _result(
+    index: int,
+    *,
+    dimensions: int = 2,
+    model_name: str = "test-model",
+) -> EmbeddingResult:
+    return EmbeddingResult(
+        index=index,
+        vector=[0.25] * dimensions,
+        model_name=model_name,
+        dimensions=dimensions,
+    )
+
+
+def test_embedding_text_trims_and_rejects_empty_content() -> None:
+    assert EmbeddingText(text="  hello  ").text == "hello"
+
+    with pytest.raises(ValidationError, match="must not be empty"):
+        EmbeddingText(text=" \n\t ")
+
+
+def test_validate_embedding_inputs_rejects_empty_batch() -> None:
+    with pytest.raises(EmbeddingInvalidInput, match="inputs must not be empty"):
+        validate_embedding_inputs([])
+
+
+def test_embedding_result_rejects_vector_dimension_mismatch() -> None:
+    with pytest.raises(ValidationError, match="vector length"):
+        EmbeddingResult(
+            index=0,
+            vector=[0.25],
+            model_name="test-model",
+            dimensions=2,
+        )
+
+
+def test_embedding_response_accepts_ordered_consistent_results() -> None:
+    response = EmbeddingResponse(
+        results=[_result(0), _result(1)],
+        model_name="test-model",
+        dimensions=2,
+    )
+
+    assert [result.index for result in response.results] == [0, 1]
+    assert response.dimensions == 2
+
+
+@pytest.mark.parametrize(
+    ("results", "message"),
+    [
+        ([_result(1), _result(0)], "preserve input order"),
+        ([_result(0, dimensions=3)], "response dimensions"),
+        ([_result(0, model_name="other-model")], "response model_name"),
+    ],
+)
+def test_embedding_response_rejects_inconsistent_results(
+    results: list[EmbeddingResult], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        EmbeddingResponse(
+            results=results,
+            model_name="test-model",
+            dimensions=2,
+        )

--- a/tests/units/infrastructure/test_embedding_config.py
+++ b/tests/units/infrastructure/test_embedding_config.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from arclith.infrastructure.config import load_config_dir
+
+
+def test_load_config_dir_loads_scoped_embedding_settings(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    embedding_dir = config_dir / "adapters" / "outbound"
+    embedding_dir.mkdir(parents=True)
+    (embedding_dir / "embedding.yaml").write_text(
+        "adapter: deterministic\n"
+        "model_name: deterministic-local\n"
+        "dimensions: 32\n"
+        "batch_size: 8\n"
+        "normalize: false\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.embedding is not None
+    assert config.adapters.embedding.model_name == "deterministic-local"
+    assert config.adapters.embedding.dimensions == 32
+    assert config.adapters.embedding.batch_size == 8
+    assert config.adapters.embedding.normalize is False
+
+
+@pytest.mark.parametrize("field", ["dimensions", "batch_size"])
+def test_embedding_settings_require_positive_sizes(tmp_path: Path, field: str) -> None:
+    config_dir = tmp_path / "config"
+    embedding_dir = config_dir / "adapters" / "outbound"
+    embedding_dir.mkdir(parents=True)
+    values = {"dimensions": 12, "batch_size": 4}
+    values[field] = 0
+    (embedding_dir / "embedding.yaml").write_text(
+        "adapter: deterministic\n"
+        "model_name: deterministic-local\n"
+        f"dimensions: {values['dimensions']}\n"
+        f"batch_size: {values['batch_size']}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match=field):
+        load_config_dir(config_dir)

--- a/tests/units/infrastructure/test_embedding_config.py
+++ b/tests/units/infrastructure/test_embedding_config.py
@@ -46,3 +46,16 @@ def test_embedding_settings_require_positive_sizes(tmp_path: Path, field: str) -
 
     with pytest.raises(ValidationError, match=field):
         load_config_dir(config_dir)
+
+
+def test_embedding_settings_reject_empty_adapter_name(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    embedding_dir = config_dir / "adapters" / "outbound"
+    embedding_dir.mkdir(parents=True)
+    (embedding_dir / "embedding.yaml").write_text(
+        "adapter: '   '\nmodel_name: deterministic-local\ndimensions: 12\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="adapters.embedding.adapter"):
+        load_config_dir(config_dir)

--- a/tests/units/infrastructure/test_embedding_factory.py
+++ b/tests/units/infrastructure/test_embedding_factory.py
@@ -1,0 +1,104 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from arclith import Arclith
+from arclith.adapters.outbound.deterministic import DeterministicEmbeddingAdapter
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingPort,
+    EmbeddingResponse,
+    EmbeddingText,
+)
+from arclith.infrastructure.config import AppConfig
+from arclith.infrastructure.embedding_factory import (
+    EmbeddingRegistry,
+    build_embedding,
+    default_embedding_registry,
+)
+from arclith.infrastructure.settings.embedding import EmbeddingSettings
+
+
+class StubEmbedding(EmbeddingPort):
+    async def embed_texts(self, inputs: Sequence[EmbeddingText]) -> EmbeddingResponse:
+        raise NotImplementedError
+
+
+def _config() -> AppConfig:
+    return AppConfig.model_validate(
+        {
+            "adapters": {
+                "embedding": {
+                    "adapter": "deterministic",
+                    "model_name": "deterministic-test",
+                    "dimensions": 12,
+                    "batch_size": 4,
+                    "normalize": True,
+                }
+            }
+        }
+    )
+
+
+def test_build_embedding_returns_deterministic_adapter(logger) -> None:
+    embedding = build_embedding(_config(), logger)
+
+    assert isinstance(embedding, DeterministicEmbeddingAdapter)
+
+
+def test_build_embedding_requires_config(logger) -> None:
+    with pytest.raises(ValueError, match="adapters.embedding"):
+        build_embedding(AppConfig(), logger)
+
+
+def test_custom_embedding_registry_builds_registered_adapter(logger) -> None:
+    expected = StubEmbedding()
+    config = AppConfig()
+    custom_settings = EmbeddingSettings.model_construct(
+        adapter="custom",
+        model_name="custom-model",
+        dimensions=3,
+        batch_size=1,
+        normalize=False,
+        multitenant=False,
+    )
+    config = config.model_copy(
+        update={
+            "adapters": config.adapters.model_copy(
+                update={"embedding": custom_settings}
+            )
+        }
+    )
+    registry = EmbeddingRegistry().register("custom", lambda _config, _logger: expected)
+
+    assert build_embedding(config, logger, registry=registry) is expected
+
+
+def test_default_embedding_registry_rejects_unknown_adapter(logger) -> None:
+    config = _config()
+    assert config.adapters.embedding is not None
+    unknown = config.adapters.embedding.model_copy(update={"adapter": "unknown"})
+    config = config.model_copy(
+        update={"adapters": config.adapters.model_copy(update={"embedding": unknown})}
+    )
+
+    with pytest.raises(ValueError, match="not registered"):
+        default_embedding_registry().build(config, logger)
+
+
+def test_arclith_builds_configured_embedding(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    embedding_dir = config_dir / "adapters" / "outbound"
+    embedding_dir.mkdir(parents=True)
+    (embedding_dir / "embedding.yaml").write_text(
+        "adapter: deterministic\n"
+        "model_name: deterministic-smoke\n"
+        "dimensions: 6\n"
+        "batch_size: 2\n"
+        "normalize: true\n",
+        encoding="utf-8",
+    )
+
+    app = Arclith(config_dir)
+
+    assert isinstance(app.embedding(), DeterministicEmbeddingAdapter)

--- a/tests/units/infrastructure/test_embedding_factory.py
+++ b/tests/units/infrastructure/test_embedding_factory.py
@@ -16,7 +16,6 @@ from arclith.infrastructure.embedding_factory import (
     build_embedding,
     default_embedding_registry,
 )
-from arclith.infrastructure.settings.embedding import EmbeddingSettings
 
 
 class StubEmbedding(EmbeddingPort):
@@ -53,20 +52,17 @@ def test_build_embedding_requires_config(logger) -> None:
 
 def test_custom_embedding_registry_builds_registered_adapter(logger) -> None:
     expected = StubEmbedding()
-    config = AppConfig()
-    custom_settings = EmbeddingSettings.model_construct(
-        adapter="custom",
-        model_name="custom-model",
-        dimensions=3,
-        batch_size=1,
-        normalize=False,
-        multitenant=False,
-    )
-    config = config.model_copy(
-        update={
-            "adapters": config.adapters.model_copy(
-                update={"embedding": custom_settings}
-            )
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "embedding": {
+                    "adapter": "custom",
+                    "model_name": "custom-model",
+                    "dimensions": 3,
+                    "batch_size": 1,
+                    "normalize": False,
+                }
+            }
         }
     )
     registry = EmbeddingRegistry().register("custom", lambda _config, _logger: expected)

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -43,6 +43,15 @@ def test_public_file_storage_exports():
     assert arclith.GCSFileStorage is not None
 
 
+def test_public_embedding_exports():
+    registry = arclith.default_embedding_registry()
+
+    assert isinstance(registry, arclith.EmbeddingRegistry)
+    assert arclith.build_embedding is not None
+    assert arclith.EmbeddingPort is not None
+    assert arclith.DeterministicEmbeddingAdapter is not None
+
+
 def test_import_arclith_does_not_require_s3_extra():
     script = """
 import importlib.abc


### PR DESCRIPTION
## Contexte

Traite #149, enfant de la roadmap #57, en ajoutant le contrat provider-neutral requis par les futurs adapters OpenAI-compatible/OpenAI et vector-stores.

Closes #149

## Changements

- ajoute `EmbeddingPort`, les modèles/règles de cohérence et les erreurs communes ;
- ajoute `EmbeddingRegistry`, `build_embedding()`, `Arclith.embedding()` et l’adapter sans dépendance `deterministic` ;
- charge `config/adapters/outbound/embedding.yaml` sous `adapters.embedding` ;
- expose `embedding/deterministic` dans le catalogue et le scaffold idempotent de `arclith-cli` ;
- documente les frontières LLM/embedding/vector-store/repository/storage et le pipeline RAG recommandé.

## Impact

- API publique Python : nouveau port, nouveaux modèles/erreurs, factory/registry et méthode d’assemblage ;
- configuration : nouvelle section optionnelle `adapters.embedding`, sans migration ni changement des configurations existantes ;
- domaine : aucun SDK provider et aucune persistance ajoutés ;
- données, HTTP, RabbitMQ, MCP et déploiement : aucun impact ;
- release : commit `feat` releasable pour le framework et catalogue CLI associé.

## Validation

- `make quality` — 1 684 passés, 5 ignorés, couverture 91 % ;
- `make precommit` — Ruff, mypy et Bandit passés ;
- `uv run --project cli --frozen pytest -q cli/tests` — 140 passés, 1 ignoré ;
- `make docs` — MkDocs strict passé ;
- hook pre-push complet passé sur le commit publié.

## Documentation

- `docs/capabilities/embedding.md`, index et navigation MkDocs ajoutés ;
- journal : `journal/2026-09-01-embedding-capability.md` ;
- ADR : non applicable, le design suit les registries/factories existants.

## Risques restants

L’adapter déterministe est volontairement non sémantique. Les providers réseau, secrets et mappings d’erreurs concrets restent dans #150 et #151.