### PR TITLE
feat: ajouter l’adapter embedding OpenAI

### DIFF
--- a/arclith/adapters/outbound/deterministic/embedding.py
+++ b/arclith/adapters/outbound/deterministic/embedding.py
@@ -20,7 +20,10 @@ class DeterministicEmbeddingAdapter(EmbeddingPort):
     """Dependency-free deterministic vectors for tests and local smoke runs."""
 
     def __init__(self, settings: EmbeddingSettings) -> None:
+        if settings.dimensions is None:
+            raise ValueError("Deterministic embedding dimensions are required")
         self._settings = settings
+        self._dimensions = settings.dimensions
 
     async def embed_texts(self, inputs: Sequence[EmbeddingText]) -> EmbeddingResponse:
         validated = validate_embedding_inputs(inputs)
@@ -33,7 +36,7 @@ class DeterministicEmbeddingAdapter(EmbeddingPort):
         return EmbeddingResponse(
             results=results,
             model_name=self._settings.model_name,
-            dimensions=self._settings.dimensions,
+            dimensions=self._dimensions,
         )
 
     def _embed_batch(
@@ -48,7 +51,7 @@ class DeterministicEmbeddingAdapter(EmbeddingPort):
                 index=offset + index,
                 vector=self._vector_for(item.text),
                 model_name=self._settings.model_name,
-                dimensions=self._settings.dimensions,
+                dimensions=self._dimensions,
             )
             for index, item in enumerate(inputs)
         ]
@@ -58,12 +61,12 @@ class DeterministicEmbeddingAdapter(EmbeddingPort):
         counter = 0
         seed = f"{self._settings.model_name}\0{text}".encode()
 
-        while len(vector) < self._settings.dimensions:
+        while len(vector) < self._dimensions:
             digest = hashlib.sha256(seed + counter.to_bytes(8, "big")).digest()
             for position in range(0, len(digest), 4):
                 integer = int.from_bytes(digest[position : position + 4], "big")
                 vector.append(((integer + 0.5) / _UINT32_RANGE) * 2.0 - 1.0)
-                if len(vector) == self._settings.dimensions:
+                if len(vector) == self._dimensions:
                     break
             counter += 1
 

--- a/arclith/adapters/outbound/openai/__init__.py
+++ b/arclith/adapters/outbound/openai/__init__.py
@@ -1,0 +1,3 @@
+from arclith.adapters.outbound.openai.embedding import OpenAIEmbeddingAdapter
+
+__all__ = ["OpenAIEmbeddingAdapter"]

--- a/arclith/adapters/outbound/openai/embedding.py
+++ b/arclith/adapters/outbound/openai/embedding.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from arclith.adapters.outbound.openai_compatible.embedding import (
+    OpenAICompatibleEmbeddingAdapter,
+)
+
+
+class OpenAIEmbeddingAdapter(OpenAICompatibleEmbeddingAdapter):
+    """Official OpenAI embeddings API adapter with mandatory credentials."""
+
+    _include_encoding_format = True
+    _requires_api_key = True
+    _missing_api_key_message = (
+        "OpenAI embeddings require adapters.embedding.api_key; "
+        "map OPENAI_API_KEY through config/secrets.yaml, environment, or Vault"
+    )
+    _rate_limit_message = "OpenAI embedding rate limit or quota exceeded"

--- a/arclith/adapters/outbound/openai_compatible/embedding.py
+++ b/arclith/adapters/outbound/openai_compatible/embedding.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from arclith.domain.ports.outbound.embedding import (
@@ -24,8 +25,39 @@ if TYPE_CHECKING:
     import httpx
 
 
+@dataclass
+class _UsageAccumulator:
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    has_prompt_tokens: bool = False
+    has_total_tokens: bool = False
+
+    def add(self, usage: EmbeddingUsage | None) -> None:
+        if usage is None:
+            return
+        if usage.prompt_tokens is not None:
+            self.prompt_tokens += usage.prompt_tokens
+            self.has_prompt_tokens = True
+        if usage.total_tokens is not None:
+            self.total_tokens += usage.total_tokens
+            self.has_total_tokens = True
+
+    def build(self) -> EmbeddingUsage | None:
+        if not (self.has_prompt_tokens or self.has_total_tokens):
+            return None
+        return EmbeddingUsage(
+            prompt_tokens=self.prompt_tokens if self.has_prompt_tokens else None,
+            total_tokens=self.total_tokens if self.has_total_tokens else None,
+        )
+
+
 class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
     """Text embeddings over the OpenAI-compatible HTTP protocol."""
+
+    _include_encoding_format = False
+    _requires_api_key = False
+    _missing_api_key_message = "embedding provider api_key is required"
+    _rate_limit_message = "embedding provider rate limit exceeded"
 
     def __init__(
         self,
@@ -35,6 +67,8 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
     ) -> None:
         if settings.base_url is None:
             raise ValueError("OpenAI-compatible embedding base_url is required")
+        if self._requires_api_key and settings.api_key is None:
+            raise EmbeddingAuthenticationError(self._missing_api_key_message)
         self._settings = settings
         self._client = client
 
@@ -53,37 +87,32 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         inputs: tuple[EmbeddingText, ...],
     ) -> EmbeddingResponse:
         results: list[EmbeddingResult] = []
-        prompt_tokens = 0
-        total_tokens = 0
-        has_prompt_tokens = False
-        has_total_tokens = False
+        usage = _UsageAccumulator()
+        dimensions = self._settings.dimensions
 
         for offset in range(0, len(inputs), self._settings.batch_size):
             batch = inputs[offset : offset + self._settings.batch_size]
-            batch_results, batch_usage = await self._request_batch(
+            batch_results, batch_usage, batch_dimensions = await self._request_batch(
                 client,
                 batch,
                 offset=offset,
             )
             results.extend(batch_results)
-            if batch_usage is not None and batch_usage.prompt_tokens is not None:
-                prompt_tokens += batch_usage.prompt_tokens
-                has_prompt_tokens = True
-            if batch_usage is not None and batch_usage.total_tokens is not None:
-                total_tokens += batch_usage.total_tokens
-                has_total_tokens = True
+            if dimensions is None:
+                dimensions = batch_dimensions
+            elif dimensions != batch_dimensions:
+                raise EmbeddingDimensionMismatch(
+                    "embedding provider returned inconsistent vector dimensions"
+                )
+            usage.add(batch_usage)
 
-        usage = None
-        if has_prompt_tokens or has_total_tokens:
-            usage = EmbeddingUsage(
-                prompt_tokens=prompt_tokens if has_prompt_tokens else None,
-                total_tokens=total_tokens if has_total_tokens else None,
-            )
+        if dimensions is None:  # pragma: no cover - guarded by non-empty batches
+            raise EmbeddingError("embedding provider returned no vector dimensions")
         return EmbeddingResponse(
             results=results,
             model_name=self._settings.model_name,
-            dimensions=self._settings.dimensions,
-            usage=usage,
+            dimensions=dimensions,
+            usage=usage.build(),
         )
 
     async def _request_batch(
@@ -92,13 +121,16 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         inputs: tuple[EmbeddingText, ...],
         *,
         offset: int,
-    ) -> tuple[list[EmbeddingResult], EmbeddingUsage | None]:
+    ) -> tuple[list[EmbeddingResult], EmbeddingUsage | None, int]:
         httpx = _require_httpx()
         payload: dict[str, object] = {
             "input": [item.text for item in inputs],
             "model": self._settings.model_name,
-            "dimensions": self._settings.dimensions,
         }
+        if self._settings.dimensions is not None:
+            payload["dimensions"] = self._settings.dimensions
+        if self._include_encoding_format:
+            payload["encoding_format"] = self._settings.encoding_format
         try:
             response = await client.post(
                 f"{self._settings.base_url}/embeddings",
@@ -108,7 +140,7 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         except (httpx.TimeoutException, httpx.TransportError) as error:
             raise EmbeddingUnavailable("embedding provider is unavailable") from error
 
-        _raise_for_status(response.status_code)
+        self._raise_for_status(response.status_code)
         try:
             body = response.json()
         except (TypeError, ValueError) as error:
@@ -123,7 +155,7 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         inputs: tuple[EmbeddingText, ...],
         *,
         offset: int,
-    ) -> tuple[list[EmbeddingResult], EmbeddingUsage | None]:
+    ) -> tuple[list[EmbeddingResult], EmbeddingUsage | None, int]:
         response = _response_mapping(body)
         _validate_provider_model(response.get("model"), self._settings.model_name)
         data = _response_data(response.get("data"), expected_count=len(inputs))
@@ -139,17 +171,18 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         if set(by_index) != set(range(len(inputs))):
             raise EmbeddingError("embedding provider returned invalid result indices")
 
+        dimensions = _consistent_dimensions(by_index.values())
         results = [
             EmbeddingResult(
                 id=inputs[index].id,
                 index=offset + index,
                 vector=by_index[index],
                 model_name=self._settings.model_name,
-                dimensions=self._settings.dimensions,
+                dimensions=dimensions,
             )
             for index in range(len(inputs))
         ]
-        return results, _parse_usage(response.get("usage"))
+        return results, _parse_usage(response.get("usage")), dimensions
 
     def _parse_result_item(self, item: Any) -> tuple[int, list[float]]:
         result = _result_mapping(item)
@@ -161,6 +194,9 @@ class OpenAICompatibleEmbeddingAdapter(EmbeddingPort):
         if self._settings.normalize:
             parsed = _normalize_vector(parsed)
         return index, parsed
+
+    def _raise_for_status(self, status_code: int) -> None:
+        _raise_for_status(status_code, rate_limit_message=self._rate_limit_message)
 
     def _request_headers(self) -> dict[str, str]:
         headers = {"Accept": "application/json"}
@@ -209,16 +245,27 @@ def _provider_index(value: Any) -> int:
     return value
 
 
-def _provider_vector(value: Any, *, dimensions: int) -> list[float]:
-    if not isinstance(value, list) or any(
-        not _is_finite_number(component) for component in value
+def _provider_vector(value: Any, *, dimensions: int | None) -> list[float]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not _is_finite_number(component) for component in value)
     ):
         raise EmbeddingError("embedding provider returned an invalid vector")
-    if len(value) != dimensions:
+    if dimensions is not None and len(value) != dimensions:
         raise EmbeddingDimensionMismatch(
             "embedding provider vector dimensions do not match configuration"
         )
     return [float(component) for component in value]
+
+
+def _consistent_dimensions(vectors: Iterable[Sequence[float]]) -> int:
+    dimensions = {len(vector) for vector in vectors}
+    if len(dimensions) != 1:
+        raise EmbeddingDimensionMismatch(
+            "embedding provider returned inconsistent vector dimensions"
+        )
+    return dimensions.pop()
 
 
 def _is_finite_number(value: Any) -> bool:
@@ -245,13 +292,13 @@ def _normalize_vector(vector: list[float]) -> list[float]:
     return [value / norm for value in vector]
 
 
-def _raise_for_status(status_code: int) -> None:
+def _raise_for_status(status_code: int, *, rate_limit_message: str) -> None:
     if status_code < 400:
         return
     if status_code in {401, 403}:
         raise EmbeddingAuthenticationError("embedding provider rejected authentication")
     if status_code == 429:
-        raise EmbeddingRateLimitError("embedding provider rate limit exceeded")
+        raise EmbeddingRateLimitError(rate_limit_message)
     if status_code < 500:
         raise EmbeddingInvalidInput("embedding provider rejected the request")
     raise EmbeddingUnavailable("embedding provider is unavailable")

--- a/arclith/infrastructure/embedding_factory.py
+++ b/arclith/infrastructure/embedding_factory.py
@@ -46,6 +46,7 @@ def default_embedding_registry() -> EmbeddingRegistry:
         EmbeddingRegistry()
         .register("deterministic", _build_deterministic)
         .register("openai-compatible", _build_openai_compatible)
+        .register("openai", _build_openai)
     )
 
 
@@ -69,3 +70,12 @@ def _build_openai_compatible(config: AppConfig, _logger: Logger) -> EmbeddingPor
     if settings is None:
         raise ValueError("OpenAI-compatible embedding settings are required")
     return OpenAICompatibleEmbeddingAdapter(settings)
+
+
+def _build_openai(config: AppConfig, _logger: Logger) -> EmbeddingPort:
+    from arclith.adapters.outbound.openai import OpenAIEmbeddingAdapter
+
+    settings = config.adapters.embedding
+    if settings is None:
+        raise ValueError("OpenAI embedding settings are required")
+    return OpenAIEmbeddingAdapter(settings)

--- a/arclith/infrastructure/settings/embedding.py
+++ b/arclith/infrastructure/settings/embedding.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.parse import urlsplit
 
 from pydantic import (
@@ -22,23 +22,30 @@ EmbeddingAdapter = Annotated[
 class EmbeddingSettings(SettingsModel):
     adapter: EmbeddingAdapter
     model_name: str
-    dimensions: PositiveInt
+    dimensions: PositiveInt | None = None
     batch_size: PositiveInt = 64
     base_url: str | None = None
     api_key: str | None = None
     timeout: PositiveFloat = 30.0
+    encoding_format: Literal["float"] = "float"
     normalize: bool = True
     multitenant: bool = False
 
     @model_validator(mode="before")
     @classmethod
     def apply_adapter_defaults(cls, values: Any) -> Any:
-        if (
-            isinstance(values, dict)
-            and values.get("adapter") == "openai-compatible"
-            and "normalize" not in values
+        if not isinstance(values, dict):
+            return values
+        adapter = values.get("adapter")
+        defaults: dict[str, Any] = {}
+        if adapter in {"openai-compatible", "openai"} and "normalize" not in values:
+            defaults["normalize"] = False
+        if adapter == "openai" and (
+            "base_url" not in values or values.get("base_url") is None
         ):
-            return {**values, "normalize": False}
+            defaults["base_url"] = "https://api.openai.com/v1"
+        if defaults:
+            return {**values, **defaults}
         return values
 
     @field_validator("model_name")
@@ -81,4 +88,9 @@ class EmbeddingSettings(SettingsModel):
     def validate_selected_adapter(self) -> "EmbeddingSettings":
         if self.adapter == "openai-compatible" and self.base_url is None:
             raise ValueError("embedding adapter openai-compatible requires base_url")
+        if (
+            self.adapter in {"deterministic", "openai-compatible"}
+            and self.dimensions is None
+        ):
+            raise ValueError(f"embedding adapter {self.adapter} requires dimensions")
         return self

--- a/cli/arclith_cli/catalogs/ai.py
+++ b/cli/arclith_cli/catalogs/ai.py
@@ -260,6 +260,95 @@ multitenant: {multitenant}
             dependency_extra="embedding",
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="openai",
+            capability="embedding",
+            layer="outbound",
+            description="Embeddings via l'API OpenAI officielle et un secret externe.",
+            config_path="config/adapters/outbound/embedding.yaml",
+            config_template="""\
+adapter: openai
+base_url: "{base_url}"
+api_key: null
+model_name: "{model_name}"
+dimensions: {dimensions}
+batch_size: {batch_size}
+timeout: {timeout}
+encoding_format: {encoding_format}
+normalize: {normalize}
+multitenant: {multitenant}
+""",
+            env_path=".env",
+            env_template="""\
+OPENAI_API_KEY={api_key}
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="adapters.embedding.api_key",
+                    secret_key="OPENAI_API_KEY",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="base_url",
+                    kind="string",
+                    prompt="Endpoint officiel OpenAI avec préfixe API",
+                    default="https://api.openai.com/v1",
+                ),
+                ParameterSpec(
+                    name="api_key",
+                    kind="string",
+                    prompt="OPENAI_API_KEY (laisser vide pour un secret externe)",
+                    default="",
+                    secret=True,
+                ),
+                ParameterSpec(
+                    name="model_name",
+                    kind="string",
+                    prompt="ID du modèle d'embedding OpenAI accessible au projet",
+                    default="remplacer-par-model-id-openai-embedding",
+                ),
+                ParameterSpec(
+                    name="dimensions",
+                    kind="string",
+                    prompt="Dimension optionnelle des vecteurs (null pour le défaut modèle)",
+                    default="null",
+                ),
+                ParameterSpec(
+                    name="batch_size",
+                    kind="string",
+                    prompt="Taille maximale des sous-batches",
+                    default="64",
+                ),
+                ParameterSpec(
+                    name="timeout",
+                    kind="string",
+                    prompt="Timeout HTTP en secondes",
+                    default="30.0",
+                ),
+                ParameterSpec(
+                    name="encoding_format",
+                    kind="string",
+                    prompt="Format des vecteurs retournés",
+                    default="float",
+                    choices=("float",),
+                ),
+                ParameterSpec(
+                    name="normalize",
+                    kind="boolean",
+                    prompt="Normaliser les vecteurs en norme L2",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Réserver la résolution de contexte par tenant",
+                    default=False,
+                ),
+            ),
+            dependency_extra="embedding",
+            entity_scoped=False,
+        ),
     ),
 )
 

--- a/cli/tests/test_embedding_capability.py
+++ b/cli/tests/test_embedding_capability.py
@@ -27,7 +27,11 @@ def test_embedding_capability_catalog_declares_deterministic_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("deterministic", "openai-compatible")
+    assert capability.adapter_names() == (
+        "deterministic",
+        "openai-compatible",
+        "openai",
+    )
     deterministic = capability.get_adapter("deterministic")
     assert deterministic is not None
     assert deterministic.entity_scoped is False
@@ -53,6 +57,29 @@ def test_embedding_capability_catalog_declares_deterministic_adapter() -> None:
         "normalize",
         "multitenant",
     ]
+    openai = capability.get_adapter("openai")
+    assert openai is not None
+    assert openai.entity_scoped is False
+    assert openai.dependency_extra == "embedding"
+    assert openai.secret_mappings[0].field_path == "adapters.embedding.api_key"
+    assert openai.secret_mappings[0].secret_key == "OPENAI_API_KEY"
+    assert [parameter.name for parameter in openai.parameters] == [
+        "base_url",
+        "api_key",
+        "model_name",
+        "dimensions",
+        "batch_size",
+        "timeout",
+        "encoding_format",
+        "normalize",
+        "multitenant",
+    ]
+    assert (
+        next(
+            parameter for parameter in openai.parameters if parameter.name == "api_key"
+        ).secret
+        is True
+    )
 
 
 def test_embedding_capability_is_exposed_in_json_catalog() -> None:
@@ -65,6 +92,20 @@ def test_embedding_capability_is_exposed_in_json_catalog() -> None:
     assert [adapter["name"] for adapter in embedding["adapters"]] == [
         "deterministic",
         "openai-compatible",
+        "openai",
+    ]
+    openai = embedding["adapters"][2]
+    api_key = next(
+        parameter
+        for parameter in openai["parameters"]
+        if parameter["name"] == "api_key"
+    )
+    assert api_key["secret"] is True
+    assert openai["secret_mappings"] == [
+        {
+            "field_path": "adapters.embedding.api_key",
+            "secret_key": "OPENAI_API_KEY",
+        }
     ]
 
 
@@ -159,3 +200,84 @@ def test_add_openai_compatible_embedding_generates_loadable_config_idempotently(
     assert "arclith[embedding]>=0.21.0" in (project_dir / "pyproject.toml").read_text(
         encoding="utf-8"
     )
+
+
+def test_add_openai_embedding_generates_safe_loadable_config_idempotently(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    (project_dir / ".env").write_text("EXISTING=value\n", encoding="utf-8")
+    params = {
+        "model_name": "configured-embedding-model",
+        "dimensions": "1536",
+    }
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="embedding",
+            adapter="openai",
+            adapter_params=params,
+            yes=True,
+        )
+
+    config_path = project_dir / "config/adapters/outbound/embedding.yaml"
+    config_text = config_path.read_text(encoding="utf-8")
+    secrets_text = (project_dir / "config/secrets.yaml").read_text(encoding="utf-8")
+    env_text = (project_dir / ".env").read_text(encoding="utf-8")
+
+    assert config_text == (
+        "adapter: openai\n"
+        'base_url: "https://api.openai.com/v1"\n'
+        "api_key: null\n"
+        'model_name: "configured-embedding-model"\n'
+        "dimensions: 1536\n"
+        "batch_size: 64\n"
+        "timeout: 30.0\n"
+        "encoding_format: float\n"
+        "normalize: false\n"
+        "multitenant: false\n"
+    )
+    assert "adapters.embedding.api_key: OPENAI_API_KEY" in secrets_text
+    assert secrets_text.count("adapters.embedding.api_key") == 1
+    assert env_text == "EXISTING=value\n"
+    assert "sk-" not in config_text + secrets_text + env_text
+    assert ".env" in (project_dir / ".gitignore").read_text(encoding="utf-8")
+    assert "arclith[embedding]>=0.21.0" in (project_dir / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    from arclith import Arclith
+    from arclith.adapters.outbound.openai import OpenAIEmbeddingAdapter
+
+    app = Arclith(project_dir / "config")
+
+    assert app.config.adapters.embedding is not None
+    assert app.config.adapters.embedding.api_key == "test-key"
+    assert type(app.embedding()) is OpenAIEmbeddingAdapter
+
+
+def test_add_openai_embedding_omits_fake_key_and_keeps_dimensions_optional(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name="embedding",
+        adapter="openai",
+        adapter_params={"model_name": "configured-embedding-model"},
+        yes=True,
+    )
+
+    config_text = (project_dir / "config/adapters/outbound/embedding.yaml").read_text(
+        encoding="utf-8"
+    )
+    env_text = (project_dir / ".env").read_text(encoding="utf-8")
+
+    assert "dimensions: null" in config_text
+    assert "api_key: null" in config_text
+    assert "OPENAI_API_KEY=" not in env_text
+    assert "sk-" not in config_text + env_text

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,7 +36,7 @@ arclith-cli capabilities --json
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |
 | [secrets](capabilities/secrets.md) | outbound | `env`, `yaml`, `vault`, `chain` | résoudre les secrets |
 | [llm](capabilities/llm.md) | outbound | `lmstudio`, `openai`, `anthropic` | configurer les modèles |
-| [embedding](capabilities/embedding.md) | outbound | `deterministic`, `openai-compatible` | calculer des vecteurs texte sans les persister |
+| [embedding](capabilities/embedding.md) | outbound | `deterministic`, `openai-compatible`, `openai` | calculer des vecteurs texte sans les persister |
 | [observability](capabilities/observability.md) ([OpenTelemetry](capabilities/opentelemetry.md)) | outbound | `langsmith`, `opentelemetry` | traces, métriques, logs et agents |
 | [command-bus](capabilities/command-bus.md) | bidirectional | `rabbitmq` | consommer et publier des commandes |
 | [runtime](capabilities/runtime.md) | runtime | `docker-image` | générer le runtime conteneur |

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -188,9 +188,13 @@ arclith-cli add-adapter \
   --capability embedding \
   --adapter openai \
   --param model_name=remplacer-par-model-id-openai-embedding \
-  --param dimensions=1536 \
   --yes
 ```
+
+Cette forme laisse le modèle choisir sa dimension native. Pour aligner
+explicitement une collection vectorielle déjà dimensionnée, ajouter par
+exemple `--param dimensions=1536`; le YAML généré contiendra alors
+`dimensions: 1536` au lieu de `null`.
 
 La configuration générée garde le secret hors Git :
 

--- a/docs/capabilities/embedding.md
+++ b/docs/capabilities/embedding.md
@@ -170,6 +170,77 @@ communes. `normalize` vaut `false` quand le champ est omis. Avec
 `normalize: true`, l'adapter applique une normalisation L2 locale ; avec
 `false`, il conserve exactement les vecteurs du provider.
 
+## Adapter OpenAI Officiel
+
+`openai` appelle l'API Embeddings officielle sur `POST /v1/embeddings`. Il
+réutilise l'extra HTTP optionnel `arclith[embedding]` et n'ajoute pas le SDK
+OpenAI à l'installation minimale.
+
+La documentation OpenAI consultée lors de cette implémentation expose notamment
+`text-embedding-3-small` et `text-embedding-3-large`. Le catalogue CLI ne choisit
+cependant aucun modèle à la place du service : vérifier les [modèles
+d'embedding disponibles](https://developers.openai.com/api/docs/models/all) et
+les droits du projet OpenAI, puis passer l'identifiant voulu explicitement.
+
+```bash
+uv add 'arclith[embedding]>=0.21.0'
+arclith-cli add-adapter \
+  --capability embedding \
+  --adapter openai \
+  --param model_name=remplacer-par-model-id-openai-embedding \
+  --param dimensions=1536 \
+  --yes
+```
+
+La configuration générée garde le secret hors Git :
+
+```yaml
+# config/adapters/outbound/embedding.yaml
+adapter: openai
+base_url: https://api.openai.com/v1
+api_key: null
+model_name: remplacer-par-model-id-openai-embedding
+dimensions: null
+batch_size: 64
+timeout: 30.0
+encoding_format: float
+normalize: false
+multitenant: false
+```
+
+```yaml
+# config/secrets.yaml
+resolver: env
+mappings:
+  adapters.embedding.api_key: OPENAI_API_KEY
+```
+
+Définir `OPENAI_API_KEY` dans l'environnement du processus, un secret
+Kubernetes ou Vault. Ne jamais écrire la valeur dans le YAML versionné ni la
+passer dans une commande conservée par l'historique du shell. Une absence de
+clé résolue provoque une `EmbeddingAuthenticationError` actionnable avant tout
+appel réseau.
+
+Conformément à la [référence Create
+embeddings](https://developers.openai.com/api/reference/resources/embeddings/methods/create),
+l'adapter envoie `input`, `model`, `encoding_format: float` et `dimensions`
+uniquement quand cette dernière est configurée. Il réordonne les résultats par
+`index` et expose `prompt_tokens`/`total_tokens` quand l'API les retourne. Le
+champ provider `user` n'est pas alimenté automatiquement : un service ne doit
+pas transmettre d'identifiant utilisateur brut sans décision explicite de
+confidentialité.
+
+Quand `dimensions` vaut `null`, l'adapter conserve la dimension renvoyée par le
+modèle et vérifie qu'elle reste cohérente sur tous les sous-batches. Quand elle
+est renseignée, toute différence déclenche `EmbeddingDimensionMismatch`. La
+collection vectorielle cible doit être créée avec exactement la même dimension.
+
+Les réponses 401/403, 429, les timeouts et les erreurs provider sont traduits
+vers les exceptions communes sans reprendre la clé, le texte source ou le
+payload dans le message. Les tests automatisés utilisent exclusivement
+`httpx.MockTransport`; aucun appel à OpenAI n'est effectué par la suite de
+tests.
+
 ## Assemblage
 
 ```python
@@ -228,6 +299,7 @@ index.
 uv run pytest tests/units/domain/ports/test_embedding.py \
   tests/units/adapters/outbound/test_deterministic_embedding.py \
   tests/units/adapters/outbound/test_openai_compatible_embedding.py \
+  tests/units/adapters/outbound/test_openai_embedding.py \
   tests/units/infrastructure/test_embedding_factory.py
 uv run --project cli pytest cli/tests/test_embedding_capability.py
 make docs

--- a/docs/production/secrets.md
+++ b/docs/production/secrets.md
@@ -39,6 +39,7 @@ chain:
 mappings:
   adapters.mongodb.uri: apps/my-service/mongodb
   cache.redis_url: apps/my-service/redis
+  adapters.embedding.api_key: OPENAI_API_KEY
 ```
 
 ## Règles
@@ -48,6 +49,9 @@ mappings:
 - Vault doit être la source de vérité en production.
 - Le fallback YAML sert au développement local, avec un fichier ignoré.
 - Chaque secret doit avoir un propriétaire, une rotation et un usage identifié.
+- Pour `embedding/openai`, laisser `api_key: null` dans la configuration et
+  résoudre `adapters.embedding.api_key` depuis `OPENAI_API_KEY` ou une entrée
+  Vault. L'adapter refuse de démarrer sans clé résolue.
 
 ## Vérifier
 

--- a/journal/2026-09-02-openai-embedding.md
+++ b/journal/2026-09-02-openai-embedding.md
@@ -1,0 +1,46 @@
+# Adapter embedding OpenAI officiel
+
+## Contexte
+
+Le port `EmbeddingPort` disposait d'un adapter déterministe et d'un transport
+OpenAI-compatible destiné aux runtimes locaux. Il manquait un adapter explicite
+pour l'API OpenAI officielle, avec une politique stricte de secret et les
+paramètres propres au contrat `POST /v1/embeddings`.
+
+## Décision
+
+- réutiliser le transport `httpx` de l'extra optionnel `arclith[embedding]`
+  plutôt que d'ajouter le SDK OpenAI à l'installation minimale ;
+- ajouter l'adapter `openai` dans la factory et le catalogue CLI ;
+- imposer une clé résolue par `adapters.embedding.api_key`, avec le mapping
+  `OPENAI_API_KEY`, avant toute requête ;
+- envoyer `encoding_format: float` et omettre `dimensions` lorsqu'elle vaut
+  `null` ;
+- déduire alors la dimension du résultat, vérifier sa cohérence entre
+  sous-batches et conserver la vérification stricte lorsqu'elle est configurée ;
+- conserver l'ordre d'entrée via l'index provider et agréger les métriques de
+  tokens ;
+- traduire authentification, rate limit ou quota, timeout et erreurs provider
+  vers les exceptions `Embedding*` sans exposer secret, texte ou payload ;
+- garder un modèle placeholder dans le scaffold : le service choisit un modèle
+  réellement disponible dans son projet OpenAI.
+
+## Impact
+
+Les projets consommateurs peuvent activer `embedding/openai` sans coupler leurs
+use cases à OpenAI. La CLI génère une configuration scoped chargeable, un
+mapping de secret idempotent et aucune fausse clé. Les adapters existants
+conservent leurs dimensions obligatoires et leurs defaults de normalisation.
+
+Les tests utilisent uniquement `httpx.MockTransport`; aucune clé ni requête
+OpenAI réelle n'est nécessaire pour les validations automatisées.
+
+## Validation
+
+- `make quality` : 1 739 tests réussis, 5 ignorés, couverture 90,71 %,
+  Ruff, Bandit, complexité et mypy verts sur 191 fichiers ;
+- `make precommit` : Ruff, mypy et Bandit verts ;
+- `uv run --frozen pytest -q` depuis `cli/` : 143 tests réussis,
+  1 ignoré ;
+- `make docs` : build MkDocs strict réussi ;
+- tests embedding ciblés : 49 tests framework et 6 tests CLI réussis.

--- a/tests/units/adapters/outbound/test_openai_embedding.py
+++ b/tests/units/adapters/outbound/test_openai_embedding.py
@@ -1,0 +1,224 @@
+import json
+import logging
+
+import httpx
+import pytest
+
+from arclith.adapters.outbound.openai import OpenAIEmbeddingAdapter
+from arclith.domain.ports.outbound.embedding import (
+    EmbeddingAuthenticationError,
+    EmbeddingDimensionMismatch,
+    EmbeddingRateLimitError,
+    EmbeddingText,
+    EmbeddingUnavailable,
+)
+from arclith.infrastructure.settings.embedding import EmbeddingSettings
+
+
+def _settings(**updates: object) -> EmbeddingSettings:
+    values: dict[str, object] = {
+        "adapter": "openai",
+        "api_key": "test-key",
+        "model_name": "configured-embedding-model",
+        "dimensions": 2,
+        "batch_size": 2,
+        "timeout": 5.0,
+        "encoding_format": "float",
+        "normalize": False,
+    }
+    values.update(updates)
+    return EmbeddingSettings.model_validate(values)
+
+
+def _response_for(request: httpx.Request, *, reverse: bool = False) -> httpx.Response:
+    payload = json.loads(request.content)
+    indices = list(range(len(payload["input"])))
+    if reverse:
+        indices.reverse()
+    return httpx.Response(
+        200,
+        json={
+            "object": "list",
+            "model": payload["model"],
+            "data": [
+                {
+                    "object": "embedding",
+                    "index": index,
+                    "embedding": [float(index + 1), float(index + 2)],
+                }
+                for index in indices
+            ],
+            "usage": {"prompt_tokens": len(indices), "total_tokens": len(indices)},
+        },
+    )
+
+
+def test_openai_embedding_requires_api_key_before_any_request() -> None:
+    with pytest.raises(EmbeddingAuthenticationError, match="OPENAI_API_KEY"):
+        OpenAIEmbeddingAdapter(_settings(api_key=None))
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_sends_official_request_and_preserves_order() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _response_for(request, reverse=True)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await OpenAIEmbeddingAdapter(_settings(), client=client).embed_texts(
+            [
+                EmbeddingText(id="first", text="alpha"),
+                EmbeddingText(id="second", text="beta"),
+            ]
+        )
+
+    request = requests[0]
+    assert str(request.url) == "https://api.openai.com/v1/embeddings"
+    assert request.headers["authorization"] == "Bearer test-key"
+    assert json.loads(request.content) == {
+        "input": ["alpha", "beta"],
+        "model": "configured-embedding-model",
+        "dimensions": 2,
+        "encoding_format": "float",
+    }
+    assert [result.id for result in response.results] == ["first", "second"]
+    assert [result.index for result in response.results] == [0, 1]
+    assert response.dimensions == 2
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 2
+    assert response.usage.total_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_omits_dimensions_and_infers_response_size() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "model": "configured-embedding-model",
+                "data": [{"index": 0, "embedding": [1.0, 2.0, 3.0]}],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        response = await OpenAIEmbeddingAdapter(
+            _settings(dimensions=None), client=client
+        ).embed_texts([EmbeddingText(text="alpha")])
+
+    payload = json.loads(requests[0].content)
+    assert "dimensions" not in payload
+    assert payload["encoding_format"] == "float"
+    assert response.dimensions == 3
+    assert response.results[0].dimensions == 3
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_rejects_configured_dimension_mismatch() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "model": "configured-embedding-model",
+                "data": [{"index": 0, "embedding": [1.0]}],
+            },
+        )
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        adapter = OpenAIEmbeddingAdapter(_settings(), client=client)
+        with pytest.raises(EmbeddingDimensionMismatch, match="dimensions"):
+            await adapter.embed_texts([EmbeddingText(text="alpha")])
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_rejects_inconsistent_inferred_batch_dimensions() -> (
+    None
+):
+    request_count = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        dimensions = 2 if request_count == 1 else 3
+        return httpx.Response(
+            200,
+            json={
+                "model": "configured-embedding-model",
+                "data": [{"index": 0, "embedding": [1.0] * dimensions}],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = OpenAIEmbeddingAdapter(
+            _settings(dimensions=None, batch_size=1), client=client
+        )
+        with pytest.raises(EmbeddingDimensionMismatch, match="inconsistent"):
+            await adapter.embed_texts(
+                [EmbeddingText(text="alpha"), EmbeddingText(text="beta")]
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403])
+async def test_openai_embedding_maps_authentication_errors(status_code: int) -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(status_code, json={"error": "denied"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        adapter = OpenAIEmbeddingAdapter(_settings(), client=client)
+        with pytest.raises(EmbeddingAuthenticationError, match="authentication"):
+            await adapter.embed_texts([EmbeddingText(text="alpha")])
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_maps_rate_limit_or_quota() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(429, json={"error": "quota"})
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        adapter = OpenAIEmbeddingAdapter(_settings(), client=client)
+        with pytest.raises(EmbeddingRateLimitError, match="rate limit or quota"):
+            await adapter.embed_texts([EmbeddingText(text="alpha")])
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_maps_timeout_without_sensitive_details() -> None:
+    secret = "private-provider-key"
+    raw_text = "private raw text"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout(raw_text, request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = OpenAIEmbeddingAdapter(_settings(api_key=secret), client=client)
+        with pytest.raises(EmbeddingUnavailable) as error:
+            await adapter.embed_texts([EmbeddingText(text=raw_text)])
+
+    message = str(error.value)
+    assert secret not in message
+    assert raw_text not in message
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_does_not_log_secret_or_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "private-provider-key"
+    raw_text = "private raw text"
+    caplog.set_level(logging.DEBUG)
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(500, json={"error": raw_text})
+    )
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        adapter = OpenAIEmbeddingAdapter(_settings(api_key=secret), client=client)
+        with pytest.raises(EmbeddingUnavailable) as error:
+            await adapter.embed_texts([EmbeddingText(text=raw_text)])
+
+    captured = caplog.text + str(error.value)
+    assert secret not in captured
+    assert raw_text not in captured

--- a/tests/units/infrastructure/test_embedding_config.py
+++ b/tests/units/infrastructure/test_embedding_config.py
@@ -89,7 +89,11 @@ def test_load_config_dir_loads_openai_compatible_settings(tmp_path: Path) -> Non
 
 @pytest.mark.parametrize(
     ("adapter", "expected"),
-    [("deterministic", True), ("openai-compatible", False)],
+    [
+        ("deterministic", True),
+        ("openai-compatible", False),
+        ("openai", False),
+    ],
 )
 def test_embedding_settings_use_adapter_specific_normalization_defaults(
     adapter: str,
@@ -102,10 +106,84 @@ def test_embedding_settings_use_adapter_specific_normalization_defaults(
     }
     if adapter == "openai-compatible":
         values["base_url"] = "http://127.0.0.1:1234/v1"
+    if adapter == "openai":
+        values["dimensions"] = None
 
     settings = EmbeddingSettings.model_validate(values)
 
     assert settings.normalize is expected
+
+
+def test_openai_embedding_settings_apply_safe_official_defaults() -> None:
+    settings = EmbeddingSettings.model_validate(
+        {
+            "adapter": "openai",
+            "model_name": "configured-embedding-model",
+        }
+    )
+
+    assert settings.base_url == "https://api.openai.com/v1"
+    assert settings.dimensions is None
+    assert settings.encoding_format == "float"
+    assert settings.api_key is None
+
+
+def test_openai_embedding_settings_reject_base64_encoding() -> None:
+    with pytest.raises(ValidationError, match="encoding_format"):
+        EmbeddingSettings.model_validate(
+            {
+                "adapter": "openai",
+                "model_name": "configured-embedding-model",
+                "encoding_format": "base64",
+            }
+        )
+
+
+def test_load_openai_embedding_api_key_from_env_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    config_dir = tmp_path / "config"
+    embedding_dir = config_dir / "adapters" / "outbound"
+    embedding_dir.mkdir(parents=True)
+    (embedding_dir / "embedding.yaml").write_text(
+        "adapter: openai\n"
+        "base_url: https://api.openai.com/v1\n"
+        "api_key: null\n"
+        "model_name: configured-embedding-model\n"
+        "dimensions: null\n"
+        "batch_size: 64\n"
+        "timeout: 30.0\n"
+        "encoding_format: float\n"
+        "normalize: false\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+    (config_dir / "secrets.yaml").write_text(
+        "resolver: env\nmappings:\n  adapters.embedding.api_key: OPENAI_API_KEY\n",
+        encoding="utf-8",
+    )
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.embedding is not None
+    assert config.adapters.embedding.adapter == "openai"
+    assert config.adapters.embedding.api_key == "test-key"
+    assert config.adapters.embedding.dimensions is None
+
+
+@pytest.mark.parametrize("adapter", ["deterministic", "openai-compatible"])
+def test_existing_embedding_adapters_still_require_dimensions(adapter: str) -> None:
+    values = {
+        "adapter": adapter,
+        "model_name": "embedding-model",
+    }
+    if adapter == "openai-compatible":
+        values["base_url"] = "http://127.0.0.1:1234/v1"
+
+    with pytest.raises(ValidationError, match="requires dimensions"):
+        EmbeddingSettings.model_validate(values)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/infrastructure/test_embedding_factory.py
+++ b/tests/units/infrastructure/test_embedding_factory.py
@@ -8,7 +8,9 @@ from arclith.adapters.outbound.deterministic import DeterministicEmbeddingAdapte
 from arclith.adapters.outbound.openai_compatible import (
     OpenAICompatibleEmbeddingAdapter,
 )
+from arclith.adapters.outbound.openai import OpenAIEmbeddingAdapter
 from arclith.domain.ports.outbound.embedding import (
+    EmbeddingAuthenticationError,
     EmbeddingPort,
     EmbeddingResponse,
     EmbeddingText,
@@ -66,6 +68,43 @@ def test_build_embedding_returns_openai_compatible_adapter(logger) -> None:
     embedding = build_embedding(config, logger)
 
     assert isinstance(embedding, OpenAICompatibleEmbeddingAdapter)
+
+
+def test_build_embedding_returns_openai_adapter(logger) -> None:
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "embedding": {
+                    "adapter": "openai",
+                    "api_key": "test-key",
+                    "model_name": "configured-embedding-model",
+                }
+            }
+        }
+    )
+
+    embedding = build_embedding(config, logger)
+
+    assert type(embedding) is OpenAIEmbeddingAdapter
+
+
+def test_build_openai_embedding_requires_resolved_api_key(logger) -> None:
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "embedding": {
+                    "adapter": "openai",
+                    "model_name": "configured-embedding-model",
+                }
+            }
+        }
+    )
+
+    with pytest.raises(
+        EmbeddingAuthenticationError,
+        match="OPENAI_API_KEY.*config/secrets.yaml",
+    ):
+        build_embedding(config, logger)
 
 
 def test_build_embedding_requires_config(logger) -> None:


### PR DESCRIPTION
## Contexte

Closes #151. Cette PR ajoute l’adapter `embedding/openai` officiel demandé par la roadmap #57, après les fondations `EmbeddingPort` (#149) et OpenAI-compatible (#150).

## Changements principaux

- ajoute `OpenAIEmbeddingAdapter` sur `POST /v1/embeddings`, en réutilisant l’extra optionnel HTTP existant ;
- exige une clé résolue par `adapters.embedding.api_key` et le mapping `OPENAI_API_KEY`, sans secret versionné ;
- envoie `encoding_format=float`, rend `dimensions` optionnel, préserve l’ordre provider et agrège l’usage ;
- vérifie les dimensions configurées ou déduites et traduit auth, quota/rate limit, timeout et indisponibilité vers `Embedding*` ;
- expose `embedding/openai` dans la factory et le catalogue CLI, avec scaffold idempotent et sans fausse clé ;
- documente l’installation, la configuration sûre, le choix explicite du modèle et la cohérence avec le vector-store ;
- ajoute le journal `journal/2026-09-02-openai-embedding.md`.

## Impact

- API publique : `Arclith.embedding()` sait assembler l’adapter `openai` ; le port domaine reste provider-neutral.
- Configuration : `dimensions` devient optionnel uniquement pour `openai`; `deterministic` et `openai-compatible` continuent de l’exiger.
- Dépendances : aucune dépendance OpenAI nouvelle ; `arclith[embedding]` conserve uniquement `httpx`.
- Données, migrations, RabbitMQ, MCP, ports réseau et déploiement : aucun impact.
- Secrets : `api_key: null` reste dans le YAML versionné ; la valeur vient de l’environnement ou de Vault.

## Validations

- `make quality` — 1 739 passed, 5 skipped, couverture 90,71 %, Ruff/Bandit/complexité/mypy verts ;
- `make precommit` — vert ;
- `uv run --frozen pytest -q` dans `cli/` — 143 passed, 1 skipped ;
- `make docs` — MkDocs strict vert ;
- tests ciblés embedding — 49 framework et 6 CLI verts.

## Documentation et risques

- documentation Pages et journal ajoutés ; ADR non nécessaire ; migration et action de déploiement non applicables ;
- les tests utilisent exclusivement `httpx.MockTransport` et ne font aucun appel OpenAI réel ;
- le modèle reste volontairement configuré par le service. Le smoke live devra être fait après création manuelle de `OPENAI_API_KEY` hors Git.
