### PR TITLE
feat: ajouter l'adapter vector-store Qdrant

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -14,6 +14,7 @@ from arclith.adapters.outbound.gcs import GCSFileStorage, GCSStorageConfig
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
+from arclith.adapters.outbound.qdrant import QdrantVectorStore
 from arclith.adapters.outbound.s3 import S3FileStorage, S3StorageConfig
 from arclith.application.command_bus import CommandDispatcher, CommandEnvelope
 from arclith.application.services.base_service import BaseService
@@ -144,6 +145,7 @@ __all__ = [
     "VectorStorePermissionDenied",
     "VectorStoreInvalidPayload",
     "MemoryVectorStore",
+    "QdrantVectorStore",
     "FileStoragePort",
     "StoredObject",
     "StoredObjectMetadata",

--- a/arclith/adapters/outbound/qdrant/__init__.py
+++ b/arclith/adapters/outbound/qdrant/__init__.py
@@ -1,0 +1,3 @@
+from arclith.adapters.outbound.qdrant.vector_store import QdrantVectorStore
+
+__all__ = ["QdrantVectorStore"]

--- a/arclith/adapters/outbound/qdrant/client.py
+++ b/arclith/adapters/outbound/qdrant/client.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from arclith.adapters.outbound.qdrant.config import ResolvedQdrantConfig
+from arclith.adapters.outbound.qdrant.errors import qdrant_error_from_provider
+from arclith.domain.ports.outbound.vector_store import VectorStoreUnavailable
+
+
+def create_qdrant_client(config: ResolvedQdrantConfig) -> Any:
+    try:
+        from qdrant_client import AsyncQdrantClient
+    except ImportError as error:
+        raise VectorStoreUnavailable(
+            "qdrant vector-store requires optional dependency arclith[qdrant]"
+        ) from error
+
+    try:
+        return AsyncQdrantClient(
+            url=config.url,
+            api_key=config.api_key,
+            prefer_grpc=config.prefer_grpc,
+            timeout=math.ceil(config.timeout),
+        )
+    except Exception as error:
+        raise qdrant_error_from_provider(error) from error
+
+
+def qdrant_models() -> Any:
+    try:
+        from qdrant_client import models
+    except ImportError as error:
+        raise VectorStoreUnavailable(
+            "qdrant vector-store requires optional dependency arclith[qdrant]"
+        ) from error
+    return models

--- a/arclith/adapters/outbound/qdrant/config.py
+++ b/arclith/adapters/outbound/qdrant/config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from arclith.adapters.context import get_adapter_tenant_context
+from arclith.domain.ports.outbound.vector_store import VectorStoreUnavailable
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+
+@dataclass(frozen=True)
+class ResolvedQdrantConfig:
+    url: str
+    api_key: str | None
+    collection_name: str
+    vector_size: int
+    distance: str
+    prefer_grpc: bool
+    timeout: float
+    create_collection: bool
+
+
+def resolve_qdrant_config(settings: VectorStoreSettings) -> ResolvedQdrantConfig:
+    url = settings.url
+    api_key = settings.api_key
+    collection_name: str | None = settings.collection_name
+    if settings.multitenant:
+        coords = get_adapter_tenant_context("qdrant")
+        if coords is not None:
+            url = _tenant_value(coords.get("url"), url)
+            api_key = _tenant_value(coords.get("api_key"), api_key)
+            collection_name = _tenant_value(
+                coords.get("collection_name"), collection_name
+            )
+
+    return ResolvedQdrantConfig(
+        url=_validated_url(url),
+        api_key=_optional_text(api_key),
+        collection_name=_validated_collection_name(collection_name),
+        vector_size=settings.vector_size,
+        distance=settings.distance,
+        prefer_grpc=settings.prefer_grpc,
+        timeout=settings.timeout,
+        create_collection=settings.create_collection,
+    )
+
+
+def _tenant_value(value: str | None, fallback: str | None) -> str | None:
+    return _optional_text(value) or fallback
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _validated_url(value: str | None) -> str:
+    normalized = (_optional_text(value) or "").rstrip("/")
+    parsed = urlsplit(normalized)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise VectorStoreUnavailable(
+            "qdrant vector-store requires a credential-free HTTP URL"
+        )
+    return normalized
+
+
+def _validated_collection_name(value: str | None) -> str:
+    normalized = (value or "").strip()
+    if not normalized:
+        raise VectorStoreUnavailable("qdrant vector-store requires a collection name")
+    return normalized

--- a/arclith/adapters/outbound/qdrant/errors.py
+++ b/arclith/adapters/outbound/qdrant/errors.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from arclith.domain.ports.outbound.vector_store import (
+    VectorStoreCollectionNotFound,
+    VectorStoreError,
+    VectorStorePermissionDenied,
+    VectorStoreUnavailable,
+)
+
+_PERMISSION_CODES = frozenset({401, 403})
+_NOT_FOUND_CODES = frozenset({404})
+_UNAVAILABLE_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+_UNAVAILABLE_ERROR_NAMES = frozenset(
+    {
+        "ConnectError",
+        "ConnectTimeout",
+        "PoolTimeout",
+        "ReadError",
+        "ReadTimeout",
+        "ResponseHandlingException",
+        "WriteError",
+        "WriteTimeout",
+    }
+)
+
+
+def qdrant_error_from_provider(error: Exception) -> VectorStoreError:
+    status_code = _provider_status_code(error)
+    if status_code in _PERMISSION_CODES:
+        return VectorStorePermissionDenied(
+            "qdrant vector-store operation is not permitted"
+        )
+    if status_code in _NOT_FOUND_CODES:
+        return VectorStoreCollectionNotFound(
+            "qdrant vector-store collection was not found"
+        )
+    if (
+        status_code in _UNAVAILABLE_CODES
+        or type(error).__name__ in _UNAVAILABLE_ERROR_NAMES
+    ):
+        return VectorStoreUnavailable("qdrant vector-store is unavailable")
+    return VectorStoreUnavailable("qdrant vector-store operation failed")
+
+
+def _provider_status_code(error: Exception) -> int | None:
+    status_code = getattr(error, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+
+    response = getattr(error, "response", None)
+    if isinstance(response, Mapping):
+        response_status = response.get("status_code") or response.get("status")
+    else:
+        response_status = getattr(response, "status_code", None)
+    return response_status if isinstance(response_status, int) else None

--- a/arclith/adapters/outbound/qdrant/vector_store.py
+++ b/arclith/adapters/outbound/qdrant/vector_store.py
@@ -207,9 +207,13 @@ def _query_filter(models: Any, filters: Mapping[str, JsonValue]) -> Any | None:
 
 
 def _normalized_point_ids(ids: Sequence[str]) -> list[str]:
-    normalized = [point_id.strip() for point_id in ids]
-    if any(not point_id for point_id in normalized):
-        raise VectorStoreInvalidPayload("qdrant point IDs must not be empty")
+    normalized: list[str] = []
+    for point_id in ids:
+        if not isinstance(point_id, str) or not point_id.strip():
+            raise VectorStoreInvalidPayload(
+                "qdrant point IDs must be non-empty strings"
+            )
+        normalized.append(point_id.strip())
     return normalized
 
 

--- a/arclith/adapters/outbound/qdrant/vector_store.py
+++ b/arclith/adapters/outbound/qdrant/vector_store.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Iterable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from typing import Any
+from uuid import UUID
+
+from pydantic import JsonValue
+
+from arclith.adapters.outbound.qdrant.client import (
+    create_qdrant_client,
+    qdrant_models,
+)
+from arclith.adapters.outbound.qdrant.config import (
+    ResolvedQdrantConfig,
+    resolve_qdrant_config,
+)
+from arclith.adapters.outbound.qdrant.errors import qdrant_error_from_provider
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchHit,
+    VectorSearchQuery,
+    VectorStoreCollectionNotFound,
+    VectorStoreDimensionMismatch,
+    VectorStoreError,
+    VectorStoreInvalidPayload,
+    VectorStorePort,
+    VectorStoreUnavailable,
+)
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+QdrantClientFactory = Callable[[ResolvedQdrantConfig], Any]
+
+
+class QdrantVectorStore(VectorStorePort):
+    """Async Qdrant implementation for one configured dense-vector collection."""
+
+    def __init__(
+        self,
+        settings: VectorStoreSettings,
+        *,
+        client: Any | None = None,
+        client_factory: QdrantClientFactory = create_qdrant_client,
+    ) -> None:
+        self._settings = settings
+        self._injected_client = client
+        self._client_factory = client_factory
+        self._default_client: Any | None = None
+
+    async def ensure_collection(self) -> None:
+        async with self._client_scope() as (resolved, client):
+            exists = await self._call(
+                client,
+                "collection_exists",
+                collection_name=resolved.collection_name,
+            )
+            if exists:
+                return
+            if not resolved.create_collection:
+                raise VectorStoreCollectionNotFound(
+                    "qdrant vector-store collection was not found"
+                )
+            models = qdrant_models()
+            await self._call(
+                client,
+                "create_collection",
+                collection_name=resolved.collection_name,
+                vectors_config=models.VectorParams(
+                    size=resolved.vector_size,
+                    distance=_distance(models, resolved.distance),
+                ),
+            )
+
+    async def upsert(self, points: Sequence[VectorPoint]) -> None:
+        materialized = tuple(points)
+        self._validate_dimensions(point.vector for point in materialized)
+        if not materialized:
+            return
+        models = qdrant_models()
+        provider_points = [
+            models.PointStruct(
+                id=point.id,
+                vector=list(point.vector),
+                payload=dict(point.payload),
+            )
+            for point in materialized
+        ]
+        async with self._client_scope() as (resolved, client):
+            await self._call(
+                client,
+                "upsert",
+                collection_name=resolved.collection_name,
+                points=provider_points,
+            )
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        point_ids = _normalized_point_ids(ids)
+        if not point_ids:
+            return
+        models = qdrant_models()
+        async with self._client_scope() as (resolved, client):
+            await self._call(
+                client,
+                "delete",
+                collection_name=resolved.collection_name,
+                points_selector=models.PointIdsList(points=point_ids),
+            )
+
+    async def search(self, query: VectorSearchQuery) -> list[VectorSearchHit]:
+        self._validate_dimensions((query.vector,))
+        models = qdrant_models()
+        query_filter = _query_filter(models, query.filters)
+        async with self._client_scope() as (resolved, client):
+            response = await self._call(
+                client,
+                "query_points",
+                collection_name=resolved.collection_name,
+                query=list(query.vector),
+                query_filter=query_filter,
+                limit=query.limit,
+                score_threshold=query.score_threshold,
+                with_payload=query.include_payload,
+                with_vectors=query.include_vector,
+            )
+        return _search_hits(response, query)
+
+    async def close(self) -> None:
+        """Close the reusable single-tenant client owned by this adapter."""
+
+        if self._default_client is None:
+            return
+        client = self._default_client
+        self._default_client = None
+        try:
+            await client.close()
+        except Exception as error:
+            raise qdrant_error_from_provider(error) from error
+
+    def _validate_dimensions(self, vectors: Iterable[Sequence[float]]) -> None:
+        expected = self._settings.vector_size
+        for vector in vectors:
+            actual = len(vector)
+            if actual != expected:
+                raise VectorStoreDimensionMismatch(
+                    f"vector dimension {actual} does not match configured size {expected}"
+                )
+
+    @asynccontextmanager
+    async def _client_scope(
+        self,
+    ) -> AsyncIterator[tuple[ResolvedQdrantConfig, Any]]:
+        resolved = resolve_qdrant_config(self._settings)
+        if self._injected_client is not None:
+            yield resolved, self._injected_client
+            return
+        if not self._settings.multitenant:
+            if self._default_client is None:
+                self._default_client = self._client_factory(resolved)
+            yield resolved, self._default_client
+            return
+
+        client = self._client_factory(resolved)
+        try:
+            yield resolved, client
+        finally:
+            await _close_transient_client(client)
+
+    @staticmethod
+    async def _call(client: Any, operation: str, **kwargs: Any) -> Any:
+        try:
+            return await getattr(client, operation)(**kwargs)
+        except VectorStoreError:
+            raise
+        except Exception as error:
+            raise qdrant_error_from_provider(error) from error
+
+
+async def _close_transient_client(client: Any) -> None:
+    try:
+        await client.close()
+    except Exception:
+        # A close failure must not hide the operation result or its mapped error.
+        return
+
+
+def _distance(models: Any, distance: str) -> Any:
+    return {
+        "cosine": models.Distance.COSINE,
+        "dot": models.Distance.DOT,
+        "euclid": models.Distance.EUCLID,
+    }[distance]
+
+
+def _query_filter(models: Any, filters: Mapping[str, JsonValue]) -> Any | None:
+    if not filters:
+        return None
+    conditions = []
+    for key, value in filters.items():
+        if not isinstance(value, (bool, int, str)):
+            raise VectorStoreInvalidPayload(
+                "qdrant exact-match filters support string, integer and boolean values"
+            )
+        conditions.append(
+            models.FieldCondition(key=key, match=models.MatchValue(value=value))
+        )
+    return models.Filter(must=conditions)
+
+
+def _normalized_point_ids(ids: Sequence[str]) -> list[str]:
+    normalized = [point_id.strip() for point_id in ids]
+    if any(not point_id for point_id in normalized):
+        raise VectorStoreInvalidPayload("qdrant point IDs must not be empty")
+    return normalized
+
+
+def _search_hits(response: Any, query: VectorSearchQuery) -> list[VectorSearchHit]:
+    points = getattr(response, "points", None)
+    if not isinstance(points, list):
+        raise VectorStoreUnavailable("qdrant vector-store returned an invalid response")
+    try:
+        return [_search_hit(point, query) for point in points]
+    except VectorStoreError:
+        raise
+    except (AttributeError, TypeError, ValueError) as error:
+        raise VectorStoreInvalidPayload(
+            "qdrant vector-store returned an invalid search result"
+        ) from error
+
+
+def _search_hit(point: Any, query: VectorSearchQuery) -> VectorSearchHit:
+    raw_payload = getattr(point, "payload", None)
+    if query.include_payload and raw_payload is not None:
+        if not isinstance(raw_payload, dict):
+            raise VectorStoreInvalidPayload(
+                "qdrant vector-store returned an invalid payload"
+            )
+        payload = raw_payload
+    else:
+        payload = {}
+    point_id = getattr(point, "id", None)
+    if isinstance(point_id, bool) or not isinstance(point_id, (int, str, UUID)):
+        raise VectorStoreInvalidPayload(
+            "qdrant vector-store returned an invalid point ID"
+        )
+    return VectorSearchHit(
+        id=str(point_id),
+        score=float(getattr(point, "score")),
+        payload=payload,
+        vector=_response_vector(point, query.include_vector),
+    )
+
+
+def _response_vector(point: Any, include_vector: bool) -> list[float] | None:
+    if not include_vector:
+        return None
+    vector = getattr(point, "vector", None)
+    if not isinstance(vector, list) or any(
+        isinstance(component, (list, dict)) for component in vector
+    ):
+        raise VectorStoreInvalidPayload(
+            "qdrant vector-store returned a non-dense vector"
+        )
+    return [float(component) for component in vector]

--- a/arclith/domain/ports/outbound/vector_store.py
+++ b/arclith/domain/ports/outbound/vector_store.py
@@ -161,6 +161,11 @@ class VectorSearchHit(_VectorStoreModel):
 class VectorStorePort(ABC):
     """Outbound port for a rebuildable dense-vector search index."""
 
+    async def close(self) -> None:
+        """Release owned provider resources; no-op for adapters without clients."""
+
+        return None
+
     @abstractmethod
     async def ensure_collection(self) -> None:
         """Create the configured logical collection when it is absent."""

--- a/arclith/infrastructure/settings/vector_store.py
+++ b/arclith/infrastructure/settings/vector_store.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
+from urllib.parse import urlsplit
 
-from pydantic import PositiveInt, StringConstraints, field_validator, model_validator
+from pydantic import (
+    PositiveFloat,
+    PositiveInt,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from arclith.infrastructure.settings._base import SettingsModel
 
@@ -15,10 +22,50 @@ VectorDistance = Literal["cosine", "dot", "euclid"]
 
 class VectorStoreSettings(SettingsModel):
     adapter: VectorStoreAdapter
+    url: str | None = None
+    api_key: str | None = None
     collection_name: str = "default"
     vector_size: PositiveInt
     distance: VectorDistance = "cosine"
+    prefer_grpc: bool = False
+    timeout: PositiveFloat = 5.0
+    create_collection: bool = True
     multitenant: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_adapter_defaults(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if values.get("adapter") == "qdrant" and values.get("url") is None:
+            return {**values, "url": "http://localhost:6333"}
+        return values
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().rstrip("/")
+        parsed = urlsplit(normalized)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("vector_store url must be a credential-free HTTP URL")
+        return normalized
+
+    @field_validator("api_key")
+    @classmethod
+    def normalize_api_key(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
 
     @field_validator("collection_name")
     @classmethod
@@ -29,7 +76,9 @@ class VectorStoreSettings(SettingsModel):
         return normalized
 
     @model_validator(mode="after")
-    def reject_unsupported_memory_multitenancy(self) -> "VectorStoreSettings":
+    def validate_selected_adapter(self) -> "VectorStoreSettings":
         if self.adapter == "memory" and self.multitenant:
             raise ValueError("vector_store adapter memory does not support multitenant")
+        if self.adapter == "qdrant" and self.url is None:
+            raise ValueError("vector_store adapter qdrant requires url")
         return self

--- a/arclith/infrastructure/vector_store_factory.py
+++ b/arclith/infrastructure/vector_store_factory.py
@@ -44,7 +44,11 @@ def build_vector_store(
 
 
 def default_vector_store_registry() -> VectorStoreRegistry:
-    return VectorStoreRegistry().register("memory", _build_memory_vector_store)
+    return (
+        VectorStoreRegistry()
+        .register("memory", _build_memory_vector_store)
+        .register("qdrant", _build_qdrant_vector_store)
+    )
 
 
 def _build_memory_vector_store(config: AppConfig, _logger: Logger) -> VectorStorePort:
@@ -54,3 +58,12 @@ def _build_memory_vector_store(config: AppConfig, _logger: Logger) -> VectorStor
     if settings is None:
         raise ValueError("Memory vector-store settings are required")
     return MemoryVectorStore(settings)
+
+
+def _build_qdrant_vector_store(config: AppConfig, _logger: Logger) -> VectorStorePort:
+    from arclith.adapters.outbound.qdrant.vector_store import QdrantVectorStore
+
+    settings = config.adapters.vector_store
+    if settings is None:
+        raise ValueError("Qdrant vector-store settings are required")
+    return QdrantVectorStore(settings)

--- a/cli/arclith_cli/catalogs/persistence.py
+++ b/cli/arclith_cli/catalogs/persistence.py
@@ -493,5 +493,83 @@ multitenant: {multitenant}
             ),
             entity_scoped=False,
         ),
+        AdapterSpec(
+            name="qdrant",
+            capability="vector-store",
+            layer="outbound",
+            description="Index vectoriel dense Qdrant via le client Python async officiel.",
+            config_path="config/adapters/outbound/vector_store.yaml",
+            config_template="""\
+adapter: qdrant
+url: "{url}"
+api_key: null
+collection_name: "{collection_name}"
+vector_size: {vector_size}
+distance: {distance}
+prefer_grpc: {prefer_grpc}
+timeout: {timeout}
+create_collection: {create_collection}
+multitenant: {multitenant}
+""",
+            secret_mappings=(
+                SecretMappingSpec(
+                    field_path="adapters.vector_store.api_key",
+                    secret_key="QDRANT_API_KEY",
+                ),
+            ),
+            parameters=(
+                ParameterSpec(
+                    name="url",
+                    kind="string",
+                    prompt="Endpoint HTTP Qdrant sans credentials",
+                    default="http://localhost:6333",
+                ),
+                ParameterSpec(
+                    name="collection_name",
+                    kind="string",
+                    prompt="Nom de la collection Qdrant",
+                    default="default",
+                ),
+                ParameterSpec(
+                    name="vector_size",
+                    kind="string",
+                    prompt="Dimension obligatoire des vecteurs",
+                    default="1536",
+                ),
+                ParameterSpec(
+                    name="distance",
+                    kind="string",
+                    prompt="Métrique de similarité",
+                    default="cosine",
+                    choices=("cosine", "dot", "euclid"),
+                ),
+                ParameterSpec(
+                    name="prefer_grpc",
+                    kind="boolean",
+                    prompt="Préférer le transport gRPC",
+                    default=False,
+                ),
+                ParameterSpec(
+                    name="timeout",
+                    kind="string",
+                    prompt="Timeout client en secondes",
+                    default="5.0",
+                ),
+                ParameterSpec(
+                    name="create_collection",
+                    kind="boolean",
+                    prompt="Créer la collection si elle manque",
+                    default=True,
+                ),
+                ParameterSpec(
+                    name="multitenant",
+                    kind="boolean",
+                    prompt="Résoudre url, api_key et collection par tenant",
+                    default=False,
+                ),
+            ),
+            dependency_extra="qdrant",
+            entity_scoped=False,
+        ),
     ),
 )

--- a/cli/tests/test_vector_store_capability.py
+++ b/cli/tests/test_vector_store_capability.py
@@ -27,7 +27,7 @@ def test_vector_store_capability_catalog_declares_memory_adapter() -> None:
     assert capability is not None
     assert capability.layer == "outbound"
     assert capability.activation_config_key is None
-    assert capability.adapter_names() == ("memory",)
+    assert capability.adapter_names() == ("memory", "qdrant")
     memory = capability.get_adapter("memory")
     assert memory is not None
     assert memory.entity_scoped is False
@@ -48,7 +48,27 @@ def test_vector_store_capability_is_exposed_in_json_catalog() -> None:
 
     vector_store = payload_by_name["vector-store"]
     assert vector_store["activation_config_key"] is None
-    assert [adapter["name"] for adapter in vector_store["adapters"]] == ["memory"]
+    assert [adapter["name"] for adapter in vector_store["adapters"]] == [
+        "memory",
+        "qdrant",
+    ]
+
+
+def test_vector_store_capability_declares_qdrant_adapter() -> None:
+    capability = get_capability("vector-store")
+
+    assert capability is not None
+    qdrant = capability.get_adapter("qdrant")
+    assert qdrant is not None
+    assert qdrant.entity_scoped is False
+    assert qdrant.dependency_extra == "qdrant"
+    assert qdrant.config_path == "config/adapters/outbound/vector_store.yaml"
+    assert [mapping.field_path for mapping in qdrant.secret_mappings] == [
+        "adapters.vector_store.api_key",
+    ]
+    assert [mapping.secret_key for mapping in qdrant.secret_mappings] == [
+        "QDRANT_API_KEY",
+    ]
 
 
 def test_add_memory_vector_store_generates_loadable_config_idempotently(
@@ -89,3 +109,58 @@ def test_add_memory_vector_store_generates_loadable_config_idempotently(
     assert "vector_store:" not in (
         project_dir / "config/adapters/adapters.yaml"
     ).read_text(encoding="utf-8")
+
+
+def test_add_qdrant_vector_store_generates_loadable_config_and_secrets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+    params = {
+        "url": "http://localhost:6333",
+        "collection_name": "documents",
+        "vector_size": "1536",
+        "distance": "cosine",
+        "prefer_grpc": "false",
+        "timeout": "5.0",
+        "create_collection": "true",
+        "multitenant": "false",
+    }
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="vector-store",
+            adapter="qdrant",
+            adapter_params=params,
+            yes=True,
+        )
+
+    config_text = (
+        project_dir / "config/adapters/outbound/vector_store.yaml"
+    ).read_text(encoding="utf-8")
+    secrets_text = (project_dir / "config/secrets.yaml").read_text(encoding="utf-8")
+
+    assert config_text == (
+        "adapter: qdrant\n"
+        'url: "http://localhost:6333"\n'
+        "api_key: null\n"
+        'collection_name: "documents"\n'
+        "vector_size: 1536\n"
+        "distance: cosine\n"
+        "prefer_grpc: false\n"
+        "timeout: 5.0\n"
+        "create_collection: true\n"
+        "multitenant: false\n"
+    )
+    assert secrets_text.count("adapters.vector_store.api_key") == 1
+    assert "adapters.vector_store.api_key: QDRANT_API_KEY" in secrets_text
+    assert "adapters.vector_store.url" not in secrets_text
+
+    from arclith import Arclith, QdrantVectorStore
+
+    monkeypatch.setenv("QDRANT_API_KEY", "test-key")
+    app = Arclith(project_dir / "config")
+    assert isinstance(app.vector_store(), QdrantVectorStore)
+    assert app.config.adapters.vector_store is not None
+    assert app.config.adapters.vector_store.api_key == "test-key"

--- a/docs/capabilities/vector-store.md
+++ b/docs/capabilities/vector-store.md
@@ -110,6 +110,137 @@ await vector_store.ensure_collection()
 valident tout le batch avant de le modifier et lèvent
 `VectorStoreDimensionMismatch` si une dimension diffère de `vector_size`.
 
+## Adapter Qdrant
+
+`qdrant` fournit l'adapter de production dense via le client Python async
+officiel. La dépendance reste optionnelle :
+
+```bash
+uv add 'arclith[qdrant]'
+```
+
+La commande CLI installe l'extra et génère le même fichier scoped que
+`memory`, sans écrire la clé API :
+
+```bash
+arclith-cli add-adapter \
+  --capability vector-store \
+  --adapter qdrant \
+  --param url=http://localhost:6333 \
+  --param collection_name=documents \
+  --param vector_size=1536 \
+  --param distance=cosine \
+  --yes
+```
+
+`config/adapters/outbound/vector_store.yaml` :
+
+```yaml
+adapter: qdrant
+url: "http://localhost:6333"
+api_key: null
+collection_name: "documents"
+vector_size: 1536
+distance: cosine
+prefer_grpc: false
+timeout: 5.0
+create_collection: true
+multitenant: false
+```
+
+Le catalogue ajoute de façon idempotente les mappings suivants dans
+`config/secrets.yaml` :
+
+```yaml
+resolver: env
+mappings:
+  adapters.vector_store.api_key: QDRANT_API_KEY
+```
+
+`QDRANT_API_KEY` reste optionnelle pour une instance locale. Une URL contenant
+des credentials est refusée afin que ceux-ci ne puissent pas fuiter par la
+configuration. Si l'endpoint doit lui aussi venir d'un resolver, le service
+peut ajouter explicitement `adapters.vector_store.url: QDRANT_URL` à ses
+mappings et fournir la variable correspondante.
+
+### Smoke Local
+
+Un `compose.yaml` minimal peut lancer Qdrant sans service annexe :
+
+```yaml
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.19.0
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+```
+
+```bash
+docker compose up -d qdrant
+curl --fail http://localhost:6333/healthz
+```
+
+Le service consommateur calcule l'embedding avant d'appeler le vector store ;
+Qdrant n'est jamais invoqué directement depuis le domaine ou l'adapter
+inbound :
+
+```python
+from arclith import (
+    EmbeddingPort,
+    EmbeddingText,
+    VectorPoint,
+    VectorSearchQuery,
+    VectorStorePort,
+)
+
+
+async def index_and_find(
+    embedding: EmbeddingPort,
+    store: VectorStorePort,
+) -> list[str]:
+    await store.ensure_collection()
+    indexed = await embedding.embed_texts(
+        [EmbeddingText(id="guide", text="Guide de démarrage")]
+    )
+    vector = indexed.results[0].vector
+    await store.upsert(
+        [
+            VectorPoint(
+                id="8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07",
+                vector=vector,
+                payload={"kind": "guide"},
+            )
+        ]
+    )
+    hits = await store.search(
+        VectorSearchQuery(vector=vector, filters={"kind": "guide"})
+    )
+    return [hit.id for hit in hits]
+```
+
+Avant l'upsert ou la recherche, l'adapter vérifie que la dimension correspond
+à `vector_size`, puis mappe les erreurs du SDK vers les erreurs communes. La
+page [Embedding](embedding.md) détaille la production du vecteur.
+
+Les filtres Qdrant v1 sont des exact-match sur un champ de premier niveau et
+acceptent les chaînes, entiers et booléens pris en charge par `MatchValue`.
+Les nombres flottants, `null`, listes et objets restent valides dans les
+payloads mais ne sont pas acceptés comme valeur de filtre Qdrant v1.
+
+### Multitenant Et Cycle De Vie
+
+Avec `multitenant: true`, le contexte d'adapter `qdrant` peut fournir `url`,
+`api_key` et `collection_name`. Chaque champ absent retombe sur la
+configuration single-tenant. L'URL effective est revalidée et aucun message
+d'erreur ne contient la clé.
+
+En single-tenant, l'adapter réutilise un unique `AsyncQdrantClient` et expose
+`await store.close()` pour le fermer lors de l'arrêt du service. Un client
+injecté appartient à l'appelant et n'est pas fermé. En multitenant, un client
+isolé est créé pour l'opération puis fermé immédiatement, afin de ne pas
+conserver les credentials tenant en cache.
+
 ## Erreurs Communes
 
 Les adapters exposent les erreurs provider-neutral suivantes :
@@ -137,6 +268,7 @@ fuiter de types fournisseur dans le domaine.
 ```bash
 uv run pytest tests/units/domain/ports/test_vector_store.py
 uv run pytest tests/units/adapters/outbound/test_memory_vector_store.py
+uv run --extra qdrant pytest tests/units/adapters/outbound/test_qdrant_vector_store.py
 uv run pytest tests/units/infrastructure/test_vector_store_config.py
 uv run pytest tests/units/infrastructure/test_vector_store_factory.py
 uv run --project cli pytest cli/tests/test_vector_store_capability.py

--- a/journal/2026-09-02-qdrant-vector-store.md
+++ b/journal/2026-09-02-qdrant-vector-store.md
@@ -1,0 +1,38 @@
+# Adapter Qdrant pour vector-store
+
+## Contexte
+
+La capability `vector-store` disposait du contrat provider-neutral et d'un
+adapter mémoire de référence. La roadmap demande désormais une cible Qdrant
+async sans transformer l'index de recherche en repository métier canonique.
+
+## Décision
+
+- utiliser `qdrant-client==1.19.0`, version stable vérifiée au moment de
+  l'implémentation, uniquement dans les extras `qdrant` et `all` ;
+- importer le SDK paresseusement pour préserver l'installation minimale ;
+- limiter la v1 à une collection, un vecteur dense et des filtres exact-match
+  `str`/`int`/`bool` ;
+- valider les dimensions avant tout appel provider et traduire les erreurs
+  HTTP/transport vers les erreurs de `VectorStorePort` ;
+- réutiliser un client possédé par l'adapter en single-tenant, et fermer un
+  client isolé après chaque opération multitenant afin de ne pas mettre les
+  credentials tenant en cache ;
+- résoudre `url`, `api_key` et `collection_name` dans le contexte `qdrant`,
+  avec repli champ par champ sur la configuration de base ;
+- générer le mapping `QDRANT_API_KEY` sans valeur secrète versionnée ; le
+  mapping optionnel `QDRANT_URL` reste à la charge du service qui en a besoin.
+
+## Conséquences
+
+`Arclith.vector_store()` construit Qdrant via la registry standard et le CLI
+peut scaffolder une configuration directement chargeable. Les fonctions
+avancées Qdrant, la génération d'embeddings et la synchronisation d'index
+restent explicites et hors scope.
+
+## Validation
+
+- tests unitaires sans serveur externe pour création, upsert, suppression,
+  recherche, erreurs, dépendance optionnelle et multitenant ;
+- tests de configuration, factory, exports et catalogue CLI ;
+- `make quality`, `make precommit`, tests CLI et `make docs`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ all     = [
     "azure-identity>=1.25.1,<2.0.0",
     "boto3>=1.43.70",
     "google-cloud-storage>=3.3.0,<4.0.0",
+    "qdrant-client==1.19.0",
 ]
 azure-blob = [
     "azure-storage-blob>=12.27.1,<13.0.0",
@@ -102,6 +103,9 @@ s3 = [
 ]
 gcs = [
     "google-cloud-storage>=3.3.0,<4.0.0",
+]
+qdrant = [
+    "qdrant-client==1.19.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/units/adapters/outbound/test_memory_vector_store.py
+++ b/tests/units/adapters/outbound/test_memory_vector_store.py
@@ -28,6 +28,8 @@ async def test_memory_vector_store_requires_collection_initialization() -> None:
     with pytest.raises(VectorStoreCollectionNotFound, match="documents"):
         await store.search(VectorSearchQuery(vector=[1.0, 0.0]))
 
+    await store.close()
+
 
 @pytest.mark.asyncio
 async def test_memory_vector_store_upserts_searches_filters_and_projects() -> None:

--- a/tests/units/adapters/outbound/test_qdrant_vector_store.py
+++ b/tests/units/adapters/outbound/test_qdrant_vector_store.py
@@ -1,0 +1,385 @@
+import builtins
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from qdrant_client import models
+
+from arclith.adapters.context import set_tenant_context
+from arclith.adapters.outbound.qdrant import QdrantVectorStore
+from arclith.adapters.outbound.qdrant.client import create_qdrant_client
+from arclith.adapters.outbound.qdrant.config import (
+    ResolvedQdrantConfig,
+    resolve_qdrant_config,
+)
+from arclith.domain.models.tenant import AdapterTenantCoords, TenantContext
+from arclith.domain.ports.outbound.vector_store import (
+    VectorPoint,
+    VectorSearchQuery,
+    VectorStoreCollectionNotFound,
+    VectorStoreDimensionMismatch,
+    VectorStoreInvalidPayload,
+    VectorStorePermissionDenied,
+    VectorStoreUnavailable,
+)
+from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+
+class FakeProviderError(Exception):
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class FakeQdrantClient:
+    def __init__(
+        self,
+        *,
+        collection_exists: bool = True,
+        response: Any | None = None,
+        errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.exists = collection_exists
+        self.response = response or SimpleNamespace(points=[])
+        self.errors = errors or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.close_count = 0
+
+    async def collection_exists(self, **kwargs: Any) -> bool:
+        return self._record("collection_exists", kwargs, self.exists)
+
+    async def create_collection(self, **kwargs: Any) -> bool:
+        return self._record("create_collection", kwargs, True)
+
+    async def upsert(self, **kwargs: Any) -> object:
+        return self._record("upsert", kwargs, object())
+
+    async def delete(self, **kwargs: Any) -> object:
+        return self._record("delete", kwargs, object())
+
+    async def query_points(self, **kwargs: Any) -> Any:
+        return self._record("query_points", kwargs, self.response)
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+    def _record(self, operation: str, kwargs: dict[str, Any], result: Any) -> Any:
+        self.calls.append((operation, kwargs))
+        error = self.errors.get(operation)
+        if error is not None:
+            raise error
+        return result
+
+
+def _settings(**updates: object) -> VectorStoreSettings:
+    values: dict[str, object] = {
+        "adapter": "qdrant",
+        "url": "http://localhost:6333",
+        "api_key": None,
+        "collection_name": "documents",
+        "vector_size": 3,
+        "distance": "cosine",
+        "prefer_grpc": False,
+        "timeout": 5.0,
+        "create_collection": True,
+        "multitenant": False,
+    }
+    values.update(updates)
+    return VectorStoreSettings.model_validate(values)
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_creates_missing_collection() -> None:
+    client = FakeQdrantClient(collection_exists=False)
+    store = QdrantVectorStore(_settings(), client=client)
+
+    await store.ensure_collection()
+
+    assert [operation for operation, _ in client.calls] == [
+        "collection_exists",
+        "create_collection",
+    ]
+    request = client.calls[1][1]
+    assert request["collection_name"] == "documents"
+    assert request["vectors_config"].size == 3
+    assert request["vectors_config"].distance is models.Distance.COSINE
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_can_refuse_implicit_creation() -> None:
+    client = FakeQdrantClient(collection_exists=False)
+    store = QdrantVectorStore(
+        _settings(create_collection=False),
+        client=client,
+    )
+
+    with pytest.raises(VectorStoreCollectionNotFound):
+        await store.ensure_collection()
+
+    assert [operation for operation, _ in client.calls] == ["collection_exists"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_delete_map_provider_models() -> None:
+    client = FakeQdrantClient()
+    store = QdrantVectorStore(_settings(), client=client)
+
+    await store.upsert(
+        [
+            VectorPoint(
+                id="8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07",
+                vector=[1.0, 0.0, 0.0],
+                payload={"kind": "guide", "published": True},
+            )
+        ]
+    )
+    await store.delete(["8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07"])
+
+    upsert = client.calls[0][1]
+    provider_point = upsert["points"][0]
+    assert upsert["collection_name"] == "documents"
+    assert provider_point.id == "8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07"
+    assert provider_point.vector == [1.0, 0.0, 0.0]
+    assert provider_point.payload == {"kind": "guide", "published": True}
+    delete = client.calls[1][1]
+    assert delete["points_selector"].points == ["8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07"]
+
+
+@pytest.mark.asyncio
+async def test_search_maps_query_filters_and_hits() -> None:
+    point_id = "8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07"
+    client = FakeQdrantClient(
+        response=SimpleNamespace(
+            points=[
+                models.ScoredPoint(
+                    id=point_id,
+                    version=1,
+                    score=0.98,
+                    payload={"kind": "guide", "published": True},
+                    vector=[1.0, 0.0, 0.0],
+                )
+            ]
+        )
+    )
+    store = QdrantVectorStore(_settings(), client=client)
+    query = VectorSearchQuery(
+        vector=[1.0, 0.0, 0.0],
+        filters={"kind": "guide", "published": True},
+        limit=4,
+        score_threshold=0.7,
+        include_payload=True,
+        include_vector=True,
+    )
+
+    hits = await store.search(query)
+
+    request = client.calls[0][1]
+    assert request["query"] == [1.0, 0.0, 0.0]
+    assert request["limit"] == 4
+    assert request["score_threshold"] == 0.7
+    assert request["with_payload"] is True
+    assert request["with_vectors"] is True
+    assert request["query_filter"].must == [
+        models.FieldCondition(key="kind", match=models.MatchValue(value="guide")),
+        models.FieldCondition(key="published", match=models.MatchValue(value=True)),
+    ]
+    assert hits[0].id == point_id
+    assert hits[0].score == 0.98
+    assert hits[0].payload == {"kind": "guide", "published": True}
+    assert hits[0].vector == [1.0, 0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_dimension_mismatch_fails_before_provider_call() -> None:
+    client = FakeQdrantClient()
+    store = QdrantVectorStore(_settings(), client=client)
+
+    with pytest.raises(VectorStoreDimensionMismatch, match="configured size 3"):
+        await store.upsert([VectorPoint(id="one", vector=[1.0, 0.0])])
+    with pytest.raises(VectorStoreDimensionMismatch, match="configured size 3"):
+        await store.search(VectorSearchQuery(vector=[1.0]))
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_qdrant_rejects_filters_not_supported_by_match_value() -> None:
+    client = FakeQdrantClient()
+    store = QdrantVectorStore(_settings(), client=client)
+
+    with pytest.raises(VectorStoreInvalidPayload, match="exact-match filters"):
+        await store.search(
+            VectorSearchQuery(
+                vector=[1.0, 0.0, 0.0],
+                filters={"nested": {"value": 1}},
+            )
+        )
+
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_invalid_provider_results() -> None:
+    client = FakeQdrantClient(
+        response=SimpleNamespace(
+            points=[SimpleNamespace(id=None, score=1.0, payload={}, vector=None)]
+        )
+    )
+    store = QdrantVectorStore(_settings(), client=client)
+
+    with pytest.raises(VectorStoreInvalidPayload, match="point ID"):
+        await store.search(VectorSearchQuery(vector=[1.0, 0.0, 0.0]))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "expected_error"),
+    [
+        (401, VectorStorePermissionDenied),
+        (403, VectorStorePermissionDenied),
+        (404, VectorStoreCollectionNotFound),
+        (503, VectorStoreUnavailable),
+    ],
+)
+async def test_provider_errors_are_mapped_without_details(
+    status_code: int,
+    expected_error: type[Exception],
+) -> None:
+    client = FakeQdrantClient(errors={"query_points": FakeProviderError(status_code)})
+    store = QdrantVectorStore(_settings(api_key="private-key"), client=client)
+
+    with pytest.raises(expected_error) as error:
+        await store.search(VectorSearchQuery(vector=[1.0, 0.0, 0.0]))
+
+    assert "private-key" not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_multitenant_overrides_coordinates_and_closes_transient_client() -> None:
+    created: list[tuple[ResolvedQdrantConfig, FakeQdrantClient]] = []
+
+    def client_factory(config: ResolvedQdrantConfig) -> FakeQdrantClient:
+        client = FakeQdrantClient()
+        created.append((config, client))
+        return client
+
+    token = set_tenant_context(
+        TenantContext(
+            adapters={
+                "qdrant": AdapterTenantCoords(
+                    params={
+                        "url": "https://tenant.qdrant.example",
+                        "api_key": "tenant-key",
+                        "collection_name": "tenant-documents",
+                    }
+                )
+            }
+        )
+    )
+    try:
+        await QdrantVectorStore(
+            _settings(multitenant=True),
+            client_factory=client_factory,
+        ).search(VectorSearchQuery(vector=[1.0, 0.0, 0.0]))
+    finally:
+        token.var.reset(token)
+
+    resolved, client = created[0]
+    assert resolved.url == "https://tenant.qdrant.example"
+    assert resolved.api_key == "tenant-key"
+    assert resolved.collection_name == "tenant-documents"
+    assert client.calls[0][1]["collection_name"] == "tenant-documents"
+    assert client.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_single_tenant_reuses_owned_client_until_close() -> None:
+    clients: list[FakeQdrantClient] = []
+
+    def client_factory(_config: ResolvedQdrantConfig) -> FakeQdrantClient:
+        client = FakeQdrantClient()
+        clients.append(client)
+        return client
+
+    store = QdrantVectorStore(_settings(), client_factory=client_factory)
+
+    await store.ensure_collection()
+    await store.ensure_collection()
+    await store.close()
+    await store.close()
+
+    assert len(clients) == 1
+    assert clients[0].close_count == 1
+
+
+def test_resolve_qdrant_config_falls_back_to_single_tenant_values() -> None:
+    token = set_tenant_context(
+        TenantContext(
+            adapters={
+                "qdrant": AdapterTenantCoords(
+                    params={"collection_name": "tenant-documents"}
+                )
+            }
+        )
+    )
+    try:
+        resolved = resolve_qdrant_config(
+            _settings(
+                url="https://fallback.qdrant.example/",
+                api_key="fallback-key",
+                multitenant=True,
+            )
+        )
+    finally:
+        token.var.reset(token)
+
+    assert resolved.url == "https://fallback.qdrant.example"
+    assert resolved.api_key == "fallback-key"
+    assert resolved.collection_name == "tenant-documents"
+
+
+def test_create_qdrant_client_requires_optional_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def guarded_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "qdrant_client" or name.startswith("qdrant_client."):
+            raise ImportError(name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    with pytest.raises(VectorStoreUnavailable, match=r"arclith\[qdrant\]"):
+        create_qdrant_client(resolve_qdrant_config(_settings()))
+
+
+def test_create_qdrant_client_uses_effective_connection_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    expected = object()
+
+    def fake_client(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr("qdrant_client.AsyncQdrantClient", fake_client)
+
+    client = create_qdrant_client(
+        resolve_qdrant_config(
+            _settings(
+                url="https://qdrant.example",
+                api_key="test-key",
+                prefer_grpc=True,
+                timeout=5.2,
+            )
+        )
+    )
+
+    assert client is expected
+    assert captured == {
+        "url": "https://qdrant.example",
+        "api_key": "test-key",
+        "prefer_grpc": True,
+        "timeout": 6,
+    }

--- a/tests/units/adapters/outbound/test_qdrant_vector_store.py
+++ b/tests/units/adapters/outbound/test_qdrant_vector_store.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from qdrant_client import models
 
 from arclith.adapters.context import set_tenant_context
 from arclith.adapters.outbound.qdrant import QdrantVectorStore
@@ -23,6 +22,8 @@ from arclith.domain.ports.outbound.vector_store import (
     VectorStoreUnavailable,
 )
 from arclith.infrastructure.settings.vector_store import VectorStoreSettings
+
+models = pytest.importorskip("qdrant_client.models")
 
 
 class FakeProviderError(Exception):
@@ -142,6 +143,17 @@ async def test_upsert_and_delete_map_provider_models() -> None:
     assert provider_point.payload == {"kind": "guide", "published": True}
     delete = client.calls[1][1]
     assert delete["points_selector"].points == ["8c7ecb96-2c97-4df9-bbf1-c3bd98bdfd07"]
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_non_string_ids_before_provider_call() -> None:
+    client = FakeQdrantClient()
+    store = QdrantVectorStore(_settings(), client=client)
+
+    with pytest.raises(VectorStoreInvalidPayload, match="non-empty strings"):
+        await store.delete([1])  # type: ignore[list-item]
+
+    assert client.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/units/infrastructure/test_vector_store_config.py
+++ b/tests/units/infrastructure/test_vector_store_config.py
@@ -31,6 +31,45 @@ def test_load_config_dir_loads_scoped_vector_store_settings(tmp_path: Path) -> N
     )
 
 
+def test_load_config_dir_loads_qdrant_settings(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    outbound = config_dir / "adapters" / "outbound"
+    outbound.mkdir(parents=True)
+    (outbound / "vector_store.yaml").write_text(
+        "adapter: qdrant\n"
+        "url: https://qdrant.example/\n"
+        "api_key: test-key\n"
+        "collection_name: documents\n"
+        "vector_size: 1536\n"
+        "distance: cosine\n"
+        "prefer_grpc: true\n"
+        "timeout: 7.5\n"
+        "create_collection: false\n"
+        "multitenant: true\n",
+        encoding="utf-8",
+    )
+
+    settings = load_config_dir(config_dir).adapters.vector_store
+
+    assert settings is not None
+    assert settings.url == "https://qdrant.example"
+    assert settings.api_key == "test-key"
+    assert settings.prefer_grpc is True
+    assert settings.timeout == 7.5
+    assert settings.create_collection is False
+    assert settings.multitenant is True
+
+
+def test_qdrant_settings_apply_local_url_default() -> None:
+    settings = VectorStoreSettings(
+        adapter="qdrant",
+        collection_name="documents",
+        vector_size=3,
+    )
+
+    assert settings.url == "http://localhost:6333"
+
+
 @pytest.mark.parametrize(
     "values",
     [
@@ -47,6 +86,18 @@ def test_load_config_dir_loads_scoped_vector_store_settings(tmp_path: Path) -> N
             "collection_name": "docs",
             "vector_size": 2,
             "multitenant": True,
+        },
+        {
+            "adapter": "qdrant",
+            "url": "https://user:password@qdrant.example",
+            "collection_name": "docs",
+            "vector_size": 2,
+        },
+        {
+            "adapter": "qdrant",
+            "url": "file:///tmp/qdrant",
+            "collection_name": "docs",
+            "vector_size": 2,
         },
     ],
 )

--- a/tests/units/infrastructure/test_vector_store_factory.py
+++ b/tests/units/infrastructure/test_vector_store_factory.py
@@ -5,6 +5,7 @@ import pytest
 
 from arclith import Arclith
 from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
+from arclith.adapters.outbound.qdrant import QdrantVectorStore
 from arclith.domain.ports.outbound.vector_store import (
     VectorPoint,
     VectorSearchHit,
@@ -49,6 +50,22 @@ def _config() -> AppConfig:
 
 def test_build_vector_store_returns_memory_adapter(logger) -> None:
     assert isinstance(build_vector_store(_config(), logger), MemoryVectorStore)
+
+
+def test_build_vector_store_returns_qdrant_adapter(logger) -> None:
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "vector_store": {
+                    "adapter": "qdrant",
+                    "collection_name": "documents",
+                    "vector_size": 3,
+                }
+            }
+        }
+    )
+
+    assert isinstance(build_vector_store(config, logger), QdrantVectorStore)
 
 
 def test_build_vector_store_requires_config(logger) -> None:

--- a/tests/units/test_init.py
+++ b/tests/units/test_init.py
@@ -59,6 +59,39 @@ def test_public_vector_store_exports():
     assert arclith.build_vector_store is not None
     assert arclith.VectorStorePort is not None
     assert arclith.MemoryVectorStore is not None
+    assert arclith.QdrantVectorStore is not None
+
+
+def test_import_arclith_does_not_require_qdrant_extra():
+    script = """
+import importlib.abc
+import sys
+
+
+class BlockQdrantExtra(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "qdrant_client" or fullname.startswith("qdrant_client."):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+
+sys.meta_path.insert(0, BlockQdrantExtra())
+
+import arclith
+
+arclith.default_vector_store_registry()
+assert arclith.QdrantVectorStore is not None
+print(arclith.__name__)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "arclith"
 
 
 def test_import_arclith_does_not_require_embedding_extra():

--- a/uv.lock
+++ b/uv.lock
@@ -148,6 +148,7 @@ all = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "openai"] },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pytz" },
+    { name = "qdrant-client" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn" },
@@ -227,6 +228,9 @@ opentelemetry = [
 postgresql = [
     { name = "asyncpg" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+]
+qdrant = [
+    { name = "qdrant-client" },
 ]
 rabbitmq = [
     { name = "aio-pika" },
@@ -329,6 +333,8 @@ requires-dist = [
     { name = "pytz", marker = "extra == 'all'", specifier = "==2024.1" },
     { name = "pytz", marker = "extra == 'duckdb'", specifier = "==2024.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "qdrant-client", marker = "extra == 'all'", specifier = "==1.19.0" },
+    { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = "==1.19.0" },
     { name = "redis", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
     { name = "redis", marker = "extra == 'langgraph-runtime'", specifier = ">=5.0.0" },
@@ -340,7 +346,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "extra == 'langgraph-runtime'", specifier = "==0.41.0" },
 ]
-provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "embedding", "rabbitmq", "langgraph", "langgraph-runtime", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs"]
+provides-extras = ["mongodb", "duckdb", "mariadb", "postgresql", "fastapi", "mcp", "vault", "cache", "auth", "embedding", "rabbitmq", "langgraph", "langgraph-runtime", "langgraph-persistence-sqlite", "langgraph-persistence-postgresql", "langgraph-persistence-mongodb", "langgraph-persistence-redis", "langsmith", "opentelemetry", "all", "azure-blob", "s3", "gcs", "qdrant"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1297,6 +1303,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1363,6 +1391,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1397,6 +1430,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/a4/c0b698a7250b7a5c2956427406560701862215c646e079a7907846608f44/hvac-2.3.0.tar.gz", hash = "sha256:1b85e3320e8642dd82f234db63253cda169a817589e823713dc5fca83119b1e2", size = 332660, upload-time = "2024-06-18T14:46:09.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/34/56facf52e2ea14ce640f434ccf00311af6f3a1df0019d4682ba28ea09948/hvac-2.3.0-py3-none-any.whl", hash = "sha256:a3afc5710760b6ee9b3571769df87a0333da45da05a5f9f963e1d3925a84be7d", size = 155860, upload-time = "2024-06-18T14:46:05.399Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -2922,6 +2964,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3537,6 +3591,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/33/c6e4ec45b4fca5a0b808e8804e60be54a6d7505b68b53c0b1d0d62ba86c1/qdrant_client-1.19.0.tar.gz", hash = "sha256:365395a04b0a26c309b25b7d8b1c99ef2071ec9a2b74bc8a5fd3b7a3642fe963", size = 350953, upload-time = "2026-08-04T14:32:56.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/3c/480c61cc8d5a3e76bb44e86231f408c93643e5498beadbbeb381ab55d02b/qdrant_client-1.19.0-py3-none-any.whl", hash = "sha256:13602a2b3478a95ecdf42f97b93d7f703b63a3361cd912a04495a33a5ac14121", size = 396157, upload-time = "2026-08-04T14:32:55.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Contexte

Closes #148.

Ajoute l'adapter Qdrant async derrière `VectorStorePort`, après le contrat provider-neutral de #147. Qdrant reste un index de projections reconstruisible et ne devient pas le repository métier canonique.

## Changements principaux

- ajoute l'extra optionnel `arclith[qdrant]` avec `qdrant-client==1.19.0`, également inclus dans `all`, sans modifier l'installation minimale ;
- ajoute `QdrantVectorStore` basé sur `AsyncQdrantClient` pour créer la collection, upsert, supprimer et rechercher via `query_points()` ;
- mappe vecteurs, payloads, filtres exact-match `str`/`int`/`bool`, résultats et erreurs vers le contrat Arclith ;
- valide les dimensions avant tout appel provider et refuse les réponses/provider payloads non conformes ;
- branche settings, factory/registry, export public et méthode de fermeture provider-neutral ;
- résout `url`, `api_key` et `collection_name` via le contexte tenant `qdrant`, avec repli sur la configuration ;
- réutilise le client single-tenant, ferme les clients transitoires multitenant et ne met pas les credentials tenant en cache ;
- expose `vector-store/qdrant` dans le CLI avec config scoped et mapping `QDRANT_API_KEY` idempotents ;
- documente installation, configuration, secrets, Docker Compose, orchestration embedding/index et limites v1 ;
- ajoute le journal `2026-09-02-qdrant-vector-store.md`.

## Impact

- API/ports : nouvel export `QdrantVectorStore` et cycle de vie `VectorStorePort.close()` no-op par défaut ;
- configuration : nouveaux champs Qdrant dans `adapters.vector_store` ;
- dépendances : `qdrant-client` uniquement dans les extras `qdrant`/`all` ;
- données : aucune migration, une collection dense active par configuration ;
- secrets : aucune clé versionnée, `api_key: null` et mapping externe `QDRANT_API_KEY` ;
- RabbitMQ/MCP/repository/storage : aucun changement ;
- déploiement : Qdrant doit être joignable pour l'usage réel, aucune action automatique ;
- release : commit `feat:` publiable en version mineure.

## Validations

- `make quality` : 1 832 passed, 5 skipped, couverture 90,61 % ;
- `make precommit` : Ruff, mypy et Bandit verts ;
- `make complexity` : vert ;
- `make docs` : MkDocs strict vert ;
- tests CLI complets : 148 passed, 1 skipped ;
- installation minimale isolée : import Arclith sans `qdrant-client` ;
- `git diff --check` : vert.

## Documentation / ADR / journal

- documentation Pages `docs/capabilities/vector-store.md` mise à jour ;
- journal ajouté ;
- pas d'ADR distincte : l'architecture reste celle décidée dans le contrat #147.

## Risques restants

La v1 ne couvre que les vecteurs denses, une collection active et les filtres exact-match scalaires pris en charge par `MatchValue`. Sparse/named vectors, hybrid search, reranking, reindexation, quantization et sharding avancé restent hors scope. Aucun smoke distant n'est exécuté par la suite unitaire.
