### PR TITLE
fix: ajouter le POC Keycloak local

### DIFF
--- a/docs/capabilities/auth.md
+++ b/docs/capabilities/auth.md
@@ -68,6 +68,9 @@ uv run pytest
 curl -fsS http://keycloak:8080/realms/rekipe/.well-known/openid-configuration
 ```
 
+Le [POC Keycloak du tutoriel Todo](../tutorials/todo-list/07-local-services.md#ajouter-keycloak-localement)
+fournit un realm importable, un client public PKCE et un smoke réel du JWKS, des rôles et des claims.
+
 ## Suite
 
 Lire [Auth production](../production/auth.md), puis [Authentification & Autorisation](../auth.md).

--- a/docs/capabilities/license.md
+++ b/docs/capabilities/license.md
@@ -84,6 +84,10 @@ Tester au minimum:
 | `realm_access` absent | `403` |
 | config `license.yaml` absente | contrôle licence désactivé |
 
+Le [POC Keycloak du tutoriel Todo](../tutorials/todo-list/07-local-services.md#ajouter-keycloak-localement)
+fournit un utilisateur licencié et un utilisateur sans rôle pour vérifier les réponses `200` et
+`403` sur une route réelle.
+
 ## Suite
 
 Lire aussi:

--- a/docs/capabilities/tenant.md
+++ b/docs/capabilities/tenant.md
@@ -129,6 +129,9 @@ Le [POC Vault du tutoriel Todo](../tutorials/todo-list/07-local-services.md#ajou
 fournit un seed local reproductible et vérifie séparément `VaultSecretAdapter` et
 `VaultTenantResolver`.
 
+Le [POC Keycloak de la même annexe](../tutorials/todo-list/07-local-services.md#ajouter-keycloak-localement)
+émet le claim signé `tenant_id=client-a`, aligné sur l'entrée Vault créée par ce seed.
+
 ## Suite
 
 Lire aussi:

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -713,6 +713,7 @@ flux Authorization Code sans challenge PKCE, l'audience, le rôle et le claim te
 
 ```bash
 mkdir -p scripts
+export ARCLITH_REF="${ARCLITH_REF:-main}"
 curl -fsSLo scripts/smoke-keycloak.sh \
   "https://raw.githubusercontent.com/karned-rekipe/arclith/${ARCLITH_REF}/docs/tutorials/todo-list/scripts/smoke-keycloak.sh"
 chmod +x scripts/smoke-keycloak.sh

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -522,6 +522,233 @@ Erreurs fréquentes :
 Références : [serveur Vault en mode dev](https://developer.hashicorp.com/vault/docs/concepts/dev-server)
 et [configuration d'un mount KV v2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2/setup).
 
+## Ajouter Keycloak localement
+
+Ce POC ajoute une identité locale au service Todo sans dépendre du fournisseur de production. Le
+realm fourni crée un client public Swagger avec PKCE S256, un rôle licence, deux utilisateurs de
+test et un claim `tenant_id`. Tout est jetable : arrêter le container supprime le realm, les comptes
+et les clés de signature.
+
+### Télécharger le realm de développement
+
+Depuis la racine du projet Todo, télécharger la même révision que celle de la documentation. Un tag
+ou un SHA peut remplacer `main` pour figer le POC :
+
+```bash
+mkdir -p local/keycloak
+export ARCLITH_REF="${ARCLITH_REF:-main}"
+curl -fsSLo local/keycloak/arclith-local-realm.json \
+  "https://raw.githubusercontent.com/karned-rekipe/arclith/${ARCLITH_REF}/docs/tutorials/todo-list/keycloak/arclith-local-realm.json"
+jq empty local/keycloak/arclith-local-realm.json
+```
+
+Le fichier [`arclith-local-realm.json`](keycloak/arclith-local-realm.json) contient exclusivement
+des données de démonstration :
+
+| Élément | Valeur locale | But |
+| --- | --- | --- |
+| realm | `arclith-local` | issuer isolé de la production |
+| client public | `todo-swagger` | Authorization Code + PKCE S256 |
+| audience | `todo-api` | validation du token par `JWTDecoder` |
+| rôle realm | `rekipe:licensed` | validation par `RoleLicenseValidator` |
+| `alice` | mot de passe `arclith-dev-only` | rôle licence et `tenant_id=client-a` |
+| `bob` | mot de passe `arclith-dev-only` | utilisateur valide sans licence |
+
+Ces mots de passe sont publics, limités au container local et ne doivent être réutilisés nulle part.
+
+### Démarrer Keycloak avec l'import
+
+La commande lie Keycloak à l'interface loopback et monte le realm en lecture seule dans le
+répertoire d'import officiel :
+
+```bash
+realm_file="$(pwd)/local/keycloak/arclith-local-realm.json"
+
+docker run --rm --name arclith-keycloak \
+  -p 127.0.0.1:8080:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=arclith-dev-only \
+  -v "${realm_file}:/opt/keycloak/data/import/arclith-local-realm.json:ro" \
+  -d quay.io/keycloak/keycloak:26.7.3 \
+  start-dev --import-realm
+```
+
+Le compte `admin` sert uniquement à inspecter ce serveur jetable. Attendre que le document de
+découverte du realm soit disponible :
+
+```bash
+for attempt in $(seq 1 60); do
+  curl -fsS \
+    http://127.0.0.1:8080/realms/arclith-local/.well-known/openid-configuration \
+    >/dev/null && break
+  if [ "$attempt" -eq 60 ]; then
+    docker logs arclith-keycloak
+    exit 1
+  fi
+  sleep 1
+done
+```
+
+L'endpoint JWKS annoncé par ce document, et utilisé par Arclith, doit être :
+
+```text
+http://127.0.0.1:8080/realms/arclith-local/protocol/openid-connect/certs
+```
+
+### Configurer l'authentification et la licence
+
+Installer l'extra d'authentification, puis utiliser les capabilities CLI courantes :
+
+```bash
+uv add "arclith[auth]"
+arclith-cli add-adapter \
+  --capability auth \
+  --adapter keycloak \
+  --param url=http://127.0.0.1:8080 \
+  --param realm=arclith-local \
+  --param audience=todo-api \
+  --param client_id=todo-swagger \
+  --yes
+
+arclith-cli add-adapter \
+  --capability license \
+  --adapter role \
+  --param role=rekipe:licensed \
+  --yes
+```
+
+Le CLI génère les deux fichiers inbound attendus :
+
+```yaml
+# config/adapters/inbound/keycloak.yaml
+url: "http://127.0.0.1:8080"
+realm: "arclith-local"
+audience: todo-api
+client_id: todo-swagger
+```
+
+```yaml
+# config/adapters/inbound/license.yaml
+role: "rekipe:licensed"
+```
+
+Dans `src/todo_list_service/adapters/inbound/fastapi/register.py`, protéger toutes les routes du
+router Todo avec la dépendance construite par Arclith :
+
+```python
+from fastapi import Depends, FastAPI
+
+# ... imports et construction des handlers inchangés ...
+
+require_auth = arclith.auth_dependency()
+app.include_router(
+    build_todo_router(handlers),
+    dependencies=[Depends(require_auth)],
+)
+```
+
+Cette dépendance vérifie la signature RS256 via le JWKS local, l'audience `todo-api`, l'expiration et
+le rôle `rekipe:licensed`. Elle produit aussi le schéma OAuth2 utilisé par Swagger UI.
+
+### Relier le claim au POC Vault
+
+Si la section Vault précédente a été suivie, son entrée `kv/rekipe/tenants/client-a` correspond déjà
+au claim signé de `alice`. Configurer le resolver avec le même nom de claim :
+
+```bash
+arclith-cli add-adapter \
+  --capability tenant \
+  --adapter vault \
+  --param addr=http://127.0.0.1:8200 \
+  --param mount=kv \
+  --param path_prefix=rekipe/tenants \
+  --param tenant_claim=tenant_id \
+  --param tenant_uri_ttl=300 \
+  --yes
+```
+
+Le smoke ci-dessous vérifie que le token porte bien `tenant_id=client-a`. Pour un repository
+`multitenant: true`, remplacer la dépendance auth seule par le pipeline complet
+`make_inject_tenant_uri` décrit dans [la documentation multitenant](../../multitenant.md#cablage-dans-le-container) :
+le resolver utilisera alors ce claim signé pour lire l'entrée Vault, sans accepter de tenant libre
+depuis un header ou une URL.
+
+### Tester Swagger et la route protégée
+
+Démarrer l'API, puis ouvrir impérativement l'URL déclarée dans le client :
+
+```text
+http://127.0.0.1:8120/docs
+```
+
+Cliquer sur **Authorize**, conserver les scopes `openid profile`, puis se connecter avec `alice` et
+le mot de passe local. Swagger exécute le flux Authorization Code avec PKCE et injecte le Bearer
+token pour appeler `GET /v1/todos/`. `bob` peut s'authentifier mais reçoit `403`, car son token ne
+porte pas le rôle licence.
+
+Pour un smoke CLI déterministe, le realm active aussi le Direct Access Grant sur ce seul client de
+développement. Ce flux par mot de passe ne remplace pas PKCE et ne doit pas être repris en
+production :
+
+```bash
+TOKEN="$(curl -fsS \
+  -X POST \
+  http://127.0.0.1:8080/realms/arclith-local/protocol/openid-connect/token \
+  -d grant_type=password \
+  -d client_id=todo-swagger \
+  -d username=alice \
+  -d password=arclith-dev-only \
+  -d 'scope=openid profile' \
+  | jq -er .access_token)"
+
+curl -fsS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "http://127.0.0.1:8120/v1/todos/?page=1&per_page=20"
+unset TOKEN
+```
+
+Le script fourni vérifie sans afficher les tokens le document de découverte, le JWKS, l'audience,
+le rôle et le claim tenant. Avec `TODO_API_URL`, il vérifie aussi les statuts de la route réelle :
+
+```bash
+mkdir -p scripts
+curl -fsSLo scripts/smoke-keycloak.sh \
+  "https://raw.githubusercontent.com/karned-rekipe/arclith/${ARCLITH_REF}/docs/tutorials/todo-list/scripts/smoke-keycloak.sh"
+chmod +x scripts/smoke-keycloak.sh
+
+./scripts/smoke-keycloak.sh
+TODO_API_URL="http://127.0.0.1:8120/v1/todos/?page=1&per_page=20" \
+  ./scripts/smoke-keycloak.sh
+```
+
+Le second appel attend `401` sans token, `200` avec `alice` et `403` avec `bob`.
+
+### Tokens courts, rotation et nettoyage
+
+Le realm fixe la durée de vie des access tokens à cinq minutes. Un client interactif renouvelle son
+token via le flux OIDC ; un traitement asynchrone ne doit jamais persister ni transporter le JWT
+brut. Keycloak renouvelle ses clés au redémarrage de ce container éphémère : redémarrer aussi l'API
+du POC pour vider son cache JWKS. En production, conserver les anciennes clés jusqu'à l'expiration
+des tokens déjà émis et coordonner la rotation avec le TTL du cache JWKS.
+
+```bash
+docker stop arclith-keycloak
+unset TOKEN KEYCLOAK_URL KEYCLOAK_REALM KEYCLOAK_CLIENT_ID KEYCLOAK_PASSWORD
+```
+
+Erreurs fréquentes :
+
+- `invalid redirect_uri` : ouvrir Swagger via `http://127.0.0.1:8120`, pas via `localhost` ;
+- `Invalid audience` : conserver `audience=todo-api` et vérifier le mapper du client importé ;
+- `Clé JWKS introuvable` après relance : redémarrer l'API locale pour vider son cache en mémoire ;
+- `403 Licence invalide ou absente` avec `alice` : vérifier `license.role=rekipe:licensed` et le realm
+  effectivement importé ;
+- claim tenant absent : vérifier le mapper `tenant-id` et l'attribut de l'utilisateur dans le realm.
+
+Références : [container Keycloak et import au démarrage](https://www.keycloak.org/server/containers#importing-a-realm-on-startup),
+[endpoints OIDC Keycloak](https://www.keycloak.org/securing-apps/oidc-layers#_endpoints) et
+[authentification Arclith](../../auth.md).
+
 ## Ajouter OpenTelemetry localement
 
 LangSmith observe surtout les runs LLM et LangGraph. OpenTelemetry sert à tracer le service comme un

--- a/docs/tutorials/todo-list/07-local-services.md
+++ b/docs/tutorials/todo-list/07-local-services.md
@@ -707,8 +707,9 @@ curl -fsS \
 unset TOKEN
 ```
 
-Le script fourni vérifie sans afficher les tokens le document de découverte, le JWKS, l'audience,
-le rôle et le claim tenant. Avec `TODO_API_URL`, il vérifie aussi les statuts de la route réelle :
+Le script fourni vérifie sans afficher les tokens le document de découverte, le JWKS, le rejet d'un
+flux Authorization Code sans challenge PKCE, l'audience, le rôle et le claim tenant. Avec
+`TODO_API_URL`, il vérifie aussi les statuts de la route réelle :
 
 ```bash
 mkdir -p scripts
@@ -734,6 +735,7 @@ des tokens déjà émis et coordonner la rotation avec le TTL du cache JWKS.
 ```bash
 docker stop arclith-keycloak
 unset TOKEN KEYCLOAK_URL KEYCLOAK_REALM KEYCLOAK_CLIENT_ID KEYCLOAK_PASSWORD
+unset PYTHON_BIN SWAGGER_REDIRECT_URI
 ```
 
 Erreurs fréquentes :

--- a/docs/tutorials/todo-list/keycloak/arclith-local-realm.json
+++ b/docs/tutorials/todo-list/keycloak/arclith-local-realm.json
@@ -12,7 +12,7 @@
     "realm": [
       {
         "name": "rekipe:licensed",
-        "description": "Acces local au POC Todo Arclith"
+        "description": "Accès local au POC Todo Arclith"
       }
     ]
   },

--- a/docs/tutorials/todo-list/keycloak/arclith-local-realm.json
+++ b/docs/tutorials/todo-list/keycloak/arclith-local-realm.json
@@ -1,0 +1,118 @@
+{
+  "realm": "arclith-local",
+  "enabled": true,
+  "displayName": "Arclith local POC",
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "rememberMe": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 300,
+  "roles": {
+    "realm": [
+      {
+        "name": "rekipe:licensed",
+        "description": "Acces local au POC Todo Arclith"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "todo-swagger",
+      "name": "Todo Swagger local",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "clientAuthenticatorType": "client-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": true,
+      "redirectUris": [
+        "http://127.0.0.1:8120/docs/oauth2-redirect"
+      ],
+      "webOrigins": [
+        "http://127.0.0.1:8120"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "todo-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "todo-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "tenant-id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "tenant_id",
+            "claim.name": "tenant_id",
+            "jsonType.label": "String",
+            "multivalued": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "alice@arclith.local.test",
+      "firstName": "Alice",
+      "lastName": "POC",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "arclith-dev-only",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "rekipe:licensed"
+      ],
+      "attributes": {
+        "tenant_id": [
+          "client-a"
+        ]
+      }
+    },
+    {
+      "username": "bob",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "bob@arclith.local.test",
+      "firstName": "Bob",
+      "lastName": "POC sans licence",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "arclith-dev-only",
+          "temporary": false
+        }
+      ],
+      "attributes": {
+        "tenant_id": [
+          "client-b"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
+++ b/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
@@ -8,6 +8,21 @@ KEYCLOAK_REALM="${KEYCLOAK_REALM:-arclith-local}"
 KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-todo-swagger}"
 KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-arclith-dev-only}"
 TODO_API_URL="${TODO_API_URL:-}"
+SWAGGER_REDIRECT_URI="${SWAGGER_REDIRECT_URI:-http://127.0.0.1:8120/docs/oauth2-redirect}"
+
+if [[ -n "${PYTHON_BIN:-}" ]]; then
+  command -v "${PYTHON_BIN}" >/dev/null || {
+    printf 'Interpréteur Python introuvable : %s\n' "${PYTHON_BIN}" >&2
+    exit 1
+  }
+elif command -v python3 >/dev/null; then
+  PYTHON_BIN=python3
+elif command -v python >/dev/null; then
+  PYTHON_BIN=python
+else
+  printf '%s\n' 'Python 3 est requis pour décoder localement les claims du smoke.' >&2
+  exit 1
+fi
 
 openid_url="${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration"
 
@@ -33,7 +48,7 @@ token_for() {
 }
 
 decode_claims() {
-  python -c '
+  "${PYTHON_BIN}" -c '
 import base64
 import json
 import sys
@@ -46,13 +61,27 @@ print(json.dumps(json.loads(payload)))
 }
 
 discovery="$(keycloak_request "${openid_url}")"
+authorization_endpoint="$(jq -er '.authorization_endpoint' <<<"${discovery}")"
 token_endpoint="$(jq -er '.token_endpoint' <<<"${discovery}")"
 jwks_uri="$(jq -er '.jwks_uri' <<<"${discovery}")"
 expected_base="${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect"
 
+test "${authorization_endpoint}" = "${expected_base}/auth"
 test "${token_endpoint}" = "${expected_base}/token"
 test "${jwks_uri}" = "${expected_base}/certs"
 keycloak_request "${jwks_uri}" | jq -e '.keys | length > 0' >/dev/null
+
+pkce_rejection="$(
+  curl --silent --show-error --get --output /dev/null --write-out '%{redirect_url}' \
+    --connect-timeout 3 --max-time 10 \
+    --data-urlencode "client_id=${KEYCLOAK_CLIENT_ID}" \
+    --data-urlencode "redirect_uri=${SWAGGER_REDIRECT_URI}" \
+    --data-urlencode "response_type=code" \
+    --data-urlencode "scope=openid" \
+    "${authorization_endpoint}"
+)"
+[[ "${pkce_rejection}" == "${SWAGGER_REDIRECT_URI}?error=invalid_request&"* ]]
+[[ "${pkce_rejection}" == *"code_challenge"* ]]
 
 alice_token="$(token_for alice)"
 alice_claims="$(printf '%s' "${alice_token}" | decode_claims)"
@@ -79,6 +108,7 @@ jq -e \
 printf '%s\n' \
   "Keycloak local prêt :" \
   "- discovery et JWKS cohérents pour ${KEYCLOAK_REALM}" \
+  "- Authorization Code sans challenge PKCE rejeté" \
   "- alice : audience, tenant_id et rôle licence présents" \
   "- bob : rôle licence absent"
 

--- a/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
+++ b/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
@@ -10,6 +10,13 @@ KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-arclith-dev-only}"
 TODO_API_URL="${TODO_API_URL:-}"
 SWAGGER_REDIRECT_URI="${SWAGGER_REDIRECT_URI:-http://127.0.0.1:8120/docs/oauth2-redirect}"
 
+for required_command in curl jq; do
+  command -v "${required_command}" >/dev/null || {
+    printf 'Commande requise introuvable : %s\n' "${required_command}" >&2
+    exit 1
+  }
+done
+
 if [[ -n "${PYTHON_BIN:-}" ]]; then
   command -v "${PYTHON_BIN}" >/dev/null || {
     printf 'Interpréteur Python introuvable : %s\n' "${PYTHON_BIN}" >&2

--- a/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
+++ b/docs/tutorials/todo-list/scripts/smoke-keycloak.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://127.0.0.1:8080}"
+KEYCLOAK_URL="${KEYCLOAK_URL%/}"
+KEYCLOAK_REALM="${KEYCLOAK_REALM:-arclith-local}"
+KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-todo-swagger}"
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-arclith-dev-only}"
+TODO_API_URL="${TODO_API_URL:-}"
+
+openid_url="${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration"
+
+keycloak_request() {
+  curl --fail --silent --show-error \
+    --connect-timeout 3 \
+    --max-time 10 \
+    "$@"
+}
+
+token_for() {
+  local username="$1"
+  keycloak_request \
+    --request POST \
+    --header "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=password" \
+    --data-urlencode "client_id=${KEYCLOAK_CLIENT_ID}" \
+    --data-urlencode "username=${username}" \
+    --data-urlencode "password=${KEYCLOAK_PASSWORD}" \
+    --data-urlencode "scope=openid profile" \
+    "${token_endpoint}" \
+    | jq -er '.access_token'
+}
+
+decode_claims() {
+  python -c '
+import base64
+import json
+import sys
+
+segment = sys.stdin.read().split(".")[1]
+segment += "=" * (-len(segment) % 4)
+payload = base64.urlsafe_b64decode(segment)
+print(json.dumps(json.loads(payload)))
+'
+}
+
+discovery="$(keycloak_request "${openid_url}")"
+token_endpoint="$(jq -er '.token_endpoint' <<<"${discovery}")"
+jwks_uri="$(jq -er '.jwks_uri' <<<"${discovery}")"
+expected_base="${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect"
+
+test "${token_endpoint}" = "${expected_base}/token"
+test "${jwks_uri}" = "${expected_base}/certs"
+keycloak_request "${jwks_uri}" | jq -e '.keys | length > 0' >/dev/null
+
+alice_token="$(token_for alice)"
+alice_claims="$(printf '%s' "${alice_token}" | decode_claims)"
+jq -e \
+  --arg issuer "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}" \
+  --arg audience "todo-api" \
+  --arg tenant "client-a" \
+  --arg role "rekipe:licensed" \
+  'def has_audience($expected):
+     (.aud == $expected)
+     or (((.aud | type) == "array") and ((.aud | index($expected)) != null));
+   (.iss == $issuer)
+   and has_audience($audience)
+   and (.tenant_id == $tenant)
+   and ((.realm_access.roles | index($role)) != null)' \
+  <<<"${alice_claims}" >/dev/null
+
+bob_token="$(token_for bob)"
+bob_claims="$(printf '%s' "${bob_token}" | decode_claims)"
+jq -e \
+  '((.realm_access.roles // []) | index("rekipe:licensed")) == null' \
+  <<<"${bob_claims}" >/dev/null
+
+printf '%s\n' \
+  "Keycloak local prêt :" \
+  "- discovery et JWKS cohérents pour ${KEYCLOAK_REALM}" \
+  "- alice : audience, tenant_id et rôle licence présents" \
+  "- bob : rôle licence absent"
+
+if [[ -n "${TODO_API_URL}" ]]; then
+  anonymous_status="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+      --connect-timeout 3 --max-time 10 "${TODO_API_URL}"
+  )"
+  alice_status="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+      --connect-timeout 3 --max-time 10 \
+      --header "Authorization: Bearer ${alice_token}" "${TODO_API_URL}"
+  )"
+  bob_status="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+      --connect-timeout 3 --max-time 10 \
+      --header "Authorization: Bearer ${bob_token}" "${TODO_API_URL}"
+  )"
+
+  test "${anonymous_status}" = "401"
+  test "${alice_status}" = "200"
+  test "${bob_status}" = "403"
+  printf '%s\n' "- route protégée : sans token=401, alice=200, bob=403"
+fi

--- a/journal/2026-09-02-keycloak-local-poc.md
+++ b/journal/2026-09-02-keycloak-local-poc.md
@@ -18,7 +18,9 @@ local ne proposait ni realm importable ni preuve reproductible du flux PKCE/JWKS
   Authorization Code avec PKCE ;
 - fixer les access tokens à cinq minutes et documenter le lien entre rotation des clés et cache
   JWKS ;
-- permettre de télécharger le realm et le script depuis un tag ou SHA via `ARCLITH_REF`.
+- permettre de télécharger le realm et le script depuis un tag ou SHA via `ARCLITH_REF` ;
+- sélectionner `python3`, puis `python` en fallback, tout en permettant une surcharge explicite par
+  `PYTHON_BIN` pour rendre le smoke portable.
 
 ## Validation
 
@@ -27,6 +29,7 @@ local ne proposait ni realm importable ni preuve reproductible du flux PKCE/JWKS
 - configuration `auth` + `license` + `tenant` générée par la CLI puis chargée par `Arclith` ;
 - import réel du realm dans le container Keycloak épinglé ;
 - document OIDC et JWKS lus depuis le realm local ;
+- requête Authorization Code sans challenge rejetée par Keycloak avec `invalid_request` ;
 - tokens `alice` et `bob` obtenus sans être affichés ;
 - audience, issuer, rôle licence et `tenant_id=client-a` vérifiés ;
 - signature et audience du token validées par le `JWTDecoder` Arclith contre le JWKS local ;

--- a/journal/2026-09-02-keycloak-local-poc.md
+++ b/journal/2026-09-02-keycloak-local-poc.md
@@ -1,0 +1,37 @@
+# POC Keycloak local pour le tutoriel Todo
+
+## Contexte
+
+Les capabilities `auth/keycloak`, `license/role` et `tenant/vault` existent déjà, mais le tutoriel
+local ne proposait ni realm importable ni preuve reproductible du flux PKCE/JWKS et des claims.
+
+## Décisions
+
+- épingler l'image officielle Keycloak `26.7.3` et importer un realm jetable au démarrage ;
+- lier le port à `127.0.0.1` et marquer explicitement tous les identifiants comme données de POC ;
+- créer un client public `todo-swagger` limité au redirect URI local et imposant PKCE S256 ;
+- ajouter l'audience `todo-api`, le rôle realm `rekipe:licensed` et le claim `tenant_id` attendu par
+  les contrats Arclith existants ;
+- fournir `alice` avec licence et tenant `client-a`, puis `bob` sans licence pour couvrir le refus
+  `403` ;
+- conserver le Direct Access Grant uniquement pour le smoke shell déterministe, Swagger utilisant
+  Authorization Code avec PKCE ;
+- fixer les access tokens à cinq minutes et documenter le lien entre rotation des clés et cache
+  JWKS ;
+- permettre de télécharger le realm et le script depuis un tag ou SHA via `ARCLITH_REF`.
+
+## Validation
+
+- JSON validé avec `jq empty` ;
+- syntaxe et règles shell vérifiées avec `bash -n` et `shellcheck` ;
+- configuration `auth` + `license` + `tenant` générée par la CLI puis chargée par `Arclith` ;
+- import réel du realm dans le container Keycloak épinglé ;
+- document OIDC et JWKS lus depuis le realm local ;
+- tokens `alice` et `bob` obtenus sans être affichés ;
+- audience, issuer, rôle licence et `tenant_id=client-a` vérifiés ;
+- signature et audience du token validées par le `JWTDecoder` Arclith contre le JWKS local ;
+- claim `client-a` résolu jusqu'aux coordonnées MongoDB seedées dans Vault par le pipeline Arclith ;
+- OpenAPI vérifié avec le schéma Authorization Code et PKCE activé ;
+- route FastAPI réelle vérifiée avec les statuts `401`, `200` et `403` ;
+- `make docs` ;
+- `make precommit`.

--- a/journal/2026-09-02-keycloak-local-poc.md
+++ b/journal/2026-09-02-keycloak-local-poc.md
@@ -20,7 +20,9 @@ local ne proposait ni realm importable ni preuve reproductible du flux PKCE/JWKS
   JWKS ;
 - permettre de télécharger le realm et le script depuis un tag ou SHA via `ARCLITH_REF` ;
 - sélectionner `python3`, puis `python` en fallback, tout en permettant une surcharge explicite par
-  `PYTHON_BIN` pour rendre le smoke portable.
+  `PYTHON_BIN` pour rendre le smoke portable ;
+- vérifier explicitement la présence de `curl` et `jq` pour produire une erreur exploitable avant
+  tout appel réseau.
 
 ## Validation
 


### PR DESCRIPTION
Closes #87

## Contexte

Le tutoriel documentait les contrats Keycloak/JWKS, licence et tenant sans realm local importable ni smoke reproductible.

## Changements

- ajoute un realm Keycloak 26.7.3 jetable avec client public PKCE S256, audience `todo-api`, rôle licence et claim `tenant_id` ;
- fournit les utilisateurs locaux `alice` (licenciée, `client-a`) et `bob` (sans licence), avec identifiants explicitement non-production ;
- ajoute un script de smoke qui contrôle discovery, JWKS, claims et, si l’API tourne, les réponses 401/200/403 sans afficher les tokens ;
- relie le tutoriel aux capabilities CLI `auth/keycloak`, `license/role` et `tenant/vault`, avec téléchargement figé possible par tag/SHA ;
- ajoute les liens Pages et le journal de décision.

## Impact

Aucun changement d’API, de domaine, de données persistantes, de RabbitMQ/MCP ni de package Python. Le POC tourne uniquement sur loopback, en mode Keycloak dev et en mémoire. Aucune migration ni action de déploiement.

## Validations

- `make docs` ;
- `make precommit` ;
- hook de push : 1 833 tests réussis, 5 ignorés, couverture 90,64 % ;
- `jq empty`, `bash -n`, `shellcheck` ;
- import Docker réel de `quay.io/keycloak/keycloak:26.7.3` ;
- JWT validé par `JWTDecoder`, OpenAPI PKCE contrôlé, route FastAPI 401/200/403 ;
- pipeline réel Keycloak `tenant_id=client-a` vers les coordonnées seedées dans Vault.

## Documentation et risques

Documentation Pages et journal ajoutés. Le Direct Access Grant est limité au smoke CLI local ; le parcours Swagger utilise Authorization Code + PKCE. Les credentials du realm sont des valeurs publiques de démonstration et ne doivent jamais être réutilisés.