### PR TITLE
fix: ajouter le POC Vault local au tutoriel

### DIFF
--- a/docs/capabilities/secrets.md
+++ b/docs/capabilities/secrets.md
@@ -76,6 +76,10 @@ uv run python -c "from arclith.infrastructure.config import load_config_dir; loa
 git diff --check
 ```
 
+Le [POC Vault du tutoriel Todo](../tutorials/todo-list/07-local-services.md#ajouter-vault-localement)
+montre le lancement du serveur dev, le seed KV v2 et la résolution d'un secret applicatif sans
+afficher sa valeur.
+
 ## Suite
 
 Lire [Secrets et Vault](../production/secrets.md), puis [tenant](tenant.md).

--- a/docs/capabilities/tenant.md
+++ b/docs/capabilities/tenant.md
@@ -125,6 +125,10 @@ Tester au minimum:
 | tenant inconnu dans Vault | erreur d'accès au tenant |
 | tenant valide | repository initialisé avec les coordonnées du tenant |
 
+Le [POC Vault du tutoriel Todo](../tutorials/todo-list/07-local-services.md#ajouter-vault-localement)
+fournit un seed local reproductible et vérifie séparément `VaultSecretAdapter` et
+`VaultTenantResolver`.
+
 ## Suite
 
 Lire aussi:

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -440,9 +440,12 @@ exposer un champ `value`; il convient aux secrets partagés par l'instance du se
 
 ### Résoudre des coordonnées par tenant
 
-Configurer séparément `tenant/vault` avec le catalogue CLI courant :
+Cette sous-partie requiert elle aussi l'extra `arclith[vault]`. L'installer si la sous-partie
+précédente n'a pas été suivie, puis configurer séparément `tenant/vault` avec le catalogue CLI
+courant :
 
 ```bash
+uv add "arclith[vault]"
 arclith-cli add-adapter \
   --capability tenant \
   --adapter vault \

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -318,6 +318,200 @@ db.todo.find().pretty()
 db.todo.countDocuments({ deleted_at: null })
 ```
 
+## Ajouter Vault localement
+
+Cette section remplace le fichier local `secrets.yaml` par un Vault de développement. Le mode dev
+conserve tout en mémoire, démarre déjà initialisé et non scellé, et utilise un token racine : il est
+adapté uniquement à ce POC local, jamais à la production.
+
+### Démarrer Vault en mode dev
+
+Choisir un token jetable dans le terminal courant. La valeur ci-dessous n'est pas un credential réel
+et ne doit pas être réutilisée ailleurs :
+
+```bash
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=arclith-dev-only
+
+docker run --rm --name arclith-vault \
+  -p 127.0.0.1:8200:8200 \
+  -e VAULT_DEV_ROOT_TOKEN_ID="$VAULT_TOKEN" \
+  -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
+  -d hashicorp/vault:2.1.0
+```
+
+Attendre au maximum 30 secondes que le serveur soit disponible :
+
+```bash
+for attempt in $(seq 1 30); do
+  curl -fsS "$VAULT_ADDR/v1/sys/health" >/dev/null && break
+  if [ "$attempt" -eq 30 ]; then
+    docker logs arclith-vault
+    exit 1
+  fi
+  sleep 1
+done
+```
+
+Le binding `127.0.0.1` évite d'exposer le port dev sur le réseau local. Le token est transmis au
+container uniquement pour ce lancement jetable ; ne pas le mettre dans Git, dans une image ou dans
+un environnement partagé.
+
+### Initialiser KV v2 et les données du POC
+
+Télécharger le [script de seed vérifié](scripts/seed-vault.sh), le placer dans le projet Todo sous
+`scripts/seed-vault.sh`, puis l'exécuter :
+
+```bash
+mkdir -p scripts
+curl -fsSLo scripts/seed-vault.sh \
+  https://raw.githubusercontent.com/karned-rekipe/arclith/main/docs/tutorials/todo-list/scripts/seed-vault.sh
+chmod +x scripts/seed-vault.sh
+./scripts/seed-vault.sh
+```
+
+Le script active le mount `kv` en KV v2 s'il n'existe pas, puis écrit deux entrées de démonstration :
+
+| Chemin | Consommateur | Forme attendue |
+| --- | --- | --- |
+| `kv/apps/todo-list/mongodb` | `VaultSecretAdapter` | champ unique `value` |
+| `kv/rekipe/tenants/client-a` | `VaultTenantResolver` | champs `uri` et `db_name` |
+
+Il peut être rejoué : les mêmes valeurs sont réécrites dans une nouvelle version KV. Pour un POC
+strictement hors ligne, copier le contenu affiché ci-dessous au lieu de le télécharger :
+
+```bash
+--8<-- "docs/tutorials/todo-list/scripts/seed-vault.sh"
+```
+
+### Résoudre le secret applicatif
+
+Installer l'extra Vault, puis remplacer le resolver YAML de la section MongoDB par la capability CLI
+`secrets/vault` :
+
+```bash
+uv add "arclith[vault]"
+arclith-cli add-adapter \
+  --capability secrets \
+  --adapter vault \
+  --param field_path=adapters.mongodb.uri \
+  --param secret_key=apps/todo-list/mongodb \
+  --param addr=http://127.0.0.1:8200 \
+  --param mount=kv \
+  --yes
+```
+
+Le fichier versionné `config/secrets.yaml` ne contient que le resolver et le mapping :
+
+```yaml
+resolver: vault
+vault:
+  addr: http://127.0.0.1:8200
+  mount: kv
+mappings:
+  adapters.mongodb.uri: apps/todo-list/mongodb
+```
+
+Prouver que le service Arclith charge le secret sans afficher sa valeur :
+
+```bash
+uv run python - <<'PY'
+from arclith import Arclith
+
+runtime = Arclith("config")
+mongodb = runtime.config.adapters.mongodb
+assert mongodb is not None and mongodb.uri
+print("Secret applicatif MongoDB résolu par Vault")
+PY
+```
+
+Lancer ensuite le service avec la même configuration ; son bootstrap effectue la même résolution :
+
+```bash
+MODE=api uv run python main.py
+```
+
+Dans un autre terminal, `curl -fsS "http://127.0.0.1:8120/v1/todos/?page=1&per_page=20"`
+doit répondre sans erreur de secret. MongoDB doit toujours être démarré comme indiqué au début de
+cette page.
+
+`VaultSecretAdapter` intervient une fois au chargement de la configuration. Le chemin mappé doit
+exposer un champ `value`; il convient aux secrets partagés par l'instance du service.
+
+### Résoudre des coordonnées par tenant
+
+Configurer séparément `tenant/vault` avec le catalogue CLI courant :
+
+```bash
+arclith-cli add-adapter \
+  --capability tenant \
+  --adapter vault \
+  --param addr=http://127.0.0.1:8200 \
+  --param mount=kv \
+  --param path_prefix=rekipe/tenants \
+  --param tenant_claim=tenant_id \
+  --param tenant_uri_ttl=300 \
+  --yes
+```
+
+Dans une API multitenant complète, le pipeline d'authentification extrait `tenant_id` d'un JWT signé
+et appelle le resolver. Pour vérifier ici le contrat Vault sans ajouter de logique métier ni simuler
+un JWT, appeler directement le port avec l'identifiant de démonstration :
+
+```bash
+uv run python - <<'PY'
+import asyncio
+import os
+
+from arclith.adapters.outbound.memory.cache_adapter import MemoryCacheAdapter
+from arclith.adapters.outbound.vault.tenant_adapter import VaultTenantResolver
+
+
+async def main() -> None:
+    resolver = VaultTenantResolver(
+        "mongodb",
+        addr=os.environ["VAULT_ADDR"],
+        mount="kv",
+        path_prefix="rekipe/tenants",
+        cache=MemoryCacheAdapter(),
+    )
+    context = await resolver.resolve("client-a")
+    coords = context.get("mongodb")
+    assert coords is not None and coords.require("uri")
+    print("Tenant résolu :", coords.require("db_name"))
+
+
+asyncio.run(main())
+PY
+```
+
+Le résultat attendu est `Tenant résolu : todo_client_a`. Contrairement au resolver de secrets
+applicatifs, `VaultTenantResolver` lit tous les champs du chemin tenant, les place dans une tranche
+`AdapterTenantCoords` et peut les mettre en cache. L'activation réelle du repository multitenant
+requiert aussi `multitenant=true` et le pipeline JWT décrit dans la capability
+[tenant](../../capabilities/tenant.md).
+
+### Réinitialiser et diagnostiquer
+
+```bash
+# Supprime le container et toutes les données en mémoire du POC.
+docker stop arclith-vault
+
+# Retire le token jetable du terminal courant.
+unset VAULT_TOKEN VAULT_ADDR
+```
+
+Erreurs fréquentes :
+
+- `permission denied` : vérifier que `VAULT_TOKEN` correspond au lancement dev courant ;
+- `no handler for route` : relancer `scripts/seed-vault.sh` pour activer le mount KV v2 ;
+- secret applicatif non résolu : vérifier le champ `value`, le mapping et l'extra `arclith[vault]` ;
+- tenant introuvable : vérifier le préfixe `rekipe/tenants` et l'identifiant `client-a` ;
+- container redémarré : le stockage dev est en mémoire, il faut donc rejouer le seed.
+
+Références : [serveur Vault en mode dev](https://developer.hashicorp.com/vault/docs/concepts/dev-server)
+et [configuration d'un mount KV v2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2/setup).
+
 ## Ajouter OpenTelemetry localement
 
 LangSmith observe surtout les runs LLM et LangGraph. OpenTelemetry sert à tracer le service comme un

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -337,7 +337,7 @@ docker run --rm --name arclith-vault \
   -p 127.0.0.1:8200:8200 \
   -e VAULT_DEV_ROOT_TOKEN_ID="$VAULT_TOKEN" \
   -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
-  -d hashicorp/vault:2.1.0
+  -d hashicorp/vault:2.1.0 server -dev
 ```
 
 Attendre au maximum 30 secondes que le serveur soit disponible :

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -370,7 +370,9 @@ chmod +x scripts/seed-vault.sh
 ./scripts/seed-vault.sh
 ```
 
-Le script active le mount `kv` en KV v2 s'il n'existe pas, puis écrit deux entrées de démonstration :
+Le script active le mount `kv` en KV v2 s'il n'existe pas. S'il existe déjà dans une autre version,
+le script échoue explicitement au lieu de poursuivre avec des routes incompatibles. Il écrit ensuite
+deux entrées de démonstration :
 
 | Chemin | Consommateur | Forme attendue |
 | --- | --- | --- |

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -364,11 +364,16 @@ Télécharger le [script de seed vérifié](scripts/seed-vault.sh), le placer da
 
 ```bash
 mkdir -p scripts
+export ARCLITH_REF="${ARCLITH_REF:-main}"
 curl -fsSLo scripts/seed-vault.sh \
-  https://raw.githubusercontent.com/karned-rekipe/arclith/main/docs/tutorials/todo-list/scripts/seed-vault.sh
+  "https://raw.githubusercontent.com/karned-rekipe/arclith/${ARCLITH_REF}/docs/tutorials/todo-list/scripts/seed-vault.sh"
 chmod +x scripts/seed-vault.sh
 ./scripts/seed-vault.sh
 ```
+
+`ARCLITH_REF` peut désigner le tag ou le SHA correspondant à la version de cette documentation afin
+de conserver un POC reproductible. Sa valeur par défaut, `main`, convient pour suivre la version de
+développement courante.
 
 Le script active le mount `kv` en KV v2 s'il n'existe pas. S'il existe déjà dans une autre version,
 le script échoue explicitement au lieu de poursuivre avec des routes incompatibles. Il écrit ensuite

--- a/docs/tutorials/todo-list/scripts/seed-vault.sh
+++ b/docs/tutorials/todo-list/scripts/seed-vault.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${VAULT_TOKEN:?Définir VAULT_TOKEN avec le token jetable du serveur Vault dev}"
+
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+VAULT_MOUNT="${VAULT_MOUNT:-kv}"
+
+vault_request() {
+  curl --fail --silent --show-error \
+    --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    "$@"
+}
+
+if ! vault_request "${VAULT_ADDR}/v1/sys/mounts" | grep -q "\"${VAULT_MOUNT}/\""; then
+  vault_request \
+    --request POST \
+    --header "Content-Type: application/json" \
+    --data '{"type":"kv","options":{"version":"2"}}' \
+    "${VAULT_ADDR}/v1/sys/mounts/${VAULT_MOUNT}" \
+    >/dev/null
+fi
+
+vault_request \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --data '{"data":{"value":"mongodb://arclith:arclith@127.0.0.1:27017/todo_list_service?authSource=admin"}}' \
+  "${VAULT_ADDR}/v1/${VAULT_MOUNT}/data/apps/todo-list/mongodb" \
+  >/dev/null
+
+vault_request \
+  --request POST \
+  --header "Content-Type: application/json" \
+  --data '{"data":{"uri":"mongodb://arclith:arclith@127.0.0.1:27017/todo_client_a?authSource=admin","db_name":"todo_client_a"}}' \
+  "${VAULT_ADDR}/v1/${VAULT_MOUNT}/data/rekipe/tenants/client-a" \
+  >/dev/null
+
+vault_request \
+  "${VAULT_ADDR}/v1/${VAULT_MOUNT}/data/apps/todo-list/mongodb" \
+  >/dev/null
+vault_request \
+  "${VAULT_ADDR}/v1/${VAULT_MOUNT}/data/rekipe/tenants/client-a" \
+  >/dev/null
+
+printf '%s\n' \
+  "Vault KV v2 prêt :" \
+  "- ${VAULT_MOUNT}/apps/todo-list/mongodb" \
+  "- ${VAULT_MOUNT}/rekipe/tenants/client-a"

--- a/docs/tutorials/todo-list/scripts/seed-vault.sh
+++ b/docs/tutorials/todo-list/scripts/seed-vault.sh
@@ -18,7 +18,7 @@ vault_request() {
 if mount_details=$(
   vault_request "${VAULT_ADDR}/v1/sys/mounts/${VAULT_MOUNT}/tune" 2>/dev/null
 ); then
-  if ! grep -Fq '"version":"2"' <<<"${mount_details}"; then
+  if ! grep -Eq '"version"[[:space:]]*:[[:space:]]*"2"' <<<"${mount_details}"; then
     printf 'Erreur : le mount %s existe mais n\x27est pas un KV v2.\n' "${VAULT_MOUNT}" >&2
     exit 1
   fi

--- a/docs/tutorials/todo-list/scripts/seed-vault.sh
+++ b/docs/tutorials/todo-list/scripts/seed-vault.sh
@@ -15,7 +15,14 @@ vault_request() {
     "$@"
 }
 
-if ! vault_request "${VAULT_ADDR}/v1/sys/mounts" | grep -Fq "\"${VAULT_MOUNT}/\""; then
+if mount_details=$(
+  vault_request "${VAULT_ADDR}/v1/sys/mounts/${VAULT_MOUNT}/tune" 2>/dev/null
+); then
+  if ! grep -Fq '"version":"2"' <<<"${mount_details}"; then
+    printf 'Erreur : le mount %s existe mais n\x27est pas un KV v2.\n' "${VAULT_MOUNT}" >&2
+    exit 1
+  fi
+else
   vault_request \
     --request POST \
     --header "Content-Type: application/json" \

--- a/docs/tutorials/todo-list/scripts/seed-vault.sh
+++ b/docs/tutorials/todo-list/scripts/seed-vault.sh
@@ -9,11 +9,13 @@ VAULT_MOUNT="${VAULT_MOUNT:-kv}"
 
 vault_request() {
   curl --fail --silent --show-error \
+    --connect-timeout 3 \
+    --max-time 10 \
     --header "X-Vault-Token: ${VAULT_TOKEN}" \
     "$@"
 }
 
-if ! vault_request "${VAULT_ADDR}/v1/sys/mounts" | grep -q "\"${VAULT_MOUNT}/\""; then
+if ! vault_request "${VAULT_ADDR}/v1/sys/mounts" | grep -Fq "\"${VAULT_MOUNT}/\""; then
   vault_request \
     --request POST \
     --header "Content-Type: application/json" \

--- a/journal/2026-09-02-vault-local-poc.md
+++ b/journal/2026-09-02-vault-local-poc.md
@@ -9,6 +9,8 @@ serveur local, de seed KV v2 ni de preuve exécutable pour les deux modes de ré
 
 - utiliser Vault 2.1.0 avec `server -dev` explicite, lié à `127.0.0.1` et sans volume persistant ;
 - conserver le token jetable hors Git et l'exiger par variable d'environnement dans le script ;
+- rendre la référence Git du script téléchargeable surchargeable par tag ou SHA, avec `main` comme
+  valeur par défaut pour la documentation de développement ;
 - fournir un script `set -euo pipefail` qui active le mount KV v2 et écrit des valeurs locales
   idempotentes pour le service et le tenant, avec timeouts réseau bornés et rejet d'un mount
   homonyme qui ne serait pas en KV v2 ;

--- a/journal/2026-09-02-vault-local-poc.md
+++ b/journal/2026-09-02-vault-local-poc.md
@@ -1,0 +1,29 @@
+# Documentation du POC Vault local
+
+## Contexte
+
+Les capabilities Vault étaient configurables par la CLI, mais le tutoriel Todo ne fournissait pas de
+serveur local, de seed KV v2 ni de preuve exécutable pour les deux modes de résolution.
+
+## Décisions
+
+- utiliser Vault 2.1.0 en mode dev, lié à `127.0.0.1` et sans volume persistant ;
+- conserver le token jetable hors Git et l'exiger par variable d'environnement dans le script ;
+- fournir un script `set -euo pipefail` qui active le mount KV v2 et écrit des valeurs locales
+  idempotentes pour le service et le tenant ;
+- utiliser les commandes existantes `secrets/vault` et `tenant/vault`, sans placeholder ;
+- vérifier le secret applicatif au chargement d'`Arclith` et les coordonnées tenant via le resolver,
+  sans afficher les URI.
+
+## Impact
+
+Le développeur peut valider localement les deux contrats Vault sans compte managé ni modification du
+domaine Todo. Le serveur dev et ses credentials de démonstration restent strictement hors production.
+
+## Validation
+
+- syntaxe du script avec `bash -n` et analyse `shellcheck` réussies ;
+- commandes CLI exécutées dans un projet fraîchement généré ;
+- smoke Docker avec Vault 2.1.0, seed rejoué deux fois, secret applicatif chargé et tenant
+  `client-a` résolu ;
+- `make docs` et `make precommit`.

--- a/journal/2026-09-02-vault-local-poc.md
+++ b/journal/2026-09-02-vault-local-poc.md
@@ -7,7 +7,7 @@ serveur local, de seed KV v2 ni de preuve exécutable pour les deux modes de ré
 
 ## Décisions
 
-- utiliser Vault 2.1.0 en mode dev, lié à `127.0.0.1` et sans volume persistant ;
+- utiliser Vault 2.1.0 avec `server -dev` explicite, lié à `127.0.0.1` et sans volume persistant ;
 - conserver le token jetable hors Git et l'exiger par variable d'environnement dans le script ;
 - fournir un script `set -euo pipefail` qui active le mount KV v2 et écrit des valeurs locales
   idempotentes pour le service et le tenant, avec timeouts réseau bornés et rejet d'un mount

--- a/journal/2026-09-02-vault-local-poc.md
+++ b/journal/2026-09-02-vault-local-poc.md
@@ -10,7 +10,7 @@ serveur local, de seed KV v2 ni de preuve exécutable pour les deux modes de ré
 - utiliser Vault 2.1.0 en mode dev, lié à `127.0.0.1` et sans volume persistant ;
 - conserver le token jetable hors Git et l'exiger par variable d'environnement dans le script ;
 - fournir un script `set -euo pipefail` qui active le mount KV v2 et écrit des valeurs locales
-  idempotentes pour le service et le tenant ;
+  idempotentes pour le service et le tenant, avec timeouts réseau bornés ;
 - utiliser les commandes existantes `secrets/vault` et `tenant/vault`, sans placeholder ;
 - vérifier le secret applicatif au chargement d'`Arclith` et les coordonnées tenant via le resolver,
   sans afficher les URI.

--- a/journal/2026-09-02-vault-local-poc.md
+++ b/journal/2026-09-02-vault-local-poc.md
@@ -10,7 +10,8 @@ serveur local, de seed KV v2 ni de preuve exécutable pour les deux modes de ré
 - utiliser Vault 2.1.0 en mode dev, lié à `127.0.0.1` et sans volume persistant ;
 - conserver le token jetable hors Git et l'exiger par variable d'environnement dans le script ;
 - fournir un script `set -euo pipefail` qui active le mount KV v2 et écrit des valeurs locales
-  idempotentes pour le service et le tenant, avec timeouts réseau bornés ;
+  idempotentes pour le service et le tenant, avec timeouts réseau bornés et rejet d'un mount
+  homonyme qui ne serait pas en KV v2 ;
 - utiliser les commandes existantes `secrets/vault` et `tenant/vault`, sans placeholder ;
 - vérifier le secret applicatif au chargement d'`Arclith` et les coordonnées tenant via le resolver,
   sans afficher les URI.


### PR DESCRIPTION
## Contexte

Closes #86, enfant de la roadmap #57. Les adapters Vault existaient mais le tutoriel Todo ne proposait ni serveur local, ni seed KV v2 complet, ni preuve de résolution.

## Changements

- ajoute un Vault 2.1.0 dev lié uniquement à `127.0.0.1:8200` avec attente bornée ;
- fournit un script exécutable `set -euo pipefail` sans token versionné ;
- active idempotemment un mount KV v2 et seed un secret applicatif et des coordonnées tenant ;
- documente les commandes CLI réelles `secrets/vault` et `tenant/vault` ;
- vérifie séparément `VaultSecretAdapter` au bootstrap et `VaultTenantResolver` ;
- ajoute cleanup, dépannage, liens depuis les pages de capability et journal.

## Impact

Documentation et script de POC uniquement. Aucun changement de domaine, API, données persistantes, RabbitMQ/MCP, port framework ou configuration par défaut. Le token et les URI sont des valeurs locales jetables ; aucun credential réel n'est commité. Le commit `fix:` rend cette correction documentaire releasable avec le package.

## Validations

- `make docs`
- `make precommit`
- `bash -n docs/tutorials/todo-list/scripts/seed-vault.sh`
- `shellcheck docs/tutorials/todo-list/scripts/seed-vault.sh`
- hook de push : 1833 tests réussis, 5 ignorés, couverture 90,64 %
- smoke CLI dans un projet fraîchement généré
- smoke Docker Vault 2.1.0 : mount KV v2 vérifié, seed rejoué deux fois, secret applicatif chargé sans affichage, tenant `client-a` résolu

## Risques et déploiement

Vault dev utilise un token racine et un stockage mémoire ; la page le réserve explicitement au POC local et documente le reset. Aucune migration, action de déploiement ou ADR n'est requise.
