### PR TITLE
feat: ajouter la capability vector-store

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -12,6 +12,7 @@ from arclith.adapters.outbound.filesystem import (
 )
 from arclith.adapters.outbound.gcs import GCSFileStorage, GCSStorageConfig
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
+from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
 from arclith.adapters.outbound.s3 import S3FileStorage, S3StorageConfig
 from arclith.application.command_bus import CommandDispatcher, CommandEnvelope
@@ -59,6 +60,18 @@ from arclith.domain.ports.outbound.observability import (
     TraceSpan,
 )
 from arclith.domain.ports.outbound.repository import Repository
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchHit,
+    VectorSearchQuery,
+    VectorStoreCollectionNotFound,
+    VectorStoreDimensionMismatch,
+    VectorStoreError,
+    VectorStoreInvalidPayload,
+    VectorStorePermissionDenied,
+    VectorStorePort,
+    VectorStoreUnavailable,
+)
 from arclith.infrastructure.adapter_registry import AdapterRegistry
 from arclith.infrastructure.config import (
     AppConfig,
@@ -95,6 +108,11 @@ from arclith.infrastructure.repository_factory import (
     build_repository,
     default_repository_registry,
 )
+from arclith.infrastructure.vector_store_factory import (
+    VectorStoreRegistry,
+    build_vector_store,
+    default_vector_store_registry,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
     from arclith.adapters.outbound.console.logger import ConsoleLogger  # noqa: F401
@@ -115,6 +133,17 @@ __all__ = [
     "EmbeddingDimensionMismatch",
     "validate_embedding_inputs",
     "DeterministicEmbeddingAdapter",
+    "VectorStorePort",
+    "VectorPoint",
+    "VectorSearchQuery",
+    "VectorSearchHit",
+    "VectorStoreError",
+    "VectorStoreUnavailable",
+    "VectorStoreCollectionNotFound",
+    "VectorStoreDimensionMismatch",
+    "VectorStorePermissionDenied",
+    "VectorStoreInvalidPayload",
+    "MemoryVectorStore",
     "FileStoragePort",
     "StoredObject",
     "StoredObjectMetadata",
@@ -167,6 +196,9 @@ __all__ = [
     "EmbeddingRegistry",
     "build_embedding",
     "default_embedding_registry",
+    "VectorStoreRegistry",
+    "build_vector_store",
+    "default_vector_store_registry",
     "FileStorageRegistry",
     "build_file_storage",
     "default_file_storage_registry",

--- a/arclith/adapters/outbound/memory/vector_store.py
+++ b/arclith/adapters/outbound/memory/vector_store.py
@@ -46,16 +46,21 @@ class MemoryVectorStore(VectorStorePort):
             if self._matches_filters(point, query)
         ]
         scored.sort(key=lambda item: (-item[0], item[1].id))
-        return [
-            VectorSearchHit(
-                id=point.id,
-                score=score,
-                payload=point.payload if query.include_payload else {},
-                vector=point.vector if query.include_vector else None,
-            ).model_copy(deep=True)
-            for score, point in scored
-            if query.score_threshold is None or score >= query.score_threshold
-        ][: query.limit]
+        hits: list[VectorSearchHit] = []
+        for score, point in scored:
+            if query.score_threshold is not None and score < query.score_threshold:
+                continue
+            hits.append(
+                VectorSearchHit(
+                    id=point.id,
+                    score=score,
+                    payload=point.payload if query.include_payload else {},
+                    vector=point.vector if query.include_vector else None,
+                ).model_copy(deep=True)
+            )
+            if len(hits) == query.limit:
+                break
+        return hits
 
     def _collection(self) -> dict[str, VectorPoint]:
         try:

--- a/arclith/adapters/outbound/memory/vector_store.py
+++ b/arclith/adapters/outbound/memory/vector_store.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 
+from pydantic import JsonValue
+
 from arclith.domain.ports.outbound.vector_store import (
     VectorPoint,
     VectorSearchHit,
@@ -88,7 +90,7 @@ class MemoryVectorStore(VectorStorePort):
     @staticmethod
     def _matches_filters(point: VectorPoint, query: VectorSearchQuery) -> bool:
         return all(
-            key in point.payload and point.payload[key] == value
+            key in point.payload and _json_values_equal(point.payload[key], value)
             for key, value in query.filters.items()
         )
 
@@ -109,3 +111,32 @@ class MemoryVectorStore(VectorStorePort):
             sum((a - b) ** 2 for a, b in zip(left, right, strict=True))
         )
         return 1.0 / (1.0 + distance)
+
+
+def _json_values_equal(left: JsonValue, right: JsonValue) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return left is right
+    if isinstance(left, list):
+        return _json_lists_equal(left, right)
+    if isinstance(right, list):
+        return False
+    if isinstance(left, dict):
+        return _json_dicts_equal(left, right)
+    if isinstance(right, dict):
+        return False
+    return left == right
+
+
+def _json_lists_equal(left: list[JsonValue], right: JsonValue) -> bool:
+    if not isinstance(right, list) or len(left) != len(right):
+        return False
+    return all(
+        _json_values_equal(left_item, right_item)
+        for left_item, right_item in zip(left, right, strict=True)
+    )
+
+
+def _json_dicts_equal(left: dict[str, JsonValue], right: JsonValue) -> bool:
+    if not isinstance(right, dict) or left.keys() != right.keys():
+        return False
+    return all(_json_values_equal(left[key], right[key]) for key in left)

--- a/arclith/adapters/outbound/memory/vector_store.py
+++ b/arclith/adapters/outbound/memory/vector_store.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchHit,
+    VectorSearchQuery,
+    VectorStoreCollectionNotFound,
+    VectorStoreDimensionMismatch,
+    VectorStorePort,
+)
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+
+class MemoryVectorStore(VectorStorePort):
+    """Deterministic exact-search vector store for tests and local POCs."""
+
+    def __init__(self, settings: VectorStoreSettings) -> None:
+        self._settings = settings
+        self._collections: dict[str, dict[str, VectorPoint]] = {}
+
+    async def ensure_collection(self) -> None:
+        self._collections.setdefault(self._settings.collection_name, {})
+
+    async def upsert(self, points: Sequence[VectorPoint]) -> None:
+        collection = self._collection()
+        materialized = tuple(points)
+        for point in materialized:
+            self._validate_dimension(point.vector)
+        for point in materialized:
+            collection[point.id] = point.model_copy(deep=True)
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        collection = self._collection()
+        for point_id in ids:
+            collection.pop(point_id, None)
+
+    async def search(self, query: VectorSearchQuery) -> list[VectorSearchHit]:
+        collection = self._collection()
+        self._validate_dimension(query.vector)
+        scored = [
+            (self._score(query.vector, point.vector), point)
+            for point in collection.values()
+            if self._matches_filters(point, query)
+        ]
+        scored.sort(key=lambda item: (-item[0], item[1].id))
+        return [
+            VectorSearchHit(
+                id=point.id,
+                score=score,
+                payload=point.payload if query.include_payload else {},
+                vector=point.vector if query.include_vector else None,
+            ).model_copy(deep=True)
+            for score, point in scored
+            if query.score_threshold is None or score >= query.score_threshold
+        ][: query.limit]
+
+    def _collection(self) -> dict[str, VectorPoint]:
+        try:
+            return self._collections[self._settings.collection_name]
+        except KeyError as exc:
+            raise VectorStoreCollectionNotFound(
+                f"vector collection '{self._settings.collection_name}' does not exist"
+            ) from exc
+
+    def _validate_dimension(self, vector: Sequence[float]) -> None:
+        actual = len(vector)
+        expected = self._settings.vector_size
+        if actual != expected:
+            raise VectorStoreDimensionMismatch(
+                f"vector dimension {actual} does not match configured size {expected}"
+            )
+
+    def _score(self, query: Sequence[float], point: Sequence[float]) -> float:
+        return {
+            "cosine": self._cosine,
+            "dot": self._dot,
+            "euclid": self._euclid_similarity,
+        }[self._settings.distance](query, point)
+
+    @staticmethod
+    def _matches_filters(point: VectorPoint, query: VectorSearchQuery) -> bool:
+        return all(
+            key in point.payload and point.payload[key] == value
+            for key, value in query.filters.items()
+        )
+
+    @staticmethod
+    def _dot(left: Sequence[float], right: Sequence[float]) -> float:
+        return sum(a * b for a, b in zip(left, right, strict=True))
+
+    @classmethod
+    def _cosine(cls, left: Sequence[float], right: Sequence[float]) -> float:
+        denominator = math.sqrt(cls._dot(left, left) * cls._dot(right, right))
+        if denominator == 0:
+            return 0.0
+        return cls._dot(left, right) / denominator
+
+    @classmethod
+    def _euclid_similarity(cls, left: Sequence[float], right: Sequence[float]) -> float:
+        distance = math.sqrt(
+            sum((a - b) ** 2 for a, b in zip(left, right, strict=True))
+        )
+        return 1.0 / (1.0 + distance)

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -21,6 +21,7 @@ from arclith.domain.ports.outbound.observability import (
     TracePort,
 )
 from arclith.domain.ports.outbound.repository import Repository
+from arclith.domain.ports.outbound.vector_store import VectorStorePort
 from arclith.infrastructure.config import (
     AppConfig,
     LangGraphStreamMode,
@@ -33,6 +34,7 @@ from arclith.infrastructure.langgraph_bootstrap import (
     LANGGRAPH_UNSET as _LANGGRAPH_UNSET,
 )
 from arclith.infrastructure.repository_factory import RepositoryRegistry
+from arclith.infrastructure.vector_store_factory import VectorStoreRegistry
 
 if TYPE_CHECKING:
     import fastmcp as _fastmcp
@@ -186,6 +188,15 @@ class Arclith:
         from arclith.infrastructure.embedding_factory import build_embedding
 
         return build_embedding(self.config, self.logger, registry=registry)
+
+    def vector_store(
+        self,
+        *,
+        registry: VectorStoreRegistry | None = None,
+    ) -> VectorStorePort:
+        from arclith.infrastructure.vector_store_factory import build_vector_store
+
+        return build_vector_store(self.config, self.logger, registry=registry)
 
     def rabbitmq_command_bus(self) -> "RabbitMQCommandBus":
         if not self.config.command_bus.is_enabled("rabbitmq"):

--- a/arclith/domain/ports/outbound/vector_store.py
+++ b/arclith/domain/ports/outbound/vector_store.py
@@ -141,6 +141,8 @@ class VectorSearchHit(_VectorStoreModel):
     def optional_vector_must_be_finite(
         cls, value: list[float] | None
     ) -> list[float] | None:
+        if value == []:
+            raise ValueError("vector search hit vector must not be empty")
         if value is not None and any(
             not math.isfinite(component) for component in value
         ):

--- a/arclith/domain/ports/outbound/vector_store.py
+++ b/arclith/domain/ports/outbound/vector_store.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    PositiveInt,
+    field_validator,
+)
+
+
+class VectorStoreError(Exception):
+    """Base error exposed by vector-store adapters."""
+
+
+class VectorStoreUnavailable(VectorStoreError):
+    """Raised when the vector backend is unavailable."""
+
+
+class VectorStoreCollectionNotFound(VectorStoreError):
+    """Raised when the configured collection does not exist."""
+
+
+class VectorStoreDimensionMismatch(VectorStoreError):
+    """Raised when a vector does not match the configured dimension."""
+
+
+class VectorStorePermissionDenied(VectorStoreError):
+    """Raised when backend credentials or policy reject an operation."""
+
+
+class VectorStoreInvalidPayload(VectorStoreError):
+    """Raised when a payload cannot be represented as JSON."""
+
+
+class _VectorStoreModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class _VectorModel(_VectorStoreModel):
+    vector: list[float] = Field(min_length=1)
+
+    @field_validator("vector")
+    @classmethod
+    def vector_must_contain_finite_values(cls, value: list[float]) -> list[float]:
+        if any(not math.isfinite(component) for component in value):
+            raise ValueError("vector values must be finite")
+        return value
+
+
+def _validate_finite_json(value: JsonValue) -> JsonValue:
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("JSON numeric values must be finite")
+    if isinstance(value, list):
+        for item in value:
+            _validate_finite_json(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _validate_finite_json(item)
+    return value
+
+
+class VectorPoint(_VectorModel):
+    """Provider-neutral vector and its JSON search projection."""
+
+    id: str
+    payload: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("id")
+    @classmethod
+    def id_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("vector point id must not be empty")
+        return normalized
+
+    @field_validator("payload")
+    @classmethod
+    def payload_must_be_strict_json(
+        cls, value: dict[str, JsonValue]
+    ) -> dict[str, JsonValue]:
+        _validate_finite_json(value)
+        return value
+
+
+class VectorSearchQuery(_VectorModel):
+    """Dense-vector search with exact-match payload filters."""
+
+    limit: PositiveInt = 10
+    filters: dict[str, JsonValue] = Field(default_factory=dict)
+    score_threshold: float | None = None
+    include_payload: bool = True
+    include_vector: bool = False
+
+    @field_validator("filters")
+    @classmethod
+    def filters_must_be_strict_json(
+        cls, value: dict[str, JsonValue]
+    ) -> dict[str, JsonValue]:
+        _validate_finite_json(value)
+        return value
+
+    @field_validator("score_threshold")
+    @classmethod
+    def score_threshold_must_be_finite(cls, value: float | None) -> float | None:
+        if value is not None and not math.isfinite(value):
+            raise ValueError("vector search score_threshold must be finite")
+        return value
+
+
+class VectorSearchHit(_VectorStoreModel):
+    """One backend-independent nearest-neighbour result."""
+
+    id: str
+    score: float
+    payload: dict[str, JsonValue] = Field(default_factory=dict)
+    vector: list[float] | None = None
+
+    @field_validator("id")
+    @classmethod
+    def id_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("vector search hit id must not be empty")
+        return normalized
+
+    @field_validator("score")
+    @classmethod
+    def score_must_be_finite(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("vector search score must be finite")
+        return value
+
+    @field_validator("vector")
+    @classmethod
+    def optional_vector_must_be_finite(
+        cls, value: list[float] | None
+    ) -> list[float] | None:
+        if value is not None and any(
+            not math.isfinite(component) for component in value
+        ):
+            raise ValueError("vector values must be finite")
+        return value
+
+
+class VectorStorePort(ABC):
+    """Outbound port for a rebuildable dense-vector search index."""
+
+    @abstractmethod
+    async def ensure_collection(self) -> None:
+        """Create the configured logical collection when it is absent."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def upsert(self, points: Sequence[VectorPoint]) -> None:
+        """Insert or replace points by their provider-neutral string ID."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def delete(self, ids: Sequence[str]) -> None:
+        """Delete point IDs; unknown IDs are ignored."""
+        pass  # pragma: no cover
+
+    @abstractmethod
+    async def search(self, query: VectorSearchQuery) -> list[VectorSearchHit]:
+        """Return best-first hits for one dense vector query."""
+        pass  # pragma: no cover

--- a/arclith/domain/ports/outbound/vector_store.py
+++ b/arclith/domain/ports/outbound/vector_store.py
@@ -129,6 +129,14 @@ class VectorSearchHit(_VectorStoreModel):
             raise ValueError("vector search hit id must not be empty")
         return normalized
 
+    @field_validator("payload")
+    @classmethod
+    def payload_must_be_strict_json(
+        cls, value: dict[str, JsonValue]
+    ) -> dict[str, JsonValue]:
+        _validate_finite_json(value)
+        return value
+
     @field_validator("score")
     @classmethod
     def score_must_be_finite(cls, value: float) -> float:

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -60,6 +60,9 @@ from arclith.infrastructure.settings import (  # noqa: F401
     StorageAdapter,
     StorageSettings,
     TenantSettings,
+    VectorDistance,
+    VectorStoreAdapter,
+    VectorStoreSettings,
 )
 
 _INBOUND_ALIAS: dict[str, str] = {"fastapi": "api", "fastmcp": "mcp"}

--- a/arclith/infrastructure/settings/__init__.py
+++ b/arclith/infrastructure/settings/__init__.py
@@ -71,6 +71,11 @@ from arclith.infrastructure.settings.storage import (
     StorageAdapter,
     StorageSettings,
 )
+from arclith.infrastructure.settings.vector_store import (
+    VectorDistance,
+    VectorStoreAdapter,
+    VectorStoreSettings,
+)
 
 __all__ = [
     "AdaptersSettings",
@@ -128,4 +133,7 @@ __all__ = [
     "StorageAdapter",
     "StorageSettings",
     "TenantSettings",
+    "VectorDistance",
+    "VectorStoreAdapter",
+    "VectorStoreSettings",
 ]

--- a/arclith/infrastructure/settings/app.py
+++ b/arclith/infrastructure/settings/app.py
@@ -22,6 +22,7 @@ from arclith.infrastructure.settings.repositories import (
     PostgreSQLSettings,
 )
 from arclith.infrastructure.settings.storage import StorageSettings
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
 
 _REPOSITORY_CONFIG_SECTIONS: dict[str, str] = {
     "mongodb": "mongodb",
@@ -57,6 +58,7 @@ class AdaptersSettings(SettingsModel):
     postgresql: PostgreSQLSettings | None = None
     storage: StorageSettings | None = None
     embedding: EmbeddingSettings | None = None
+    vector_store: VectorStoreSettings | None = None
     lm: LMSettings | None = None
     langsmith: LangSmithSettings | None = None
     opentelemetry: OpenTelemetrySettings | None = None

--- a/arclith/infrastructure/settings/vector_store.py
+++ b/arclith/infrastructure/settings/vector_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import PositiveInt, StringConstraints, field_validator, model_validator
+
+from arclith.infrastructure.settings._base import SettingsModel
+
+VectorStoreAdapter = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
+VectorDistance = Literal["cosine", "dot", "euclid"]
+
+
+class VectorStoreSettings(SettingsModel):
+    adapter: VectorStoreAdapter
+    collection_name: str = "default"
+    vector_size: PositiveInt
+    distance: VectorDistance = "cosine"
+    multitenant: bool = False
+
+    @field_validator("collection_name")
+    @classmethod
+    def collection_name_must_not_be_empty(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("vector_store collection_name must not be empty")
+        return normalized
+
+    @model_validator(mode="after")
+    def reject_unsupported_memory_multitenancy(self) -> "VectorStoreSettings":
+        if self.adapter == "memory" and self.multitenant:
+            raise ValueError("vector_store adapter memory does not support multitenant")
+        return self

--- a/arclith/infrastructure/vector_store_factory.py
+++ b/arclith/infrastructure/vector_store_factory.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.domain.ports.outbound.vector_store import VectorStorePort
+from arclith.infrastructure.config import AppConfig
+
+VectorStoreFactory = Callable[[AppConfig, Logger], VectorStorePort]
+
+
+class VectorStoreRegistry:
+    """Registry mapping vector-store adapter names to factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, VectorStoreFactory] = {}
+
+    def register(self, name: str, factory: VectorStoreFactory) -> "VectorStoreRegistry":
+        self._factories[name] = factory
+        return self
+
+    def build(self, config: AppConfig, logger: Logger) -> VectorStorePort:
+        settings = config.adapters.vector_store
+        if settings is None:
+            raise ValueError(
+                "adapters.vector_store is required to build a vector store"
+            )
+        if settings.adapter not in self._factories:
+            raise ValueError(
+                f"Vector-store adapter '{settings.adapter}' not registered. "
+                f"Available: {sorted(self._factories)}."
+            )
+        return self._factories[settings.adapter](config, logger)
+
+
+def build_vector_store(
+    config: AppConfig,
+    logger: Logger,
+    *,
+    registry: VectorStoreRegistry | None = None,
+) -> VectorStorePort:
+    active_registry = registry or default_vector_store_registry()
+    return active_registry.build(config, logger)
+
+
+def default_vector_store_registry() -> VectorStoreRegistry:
+    return VectorStoreRegistry().register("memory", _build_memory_vector_store)
+
+
+def _build_memory_vector_store(config: AppConfig, _logger: Logger) -> VectorStorePort:
+    from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
+
+    settings = config.adapters.vector_store
+    if settings is None:
+        raise ValueError("Memory vector-store settings are required")
+    return MemoryVectorStore(settings)

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -24,7 +24,11 @@ from arclith_cli.catalogs.core import (
     SECRETS_CAPABILITY,
 )
 from arclith_cli.catalogs.observability import OBSERVABILITY_CAPABILITY
-from arclith_cli.catalogs.persistence import REPOSITORY_CAPABILITY, STORAGE_CAPABILITY
+from arclith_cli.catalogs.persistence import (
+    REPOSITORY_CAPABILITY,
+    STORAGE_CAPABILITY,
+    VECTOR_STORE_CAPABILITY,
+)
 from arclith_cli.catalogs.security import (
     AUTH_CAPABILITY,
     LICENSE_CAPABILITY,
@@ -68,6 +72,7 @@ __all__ = [
     "STORAGE_CAPABILITY",
     "SecretMappingSpec",
     "TENANT_CAPABILITY",
+    "VECTOR_STORE_CAPABILITY",
     "capability_catalog_as_dict",
     "capability_names",
     "get_capability",
@@ -77,6 +82,7 @@ __all__ = [
 CAPABILITY_CATALOG = (
     REPOSITORY_CAPABILITY,
     STORAGE_CAPABILITY,
+    VECTOR_STORE_CAPABILITY,
     CACHE_CAPABILITY,
     LOGGER_CAPABILITY,
     SECRETS_CAPABILITY,

--- a/cli/arclith_cli/catalogs/persistence.py
+++ b/cli/arclith_cli/catalogs/persistence.py
@@ -444,3 +444,54 @@ multitenant: {multitenant}
         ),
     ),
 )
+
+VECTOR_STORE_CAPABILITY = CapabilitySpec(
+    name="vector-store",
+    layer="outbound",
+    description="Indexation et recherche dense derrière un port provider-neutral.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="memory",
+            capability="vector-store",
+            layer="outbound",
+            description="Recherche exacte déterministe sans dépendance pour tests et POC.",
+            config_path="config/adapters/outbound/vector_store.yaml",
+            config_template="""\
+adapter: memory
+collection_name: "{collection_name}"
+vector_size: {vector_size}
+distance: {distance}
+multitenant: {multitenant}
+""",
+            parameters=(
+                ParameterSpec(
+                    name="collection_name",
+                    kind="string",
+                    prompt="Nom logique de la collection",
+                    default="default",
+                ),
+                ParameterSpec(
+                    name="vector_size",
+                    kind="string",
+                    prompt="Dimension obligatoire des vecteurs",
+                    default="1536",
+                ),
+                ParameterSpec(
+                    name="distance",
+                    kind="string",
+                    prompt="Métrique de similarité",
+                    default="cosine",
+                    choices=("cosine", "dot", "euclid"),
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Réserver la résolution de contexte par tenant",
+                    default=False,
+                ),
+            ),
+            entity_scoped=False,
+        ),
+    ),
+)

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -164,7 +164,7 @@ def add_adapter(
             "--capability",
             help=(
                 "Capacité cible: repository, cache, logger, secrets, api, mcp, probe, http, "
-                "command-bus, runtime, auth, tenant, license, llm, embedding, agent, "
+                "command-bus, runtime, auth, tenant, license, llm, embedding, vector-store, agent, "
                 "agent-persistence ou observability"
             ),
         ),

--- a/cli/tests/test_vector_store_capability.py
+++ b/cli/tests/test_vector_store_capability.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from arclith_cli.add_adapter import add_adapter_cmd
+from arclith_cli.capabilities import capability_catalog_as_dict, get_capability
+
+
+def _minimal_project(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "demo-service"
+    (project_dir / "src" / "demo_service" / "domain" / "models").mkdir(parents=True)
+    config_dir = project_dir / "config" / "adapters"
+    config_dir.mkdir(parents=True)
+    (config_dir / "adapters.yaml").write_text(
+        "logger: console\nrepository: memory\nobservability:\n  enabled: []\n",
+        encoding="utf-8",
+    )
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "demo-service"\nversion = "0.1.0"\n'
+        'dependencies = ["arclith>=0.21.0"]\n',
+        encoding="utf-8",
+    )
+    return project_dir
+
+
+def test_vector_store_capability_catalog_declares_memory_adapter() -> None:
+    capability = get_capability("vector-store")
+
+    assert capability is not None
+    assert capability.layer == "outbound"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("memory",)
+    memory = capability.get_adapter("memory")
+    assert memory is not None
+    assert memory.entity_scoped is False
+    assert memory.dependency_extra is None
+    assert memory.config_path == "config/adapters/outbound/vector_store.yaml"
+    assert [parameter.name for parameter in memory.parameters] == [
+        "collection_name",
+        "vector_size",
+        "distance",
+        "multitenant",
+    ]
+
+
+def test_vector_store_capability_is_exposed_in_json_catalog() -> None:
+    payload_by_name = {
+        capability["name"]: capability for capability in capability_catalog_as_dict()
+    }
+
+    vector_store = payload_by_name["vector-store"]
+    assert vector_store["activation_config_key"] is None
+    assert [adapter["name"] for adapter in vector_store["adapters"]] == ["memory"]
+
+
+def test_add_memory_vector_store_generates_loadable_config_idempotently(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    params = {
+        "collection_name": "documents",
+        "vector_size": "3",
+        "distance": "cosine",
+        "multitenant": "false",
+    }
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="vector-store",
+            adapter="memory",
+            adapter_params=params,
+            yes=True,
+        )
+
+    from arclith import Arclith, MemoryVectorStore
+
+    config_path = project_dir / "config/adapters/outbound/vector_store.yaml"
+    app = Arclith(project_dir / "config")
+
+    assert config_path.read_text(encoding="utf-8") == (
+        "adapter: memory\n"
+        'collection_name: "documents"\n'
+        "vector_size: 3\n"
+        "distance: cosine\n"
+        "multitenant: false\n"
+    )
+    assert app.config.adapters.vector_store is not None
+    assert app.config.adapters.vector_store.vector_size == 3
+    assert isinstance(app.vector_store(), MemoryVectorStore)
+    assert "vector_store:" not in (
+        project_dir / "config/adapters/adapters.yaml"
+    ).read_text(encoding="utf-8")

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -37,6 +37,7 @@ arclith-cli capabilities --json
 | [secrets](capabilities/secrets.md) | outbound | `env`, `yaml`, `vault`, `chain` | résoudre les secrets |
 | [llm](capabilities/llm.md) | outbound | `lmstudio`, `openai`, `anthropic` | configurer les modèles |
 | [embedding](capabilities/embedding.md) | outbound | `deterministic`, `openai-compatible`, `openai` | calculer des vecteurs texte sans les persister |
+| [vector-store](capabilities/vector-store.md) | outbound | `memory` | indexer et rechercher des projections vectorielles |
 | [observability](capabilities/observability.md) ([OpenTelemetry](capabilities/opentelemetry.md)) | outbound | `langsmith`, `opentelemetry` | traces, métriques, logs et agents |
 | [command-bus](capabilities/command-bus.md) | bidirectional | `rabbitmq` | consommer et publier des commandes |
 | [runtime](capabilities/runtime.md) | runtime | `docker-image` | générer le runtime conteneur |
@@ -49,7 +50,7 @@ arclith-cli capabilities --json
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
 | Agent local | [Quickstart Agent](quickstarts/agent.md), [formation agent](tutorials/todo-list/06-agent.md), puis [agent/langgraph](capabilities/agent.md) et [persistance](capabilities/agent-persistence.md) |
-| Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis la capability vector-store adaptée |
+| Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis [vector-store](capabilities/vector-store.md) pour les indexer |
 | Observabilité locale | [OpenTelemetry de bout en bout](capabilities/opentelemetry.md), puis [observabilité production](production/observability.md) |
 | Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |

--- a/docs/capabilities/vector-store.md
+++ b/docs/capabilities/vector-store.md
@@ -1,0 +1,144 @@
+# Vector Store
+
+La capability outbound `vector-store` indexe des projections vectorielles et
+retrouve leurs voisins derrière `VectorStorePort`. Elle reste indépendante des
+SDK fournisseurs et n'est pas la source de vérité métier par défaut.
+
+## Choisir La Bonne Persistance
+
+| Besoin | Capability | Responsabilité |
+|---|---|---|
+| conserver les entités métier et leur cycle de vie | `repository` | source de vérité CRUD |
+| conserver des fichiers ou blobs | `storage` | octets et métadonnées objet |
+| retrouver des contenus proches d'un vecteur | `vector-store` | index de recherche reconstruisible |
+| calculer un vecteur depuis du texte | `embedding` | inférence, sans persistance |
+
+Qdrant ou un autre moteur vectoriel ne remplace donc pas automatiquement
+`Repository[T]`. Le service consommateur peut faire ce choix explicitement,
+mais Arclith traite l'index comme une projection reconstruisible.
+
+## Position Hexagonale
+
+```text
+adapter inbound -> use case applicatif -> Repository[T]
+                                      -> EmbeddingPort
+                                      -> VectorStorePort
+```
+
+L'adapter inbound ne connaît ni le SDK ni les types d'un backend vectoriel. Le
+use case orchestre la persistance canonique puis l'indexation. En production,
+si ces écritures doivent résister à une panne entre les deux étapes, le service
+consommateur doit prévoir un mécanisme de reprise ou un outbox ; la capability
+n'ajoute pas de synchronisation implicite.
+
+## Contrat V1
+
+```python
+from arclith import VectorPoint, VectorSearchQuery, VectorStorePort
+
+
+async def index_and_search(store: VectorStorePort) -> list[str]:
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(
+                id="doc-1",
+                vector=[1.0, 0.0, 0.0],
+                payload={"kind": "guide", "published": True},
+            )
+        ]
+    )
+    hits = await store.search(
+        VectorSearchQuery(
+            vector=[1.0, 0.0, 0.0],
+            filters={"kind": "guide"},
+            limit=5,
+        )
+    )
+    return [hit.id for hit in hits]
+```
+
+Le contrat accepte uniquement des vecteurs denses et des payloads JSON :
+`null`, booléens, nombres finis, chaînes, listes et objets. Les IDs sont des
+chaînes provider-neutral ; pour une entité Arclith, utiliser
+`str(entity.uuid)`.
+
+Les filtres v1 font un exact-match sur les champs de premier niveau du payload.
+Les résultats sont triés du meilleur score au moins bon. Pour `euclid`,
+l'adapter mémoire convertit la distance en similarité avec `1 / (1 + distance)`
+afin qu'un score supérieur reste meilleur pour les trois métriques.
+
+## Adapter Memory
+
+`memory` fournit une recherche exacte, déterministe et sans dépendance externe.
+Il cible les tests, les démonstrations et les smoke tests locaux, pas les grands
+volumes ni la recherche approximate-nearest-neighbour.
+
+```bash
+arclith-cli add-adapter \
+  --capability vector-store \
+  --adapter memory \
+  --param collection_name=documents \
+  --param vector_size=3 \
+  --param distance=cosine \
+  --yes
+```
+
+La commande crée de façon idempotente
+`config/adapters/outbound/vector_store.yaml` :
+
+```yaml
+adapter: memory
+collection_name: documents
+vector_size: 3
+distance: cosine
+multitenant: false
+```
+
+Puis l'assemblage passe par la factory publique :
+
+```python
+from arclith import Arclith
+
+app = Arclith("config")
+vector_store = app.vector_store()
+await vector_store.ensure_collection()
+```
+
+`ensure_collection()` est idempotente. Les autres opérations échouent avec
+`VectorStoreCollectionNotFound` si elle n'a pas encore été appelée. Les upserts
+valident tout le batch avant de le modifier et lèvent
+`VectorStoreDimensionMismatch` si une dimension diffère de `vector_size`.
+
+## Erreurs Communes
+
+Les adapters exposent les erreurs provider-neutral suivantes :
+
+- `VectorStoreUnavailable` ;
+- `VectorStoreCollectionNotFound` ;
+- `VectorStoreDimensionMismatch` ;
+- `VectorStorePermissionDenied` ;
+- `VectorStoreInvalidPayload`.
+
+Les modèles Pydantic refusent en amont les payloads non JSON, les vecteurs vides
+ou non finis et les limites non positives. Les adapters externes doivent mapper
+leurs erreurs sans exposer de token, de clé API ni d'URL contenant des
+credentials.
+
+## Limites V1
+
+La recherche hybride, les sparse vectors, les named vectors multiples,
+recommend/discover, le reranking et la synchronisation automatique avec un
+repository sont hors scope. Ils devront étendre le contrat commun sans faire
+fuiter de types fournisseur dans le domaine.
+
+## Validation Locale
+
+```bash
+uv run pytest tests/units/domain/ports/test_vector_store.py
+uv run pytest tests/units/adapters/outbound/test_memory_vector_store.py
+uv run pytest tests/units/infrastructure/test_vector_store_config.py
+uv run pytest tests/units/infrastructure/test_vector_store_factory.py
+uv run --project cli pytest cli/tests/test_vector_store_capability.py
+make docs
+```

--- a/docs/deep-dives/configuration.md
+++ b/docs/deep-dives/configuration.md
@@ -30,6 +30,7 @@ Chaque capability possède son propre fichier quand c'est pertinent:
 | Agent | `config/adapters/inbound/langgraph.yaml` |
 | Repository | `config/adapters/outbound/mongodb.yaml` |
 | Storage | `config/adapters/outbound/storage.yaml` |
+| Vector store | `config/adapters/outbound/vector_store.yaml` |
 | LLM | `config/adapters/outbound/lm.yaml` |
 | Command Bus | `config/command_bus.yaml` |
 

--- a/journal/2026-09-02-vector-store-contract.md
+++ b/journal/2026-09-02-vector-store-contract.md
@@ -1,0 +1,35 @@
+# Capability vector-store : contrat commun et adapter memory
+
+## Contexte
+
+L'issue #147 introduit une persistance de recherche vectorielle distincte du
+repository métier et du stockage de fichiers. Le premier adapter doit permettre
+un usage exécutable sans service ni dépendance externe avant l'intégration de
+Qdrant prévue par #148.
+
+## Décisions
+
+- Le domaine expose des modèles Pydantic stricts et un `VectorStorePort` limité
+  aux vecteurs denses.
+- Les payloads utilisent `JsonValue` afin qu'aucun objet Python arbitraire ne
+  traverse le port.
+- Les scores sont toujours triés du plus pertinent au moins pertinent ; la
+  distance euclidienne mémoire est convertie en `1 / (1 + distance)`.
+- L'adapter mémoire exige un `ensure_collection()` explicite, valide les batchs
+  avant mutation et copie profondément les points stockés et retournés.
+- `config/adapters/outbound/vector_store.yaml` alimente
+  `adapters.vector_store`, sans sélecteur dans `adapters.yaml`.
+- Le registry public permet aux applications d'ajouter un backend sans modifier
+  le domaine.
+
+## Validation prévue
+
+- Tests des modèles, de l'adapter mémoire, de la config, de la factory et du
+  scaffold CLI.
+- `make quality`, `make precommit` et `make docs`.
+
+## Impact et suites
+
+Aucune dépendance n'est ajoutée. Le contrat et l'adapter mémoire sont inclus
+dans le package principal. #148 pourra ajouter Qdrant derrière ce port et mapper
+ses erreurs propres vers les exceptions communes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - HTTP: capabilities/http.md
       - LLM: capabilities/llm.md
       - Embedding: capabilities/embedding.md
+      - Vector Store: capabilities/vector-store.md
       - Observability:
           - Vue d'ensemble: capabilities/observability.md
           - OpenTelemetry: capabilities/opentelemetry.md

--- a/tests/units/adapters/outbound/test_memory_vector_store.py
+++ b/tests/units/adapters/outbound/test_memory_vector_store.py
@@ -1,0 +1,192 @@
+import pytest
+
+from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchQuery,
+    VectorStoreCollectionNotFound,
+    VectorStoreDimensionMismatch,
+)
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+
+def _store(*, distance: str = "cosine") -> MemoryVectorStore:
+    return MemoryVectorStore(
+        VectorStoreSettings(
+            adapter="memory",
+            collection_name="documents",
+            vector_size=2,
+            distance=distance,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_requires_collection_initialization() -> None:
+    store = _store()
+
+    with pytest.raises(VectorStoreCollectionNotFound, match="documents"):
+        await store.search(VectorSearchQuery(vector=[1.0, 0.0]))
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_upserts_searches_filters_and_projects() -> None:
+    store = _store()
+    await store.ensure_collection()
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(
+                id="near", vector=[1.0, 0.0], payload={"kind": "guide", "v": 1}
+            ),
+            VectorPoint(id="far", vector=[0.0, 1.0], payload={"kind": "guide", "v": 2}),
+            VectorPoint(
+                id="excluded",
+                vector=[0.9, 0.1],
+                payload={"kind": "internal"},
+            ),
+        ]
+    )
+
+    hits = await store.search(
+        VectorSearchQuery(
+            vector=[1.0, 0.0],
+            filters={"kind": "guide"},
+            include_vector=True,
+        )
+    )
+
+    assert [hit.id for hit in hits] == ["near", "far"]
+    assert hits[0].payload == {"kind": "guide", "v": 1}
+    assert hits[0].vector == [1.0, 0.0]
+    assert hits[0].score == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_applies_limit_threshold_and_projection_flags() -> (
+    None
+):
+    store = _store(distance="dot")
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(id="a", vector=[1.0, 0.0], payload={"copy": "safe"}),
+            VectorPoint(id="b", vector=[0.5, 0.0]),
+            VectorPoint(id="c", vector=[-1.0, 0.0]),
+        ]
+    )
+
+    hits = await store.search(
+        VectorSearchQuery(
+            vector=[1.0, 0.0],
+            limit=1,
+            score_threshold=0.5,
+            include_payload=False,
+        )
+    )
+
+    assert [(hit.id, hit.score) for hit in hits] == [("a", 1.0)]
+    assert hits[0].payload == {}
+    assert hits[0].vector is None
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_distinguishes_missing_filter_from_json_null() -> (
+    None
+):
+    store = _store()
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(id="missing", vector=[1.0, 0.0]),
+            VectorPoint(id="null", vector=[1.0, 0.0], payload={"category": None}),
+        ]
+    )
+
+    hits = await store.search(
+        VectorSearchQuery(vector=[1.0, 0.0], filters={"category": None})
+    )
+
+    assert [hit.id for hit in hits] == ["null"]
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_replaces_and_deletes_points() -> None:
+    store = _store()
+    await store.ensure_collection()
+    await store.upsert([VectorPoint(id="doc", vector=[1.0, 0.0])])
+    await store.upsert([VectorPoint(id="doc", vector=[0.0, 1.0])])
+
+    hits = await store.search(VectorSearchQuery(vector=[0.0, 1.0]))
+    assert [hit.id for hit in hits] == ["doc"]
+    assert hits[0].score == pytest.approx(1.0)
+
+    await store.delete(["missing", "doc"])
+    assert await store.search(VectorSearchQuery(vector=[0.0, 1.0])) == []
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_dimension_validation_is_atomic() -> None:
+    store = _store()
+    await store.ensure_collection()
+
+    with pytest.raises(VectorStoreDimensionMismatch, match="configured size 2"):
+        await store.upsert(
+            [
+                VectorPoint(id="valid", vector=[1.0, 0.0]),
+                VectorPoint(id="invalid", vector=[1.0]),
+            ]
+        )
+    assert await store.search(VectorSearchQuery(vector=[1.0, 0.0])) == []
+
+    with pytest.raises(VectorStoreDimensionMismatch, match="configured size 2"):
+        await store.search(VectorSearchQuery(vector=[1.0]))
+
+
+@pytest.mark.asyncio
+async def test_memory_vector_store_returns_detached_results() -> None:
+    store = _store()
+    await store.ensure_collection()
+    point = VectorPoint(id="doc", vector=[1.0, 0.0], payload={"nested": ["value"]})
+    await store.upsert([point])
+
+    point.vector[0] = 0.0
+    point.payload["nested"] = ["changed"]
+    first = await store.search(
+        VectorSearchQuery(vector=[1.0, 0.0], include_vector=True)
+    )
+    first[0].vector[0] = 0.0  # type: ignore[index]
+    first[0].payload["nested"] = ["changed-again"]
+    second = await store.search(
+        VectorSearchQuery(vector=[1.0, 0.0], include_vector=True)
+    )
+
+    assert second[0].vector == [1.0, 0.0]
+    assert second[0].payload == {"nested": ["value"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("distance", "expected_order"),
+    [
+        ("cosine", ["exact", "close", "far"]),
+        ("dot", ["exact", "close", "far"]),
+        ("euclid", ["exact", "close", "far"]),
+    ],
+)
+async def test_memory_vector_store_orders_all_supported_distances(
+    distance: str, expected_order: list[str]
+) -> None:
+    store = _store(distance=distance)
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(id="far", vector=[0.0, 1.0]),
+            VectorPoint(id="close", vector=[0.8, 0.2]),
+            VectorPoint(id="exact", vector=[1.0, 0.0]),
+        ]
+    )
+
+    hits = await store.search(VectorSearchQuery(vector=[1.0, 0.0]))
+
+    assert [hit.id for hit in hits] == expected_order

--- a/tests/units/adapters/outbound/test_memory_vector_store.py
+++ b/tests/units/adapters/outbound/test_memory_vector_store.py
@@ -111,6 +111,32 @@ async def test_memory_vector_store_distinguishes_missing_filter_from_json_null()
 
 
 @pytest.mark.asyncio
+async def test_memory_vector_store_distinguishes_json_booleans_from_numbers() -> None:
+    store = _store()
+    await store.ensure_collection()
+    await store.upsert(
+        [
+            VectorPoint(
+                id="boolean",
+                vector=[1.0, 0.0],
+                payload={"value": {"nested": [True]}},
+            ),
+            VectorPoint(
+                id="number",
+                vector=[1.0, 0.0],
+                payload={"value": {"nested": [1]}},
+            ),
+        ]
+    )
+
+    hits = await store.search(
+        VectorSearchQuery(vector=[1.0, 0.0], filters={"value": {"nested": [True]}})
+    )
+
+    assert [hit.id for hit in hits] == ["boolean"]
+
+
+@pytest.mark.asyncio
 async def test_memory_vector_store_replaces_and_deletes_points() -> None:
     store = _store()
     await store.ensure_collection()

--- a/tests/units/domain/ports/test_vector_store.py
+++ b/tests/units/domain/ports/test_vector_store.py
@@ -56,6 +56,11 @@ def test_vector_search_hit_rejects_non_finite_score() -> None:
         VectorSearchHit(id="doc-1", score=math.nan)
 
 
+def test_vector_search_hit_rejects_non_finite_payload() -> None:
+    with pytest.raises(ValidationError, match="payload"):
+        VectorSearchHit(id="doc-1", score=1.0, payload={"rank": math.inf})
+
+
 def test_vector_search_hit_rejects_empty_included_vector() -> None:
     with pytest.raises(ValidationError, match="must not be empty"):
         VectorSearchHit(id="doc-1", score=1.0, vector=[])

--- a/tests/units/domain/ports/test_vector_store.py
+++ b/tests/units/domain/ports/test_vector_store.py
@@ -1,0 +1,56 @@
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchHit,
+    VectorSearchQuery,
+)
+
+
+def test_vector_point_accepts_nested_json_payload() -> None:
+    point = VectorPoint(
+        id="  doc-1  ",
+        vector=[0.25, -0.5],
+        payload={
+            "published": True,
+            "rank": 3,
+            "tags": ["python", None],
+            "metadata": {"language": "fr"},
+        },
+    )
+
+    assert point.id == "doc-1"
+    assert point.payload["metadata"] == {"language": "fr"}
+
+
+@pytest.mark.parametrize("invalid", [object(), math.nan, math.inf])
+def test_vector_point_rejects_non_json_or_non_finite_payload(invalid: object) -> None:
+    with pytest.raises(ValidationError, match="payload"):
+        VectorPoint(id="doc-1", vector=[1.0], payload={"value": invalid})
+
+
+def test_vector_search_query_rejects_non_finite_filter() -> None:
+    with pytest.raises(ValidationError, match="filters"):
+        VectorSearchQuery(vector=[1.0], filters={"nested": [math.nan]})
+
+
+@pytest.mark.parametrize("invalid", [[], [math.nan], [math.inf]])
+def test_vector_models_reject_empty_or_non_finite_vectors(invalid: list[float]) -> None:
+    with pytest.raises(ValidationError, match="vector"):
+        VectorPoint(id="doc-1", vector=invalid)
+
+
+def test_vector_search_query_requires_positive_limit_and_finite_threshold() -> None:
+    with pytest.raises(ValidationError, match="limit"):
+        VectorSearchQuery(vector=[1.0], limit=0)
+
+    with pytest.raises(ValidationError, match="score_threshold"):
+        VectorSearchQuery(vector=[1.0], score_threshold=math.inf)
+
+
+def test_vector_search_hit_rejects_non_finite_score() -> None:
+    with pytest.raises(ValidationError, match="score"):
+        VectorSearchHit(id="doc-1", score=math.nan)

--- a/tests/units/domain/ports/test_vector_store.py
+++ b/tests/units/domain/ports/test_vector_store.py
@@ -54,3 +54,8 @@ def test_vector_search_query_requires_positive_limit_and_finite_threshold() -> N
 def test_vector_search_hit_rejects_non_finite_score() -> None:
     with pytest.raises(ValidationError, match="score"):
         VectorSearchHit(id="doc-1", score=math.nan)
+
+
+def test_vector_search_hit_rejects_empty_included_vector() -> None:
+    with pytest.raises(ValidationError, match="must not be empty"):
+        VectorSearchHit(id="doc-1", score=1.0, vector=[])

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -32,6 +32,7 @@ from arclith.infrastructure.config import (
 def test_default_config_uses_memory():
     assert AppConfig().adapters.repository == "memory"
     assert AppConfig().adapters.storage is None
+    assert AppConfig().adapters.vector_store is None
     assert AppConfig().adapters.observability.enabled == []
     assert AppConfig().command_bus.enabled == []
 
@@ -113,6 +114,10 @@ def test_resolve_output_adapter():
     assert _resolve_key_path(Path("adapters/outbound/storage.yaml")) == [
         "adapters",
         "storage",
+    ]
+    assert _resolve_key_path(Path("adapters/outbound/vector_store.yaml")) == [
+        "adapters",
+        "vector_store",
     ]
 
 

--- a/tests/units/infrastructure/test_vector_store_config.py
+++ b/tests/units/infrastructure/test_vector_store_config.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from arclith.infrastructure.config import load_config_dir
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+
+def test_load_config_dir_loads_scoped_vector_store_settings(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    outbound = config_dir / "adapters" / "outbound"
+    outbound.mkdir(parents=True)
+    (outbound / "vector_store.yaml").write_text(
+        "adapter: memory\n"
+        "collection_name: documents\n"
+        "vector_size: 3\n"
+        "distance: dot\n"
+        "multitenant: false\n",
+        encoding="utf-8",
+    )
+
+    config = load_config_dir(config_dir)
+
+    assert config.adapters.vector_store == VectorStoreSettings(
+        adapter="memory",
+        collection_name="documents",
+        vector_size=3,
+        distance="dot",
+        multitenant=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"adapter": "memory", "collection_name": " ", "vector_size": 2},
+        {"adapter": "memory", "collection_name": "docs", "vector_size": 0},
+        {
+            "adapter": "memory",
+            "collection_name": "docs",
+            "vector_size": 2,
+            "distance": "manhattan",
+        },
+        {
+            "adapter": "memory",
+            "collection_name": "docs",
+            "vector_size": 2,
+            "multitenant": True,
+        },
+    ],
+)
+def test_vector_store_settings_reject_invalid_values(values: dict) -> None:
+    with pytest.raises(ValidationError):
+        VectorStoreSettings.model_validate(values)

--- a/tests/units/infrastructure/test_vector_store_factory.py
+++ b/tests/units/infrastructure/test_vector_store_factory.py
@@ -1,0 +1,97 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from arclith import Arclith
+from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchHit,
+    VectorSearchQuery,
+    VectorStorePort,
+)
+from arclith.infrastructure.config import AppConfig
+from arclith.infrastructure.vector_store_factory import (
+    VectorStoreRegistry,
+    build_vector_store,
+    default_vector_store_registry,
+)
+
+
+class StubVectorStore(VectorStorePort):
+    async def ensure_collection(self) -> None:
+        pass
+
+    async def upsert(self, points: Sequence[VectorPoint]) -> None:
+        pass
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        pass
+
+    async def search(self, query: VectorSearchQuery) -> list[VectorSearchHit]:
+        return []
+
+
+def _config() -> AppConfig:
+    return AppConfig.model_validate(
+        {
+            "adapters": {
+                "vector_store": {
+                    "adapter": "memory",
+                    "collection_name": "documents",
+                    "vector_size": 3,
+                }
+            }
+        }
+    )
+
+
+def test_build_vector_store_returns_memory_adapter(logger) -> None:
+    assert isinstance(build_vector_store(_config(), logger), MemoryVectorStore)
+
+
+def test_build_vector_store_requires_config(logger) -> None:
+    with pytest.raises(ValueError, match="adapters.vector_store"):
+        build_vector_store(AppConfig(), logger)
+
+
+def test_default_vector_store_registry_rejects_unknown_adapter(logger) -> None:
+    config = _config()
+    assert config.adapters.vector_store is not None
+    unknown = config.adapters.vector_store.model_copy(update={"adapter": "unknown"})
+    config = config.model_copy(
+        update={
+            "adapters": config.adapters.model_copy(update={"vector_store": unknown})
+        }
+    )
+
+    with pytest.raises(ValueError, match="not registered"):
+        default_vector_store_registry().build(config, logger)
+
+
+def test_custom_vector_store_registry_builds_registered_adapter(logger) -> None:
+    expected = StubVectorStore()
+    config = _config()
+    assert config.adapters.vector_store is not None
+    custom = config.adapters.vector_store.model_copy(update={"adapter": "custom"})
+    config = config.model_copy(
+        update={"adapters": config.adapters.model_copy(update={"vector_store": custom})}
+    )
+    registry = VectorStoreRegistry().register(
+        "custom", lambda _config, _logger: expected
+    )
+
+    assert build_vector_store(config, logger, registry=registry) is expected
+
+
+def test_arclith_builds_configured_vector_store(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    outbound = config_dir / "adapters" / "outbound"
+    outbound.mkdir(parents=True)
+    (outbound / "vector_store.yaml").write_text(
+        "adapter: memory\ncollection_name: documents\nvector_size: 2\n",
+        encoding="utf-8",
+    )
+
+    assert isinstance(Arclith(config_dir).vector_store(), MemoryVectorStore)

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -52,6 +52,15 @@ def test_public_embedding_exports():
     assert arclith.DeterministicEmbeddingAdapter is not None
 
 
+def test_public_vector_store_exports():
+    registry = arclith.default_vector_store_registry()
+
+    assert registry is not None
+    assert arclith.build_vector_store is not None
+    assert arclith.VectorStorePort is not None
+    assert arclith.MemoryVectorStore is not None
+
+
 def test_import_arclith_does_not_require_embedding_extra():
     script = """
 import importlib.abc


### PR DESCRIPTION
## Contexte

Closes #147.

Ajoute le socle provider-neutral de recherche vectorielle attendu par la roadmap #57, avant l'adapter Qdrant de #148. L'index reste une projection reconstruisible distincte du repository métier et du stockage de fichiers.

## Changements principaux

- ajoute `VectorStorePort`, les modèles d'entrée/sortie JSON stricts et les erreurs communes ;
- ajoute `MemoryVectorStore` avec collections explicites, upsert atomique, filtres exact-match et scores cosine/dot/euclid ;
- branche `adapters.vector_store`, `build_vector_store()` et `Arclith.vector_store()` avec registry extensible ;
- expose `vector-store/memory` dans le catalogue et le scaffold CLI idempotent ;
- documente l'architecture, le pattern repository puis index, le smoke local et les limites v1 ;
- ajoute le journal `2026-09-02-vector-store-contract.md`.

## Impact

- API publique : nouveaux exports `VectorStorePort`, modèles, erreurs, factory/registry et adapter mémoire ;
- configuration : nouveau fichier scoped `config/adapters/outbound/vector_store.yaml`, sans sélecteur dans `adapters.yaml` ;
- domaine/données : payloads limités au JSON strict et vecteurs denses de dimension configurée ; aucune migration ;
- RabbitMQ/MCP/ports existants : aucun changement ;
- dépendances et déploiement : aucune dépendance externe ni action de déploiement ;
- release : commit `feat:` publiable en version mineure selon semantic-release.

## Validations

- `make quality` : 1 786 passed, 5 skipped, couverture 90,85 % ;
- `make precommit` : Ruff, mypy et Bandit verts ;
- `uv run --frozen pytest -q` dans `cli/` : 146 passed, 1 skipped ;
- `make docs` : MkDocs strict vert ;
- `git diff --check` : vert.

## Risques restants

L'adapter mémoire effectue une recherche exacte en O(n) et ne cible pas la production ni l'ANN. Le multitenant est volontairement refusé pour `memory`. Qdrant, les sparse/named vectors, la recherche hybride et le reranking restent hors scope et seront traités séparément.
