### PR TITLE
feat: ajouter les facets des adapters repository

### DIFF
--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from arclith_cli.capability_models import (
+    AdapterFacets,
     AdapterProfileSpec,
     AdapterSpec,
     CapabilitySpec,
@@ -48,6 +49,7 @@ __all__ = [
     "AGENT_PERSISTENCE_CAPABILITY",
     "API_CAPABILITY",
     "AUTH_CAPABILITY",
+    "AdapterFacets",
     "AdapterProfileSpec",
     "AdapterSpec",
     "CACHE_CAPABILITY",

--- a/cli/arclith_cli/capability_models.py
+++ b/cli/arclith_cli/capability_models.py
@@ -5,6 +5,16 @@ from typing import Any, Literal
 
 ParameterKind = Literal["string", "boolean"]
 LayerKind = Literal["inbound", "outbound", "bidirectional", "runtime"]
+StorageModel = Literal[
+    "memory",
+    "document",
+    "relational_json",
+    "embedded_analytics",
+    "relational_structured",
+]
+RuntimeKind = Literal["in_process", "file", "server"]
+TransactionSupport = Literal["none", "limited", "strong"]
+SchemaStrategy = Literal["flexible", "json_table", "structured_tables"]
 
 
 @dataclass(frozen=True)
@@ -71,6 +81,30 @@ class AdapterProfileSpec:
 
 
 @dataclass(frozen=True)
+class AdapterFacets:
+    storage_model: StorageModel
+    runtime: RuntimeKind
+    production_ready: bool
+    multi_process: bool
+    transactions: TransactionSupport
+    schema_strategy: SchemaStrategy
+    recommended_for: tuple[str, ...]
+    limits: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "storage_model": self.storage_model,
+            "runtime": self.runtime,
+            "production_ready": self.production_ready,
+            "multi_process": self.multi_process,
+            "transactions": self.transactions,
+            "schema_strategy": self.schema_strategy,
+            "recommended_for": list(self.recommended_for),
+            "limits": list(self.limits),
+        }
+
+
+@dataclass(frozen=True)
 class AdapterSpec:
     name: str
     capability: str
@@ -90,6 +124,7 @@ class AdapterSpec:
     profiles: tuple[AdapterProfileSpec, ...] = ()
     dependency_extra: str | None = None
     entity_scoped: bool = True
+    facets: AdapterFacets | None = None
 
     def has_config(self) -> bool:
         return self.config_path is not None and bool(self.config_template)
@@ -137,6 +172,7 @@ class AdapterSpec:
             "profiles": [profile.to_dict() for profile in self.profiles],
             "dependency_extra": self.dependency_extra,
             "entity_scoped": self.entity_scoped,
+            "facets": self.facets.to_dict() if self.facets is not None else None,
         }
 
 
@@ -169,6 +205,7 @@ class CapabilitySpec:
 
 
 __all__ = [
+    "AdapterFacets",
     "AdapterProfileSpec",
     "AdapterSpec",
     "CapabilitySpec",
@@ -176,5 +213,9 @@ __all__ = [
     "LayerKind",
     "ParameterKind",
     "ParameterSpec",
+    "RuntimeKind",
+    "SchemaStrategy",
     "SecretMappingSpec",
+    "StorageModel",
+    "TransactionSupport",
 ]

--- a/cli/arclith_cli/catalogs/persistence.py
+++ b/cli/arclith_cli/catalogs/persistence.py
@@ -6,6 +6,13 @@ from arclith_cli.capability_models import (
     ParameterSpec,
     SecretMappingSpec,
 )
+from arclith_cli.catalogs.repository_facets import (
+    DUCKDB_FACETS,
+    MARIADB_FACETS,
+    MEMORY_FACETS,
+    MONGODB_FACETS,
+    POSTGRESQL_FACETS,
+)
 
 REPOSITORY_CAPABILITY = CapabilitySpec(
     name="repository",
@@ -18,6 +25,7 @@ REPOSITORY_CAPABILITY = CapabilitySpec(
             capability="repository",
             layer="outbound",
             description="Stockage volatile en mémoire pour dev, tests et smoke locaux.",
+            facets=MEMORY_FACETS,
         ),
         AdapterSpec(
             name="mongodb",
@@ -57,6 +65,7 @@ multitenant: {multitenant}   # true = uri/db_name résolus par requête via JWT 
                     default=False,
                 ),
             ),
+            facets=MONGODB_FACETS,
         ),
         AdapterSpec(
             name="duckdb",
@@ -76,6 +85,7 @@ path: {path}
                     default="data/",
                 ),
             ),
+            facets=DUCKDB_FACETS,
         ),
         AdapterSpec(
             name="mariadb",
@@ -142,6 +152,7 @@ multitenant: false
                     default="",
                 ),
             ),
+            facets=MARIADB_FACETS,
         ),
         AdapterSpec(
             name="postgresql",
@@ -221,6 +232,7 @@ multitenant: {multitenant}
                     default=False,
                 ),
             ),
+            facets=POSTGRESQL_FACETS,
         ),
     ),
 )

--- a/cli/arclith_cli/catalogs/repository_facets.py
+++ b/cli/arclith_cli/catalogs/repository_facets.py
@@ -1,0 +1,94 @@
+from arclith_cli.capability_models import AdapterFacets
+
+MEMORY_FACETS = AdapterFacets(
+    storage_model="memory",
+    runtime="in_process",
+    production_ready=False,
+    multi_process=False,
+    transactions="none",
+    schema_strategy="flexible",
+    recommended_for=(
+        "tests unitaires",
+        "développement et smoke dans un seul processus",
+    ),
+    limits=(
+        "données perdues à l'arrêt",
+        "état non partagé entre processus",
+    ),
+)
+
+MONGODB_FACETS = AdapterFacets(
+    storage_model="document",
+    runtime="server",
+    production_ready=True,
+    multi_process=True,
+    transactions="limited",
+    schema_strategy="flexible",
+    recommended_for=(
+        "API, MCP et agents avec état partagé",
+        "données métier document-first ou à schéma évolutif",
+    ),
+    limits=(
+        "pas de modèle relationnel riche via Repository[T]",
+        "pas de transaction multi-opérations exposée par le port",
+    ),
+)
+
+DUCKDB_FACETS = AdapterFacets(
+    storage_model="embedded_analytics",
+    runtime="file",
+    production_ready=False,
+    multi_process=False,
+    transactions="limited",
+    schema_strategy="structured_tables",
+    recommended_for=(
+        "démonstrations et traitements analytiques locaux",
+        "données persistées dans des fichiers locaux",
+    ),
+    limits=(
+        "pas conçu comme base applicative serveur multi-process",
+        "concurrence d'écriture et formats de fichier à encadrer",
+    ),
+)
+
+MARIADB_FACETS = AdapterFacets(
+    storage_model="relational_json",
+    runtime="server",
+    production_ready=True,
+    multi_process=True,
+    transactions="strong",
+    schema_strategy="json_table",
+    recommended_for=(
+        "SI existant basé sur MariaDB",
+        "état partagé nécessitant un serveur SQL",
+    ),
+    limits=(
+        "entité stockée comme payload JSON générique",
+        "pas de relations, joins ou migrations métier via le port",
+    ),
+)
+
+POSTGRESQL_FACETS = AdapterFacets(
+    storage_model="relational_json",
+    runtime="server",
+    production_ready=True,
+    multi_process=True,
+    transactions="strong",
+    schema_strategy="json_table",
+    recommended_for=(
+        "services nécessitant un SQL serveur robuste",
+        "état partagé multi-process avec payload JSONB",
+    ),
+    limits=(
+        "entité stockée comme payload JSONB générique",
+        "pas de relations, joins ou migrations métier via le port",
+    ),
+)
+
+__all__ = [
+    "DUCKDB_FACETS",
+    "MARIADB_FACETS",
+    "MEMORY_FACETS",
+    "MONGODB_FACETS",
+    "POSTGRESQL_FACETS",
+]

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -49,6 +49,80 @@ def test_repository_capability_catalog_declares_standard_adapters() -> None:
     ]
 
 
+def test_repository_adapter_facets_have_a_stable_serializable_shape() -> None:
+    capability = get_capability("repository")
+    assert capability is not None
+
+    expected_facets = {
+        "memory": (
+            "memory",
+            "in_process",
+            False,
+            False,
+            "none",
+            "flexible",
+        ),
+        "mongodb": (
+            "document",
+            "server",
+            True,
+            True,
+            "limited",
+            "flexible",
+        ),
+        "duckdb": (
+            "embedded_analytics",
+            "file",
+            False,
+            False,
+            "limited",
+            "structured_tables",
+        ),
+        "mariadb": (
+            "relational_json",
+            "server",
+            True,
+            True,
+            "strong",
+            "json_table",
+        ),
+        "postgresql": (
+            "relational_json",
+            "server",
+            True,
+            True,
+            "strong",
+            "json_table",
+        ),
+    }
+
+    for adapter in capability.adapters:
+        assert adapter.facets is not None
+        payload = adapter.facets.to_dict()
+        assert set(payload) == {
+            "storage_model",
+            "runtime",
+            "production_ready",
+            "multi_process",
+            "transactions",
+            "schema_strategy",
+            "recommended_for",
+            "limits",
+        }
+        assert (
+            payload["storage_model"],
+            payload["runtime"],
+            payload["production_ready"],
+            payload["multi_process"],
+            payload["transactions"],
+            payload["schema_strategy"],
+        ) == expected_facets[adapter.name]
+        assert payload["recommended_for"]
+        assert all(isinstance(value, str) for value in payload["recommended_for"])
+        assert payload["limits"]
+        assert all(isinstance(value, str) for value in payload["limits"])
+
+
 def test_cache_capability_catalog_declares_memory_adapter() -> None:
     capability = get_capability("cache")
 
@@ -704,6 +778,22 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "postgresql",
     ]
     assert repository["adapters"][0]["entity_scoped"] is True
+    assert repository["adapters"][0]["facets"] == {
+        "storage_model": "memory",
+        "runtime": "in_process",
+        "production_ready": False,
+        "multi_process": False,
+        "transactions": "none",
+        "schema_strategy": "flexible",
+        "recommended_for": [
+            "tests unitaires",
+            "développement et smoke dans un seul processus",
+        ],
+        "limits": [
+            "données perdues à l'arrêt",
+            "état non partagé entre processus",
+        ],
+    }
     duckdb = repository["adapters"][2]
     assert duckdb["name"] == "duckdb"
     assert duckdb["config_path"] == "config/adapters/outbound/duckdb.yaml"
@@ -730,6 +820,7 @@ def test_capabilities_command_outputs_json_catalog() -> None:
     filesystem = storage["adapters"][0]
     assert filesystem["config_path"] == "config/adapters/outbound/storage.yaml"
     assert filesystem["entity_scoped"] is False
+    assert filesystem["facets"] is None
     assert [parameter["name"] for parameter in filesystem["parameters"]] == [
         "root_path",
         "prefix",

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -30,7 +30,7 @@ arclith-cli capabilities --json
 | [license](capabilities/license.md) | inbound | `role` | contrôler un droit d'accès |
 | [probe](capabilities/probe.md) | inbound | `server` | exposer `/health` et `/ready` |
 | [http](capabilities/http.md) | inbound | `idempotency`, `etag`, `cache-control` | durcir les conventions HTTP |
-| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | persister les entités |
+| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | choisir les garanties et persister les entités métier |
 | [storage](capabilities/storage.md) | outbound | `filesystem`, `s3`, `azure-blob`, `gcs` | stocker fichiers et blobs |
 | [cache](capabilities/cache.md) | outbound | `memory`, `redis` | partager JWKS, tenants et idempotence |
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |
@@ -53,6 +53,7 @@ arclith-cli capabilities --json
 | Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis [vector-store](capabilities/vector-store.md) pour les indexer |
 | Observabilité locale | [OpenTelemetry de bout en bout](capabilities/opentelemetry.md), puis [observabilité production](production/observability.md) |
 | Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
+| Persistance métier | [repository et sa matrice de choix](capabilities/repository.md), puis [storage](capabilities/storage.md) ou [vector-store](capabilities/vector-store.md) pour les responsabilités distinctes |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |
 | Déploiement | [Runtime Docker](runtime-docker.md), puis [Docker Compose](runtime-docker/docker-compose.md) |
 

--- a/docs/capabilities/repository.md
+++ b/docs/capabilities/repository.md
@@ -1,54 +1,183 @@
 # Capability Repository
 
-Persistance des entités métier derrière un port repository.
+## Intention
 
-## Objectif
+La capability outbound `repository` persiste les entités métier et leur cycle
+de vie derrière le port commun `Repository[T]`. Le domaine et les use cases ne
+dépendent ni de MongoDB, ni d'un moteur SQL, ni d'un format de fichier.
 
-Un repository est un adapter outbound. Les use cases dépendent du port
-`Repository[T]`; le choix MongoDB, PostgreSQL, MariaDB, DuckDB ou mémoire reste
-dans la configuration et l'assemblage applicatif.
+Utiliser un repository pour la source de vérité CRUD d'une entité. Ne pas
+l'utiliser pour stocker directement un fichier volumineux, calculer un
+embedding ou maintenir un index vectoriel reconstruisible.
 
-## Choisir L'adapter
+## Position Hexagonale
 
-| Adapter | Usage |
-|---|---|
-| `memory` | tests unitaires, développement, un seul processus |
-| `mongodb` | standard document, API/MCP/agent avec état partagé |
-| `duckdb` | fichier local, démo, analytique embarquée |
-| `mariadb` | SQL serveur, intégration SI existant |
-| `postgresql` | SQL serveur robuste, JSONB générique, état partagé multi-process |
+```text
+adapter inbound -> port inbound -> use case -> Repository[T]
+                                             -> FileStoragePort
+                                             -> VectorStorePort
+```
 
-## Installer
+Chaque port correspond à une responsabilité différente :
+
+| Besoin | Capability | Responsabilité |
+|---|---|---|
+| conserver une entité métier et son cycle de vie | `repository` | source de vérité CRUD |
+| conserver un fichier ou un blob original | [`storage`](storage.md) | octets et métadonnées objet |
+| retrouver les voisins d'un vecteur | [`vector-store`](vector-store.md) | index de recherche reconstruisible |
+
+### Pourquoi SQL Et NoSQL Restent Une Même Capability
+
+SQL et NoSQL décrivent ici des familles d'implémentation et de garanties, pas
+deux responsabilités métier. `Repository[T]` reste donc le port commun tant que
+le contrat est centré sur les entités et le CRUD.
+
+Créer maintenant `sql-repository` et `nosql-repository` dupliquerait le même
+port sans donner de capacité supplémentaire aux use cases. Un port relationnel
+spécifique ne deviendrait pertinent que si Arclith devait exposer explicitement
+des transactions applicatives, des contraintes uniques, des requêtes typées,
+des relations ou joins, des migrations, ou des schémas structurés par champ.
+
+`storage` reste séparé parce qu'il conserve les blobs originaux.
+`vector-store` reste séparé parce qu'il conserve un index ou une projection de
+recherche, et non la source de vérité métier par défaut.
+
+## Quickstart
+
+Afficher le catalogue lisible par une personne ou exploitable par un outil :
 
 ```bash
-arclith-cli add-adapter --capability repository --adapter memory --yes
-arclith-cli add-adapter --capability repository --adapter mongodb --yes
+arclith-cli capabilities
+arclith-cli capabilities --json
+```
+
+Ajouter un adapter à un projet :
+
+```bash
 arclith-cli add-adapter \
   --capability repository \
-  --adapter postgresql \
-  --param database=my_service \
+  --adapter mongodb \
   --yes
 ```
 
-Pour MongoDB, MariaDB ou PostgreSQL, ajouter aussi le resolver de secrets adapté.
-
-```bash
-arclith-cli add-adapter \
-  --capability secrets \
-  --adapter chain \
-  --param field_path=adapters.mongodb.uri \
-  --param secret_key=apps/my-service/mongodb \
-  --yes
-```
-
-## Activer
+L'adapter actif reste choisi par la configuration existante :
 
 ```yaml
 # config/adapters/adapters.yaml
 repository: mongodb
 ```
 
-## MongoDB
+Les facets sont uniquement des métadonnées de choix dans le catalogue CLI.
+Elles ne changent ni ce fichier, ni le contrat du port, ni le comportement des
+projets existants.
+
+Voir aussi le [quickstart historique](../quickstart.md) pour le wizard complet.
+
+## Formation
+
+Le projet Todo montre le chemin complet :
+
+1. [initialiser le projet avec `repository: memory`](../tutorials/todo-list/01-init-project.md) ;
+2. [faire dépendre les use cases du port](../tutorials/todo-list/03-create-usecase.md) ;
+3. [passer à MongoDB pour partager l'état entre processus](../tutorials/todo-list/07-local-services.md).
+
+## Contrat
+
+`Repository[T]` fournit le même contrat quel que soit l'adapter :
+
+| Méthode | Rôle |
+|---|---|
+| `create(entity)` | persister une nouvelle entité |
+| `read(uuid)` | lire une entité, supprimée logiquement ou non |
+| `update(entity)` | remplacer l'état persistant de l'entité |
+| `delete(uuid)` | supprimer physiquement une entité |
+| `find_all()` | lister les entités non supprimées |
+| `find_page(offset, limit)` | paginer les entités non supprimées avec leur total |
+| `find_deleted()` | lister les entités supprimées logiquement |
+| `duplicate(uuid)` | créer une copie avec un nouvel UUID |
+
+Le choix de l'adapter passe par `build_repository()` et `Arclith.repository()`.
+Les adapters inbound ne doivent jamais instancier une implémentation concrète.
+
+### Contrat JSON Des Facets
+
+Chaque adapter repository expose un objet `facets` dans
+`arclith-cli capabilities --json` :
+
+```json
+{
+  "storage_model": "document",
+  "runtime": "server",
+  "production_ready": true,
+  "multi_process": true,
+  "transactions": "limited",
+  "schema_strategy": "flexible",
+  "recommended_for": [
+    "API, MCP et agents avec état partagé"
+  ],
+  "limits": [
+    "pas de modèle relationnel riche via Repository[T]"
+  ]
+}
+```
+
+La forme est stable et entièrement sérialisable :
+
+| Facet | Valeurs | Lecture |
+|---|---|---|
+| `storage_model` | `memory`, `document`, `relational_json`, `embedded_analytics`, `relational_structured` | famille de persistance |
+| `runtime` | `in_process`, `file`, `server` | emplacement et durée de vie du moteur |
+| `production_ready` | booléen | adapter destiné ou non à un runtime de production |
+| `multi_process` | booléen | état partageable entre plusieurs processus applicatifs |
+| `transactions` | `none`, `limited`, `strong` | niveau transactionnel réellement accessible via l'adapter |
+| `schema_strategy` | `flexible`, `json_table`, `structured_tables` | façon dont les entités sont matérialisées |
+| `recommended_for` | liste de chaînes | usages conseillés |
+| `limits` | liste de chaînes | compromis à vérifier avant sélection |
+
+`strong` signifie que chaque opération repository s'exécute dans une
+transaction forte du moteur. Le port ne fournit toutefois pas d'unité de
+travail permettant de regrouper plusieurs appels dans une même transaction.
+`limited` couvre une atomicité limitée à l'opération ou aux garanties propres
+au moteur, sans transaction applicative multi-opérations exposée.
+
+Les autres capabilities peuvent laisser `facets` à `null`. Cela permet
+d'étendre progressivement le catalogue sans imposer artificiellement ces axes
+de persistance aux adapters inbound ou runtime.
+
+## Adapters
+
+### Matrice De Choix
+
+| Adapter | Famille et runtime | Usage recommandé | Limite principale |
+|---|---|---|---|
+| `memory` | mémoire / processus | tests, smoke, développement local mono-processus | volatile et non partagé entre processus |
+| `mongodb` | document / serveur | état métier partagé, modèle document-first ou évolutif | pas de modèle relationnel riche via le port |
+| `duckdb` | analytique embarqué / fichier | démonstrations et traitements analytiques locaux | pas une base applicative serveur multi-processus |
+| `mariadb` | relationnel avec payload JSON / serveur | intégration à un SI MariaDB existant | entité stockée en JSON, sans mapping relationnel métier riche |
+| `postgresql` | relationnel avec payload JSONB / serveur | SQL serveur robuste et état partagé | entité stockée en JSONB, sans mapping relationnel métier riche |
+
+### Matrice Des Garanties
+
+| Adapter | Production ready | Multi-processus | Transactions | Stratégie de schéma |
+|---|---:|---:|---|---|
+| `memory` | non | non | `none` | `flexible` |
+| `mongodb` | oui | oui | `limited` | `flexible` |
+| `duckdb` | non | non | `limited` | `structured_tables` |
+| `mariadb` | oui | oui | `strong` | `json_table` |
+| `postgresql` | oui | oui | `strong` | `json_table` |
+
+`production_ready` décrit la cible de l'adapter Arclith, pas une certification
+automatique du déploiement. La haute disponibilité, les sauvegardes, la
+réplication, le chiffrement et les tests de charge restent à valider dans
+l'infrastructure du service.
+
+### Memory
+
+`memory` n'a pas de fichier scoped. Il est le choix par défaut pour les tests
+rapides, mais chaque processus possède son propre état et toute donnée est
+perdue à son arrêt.
+
+### MongoDB
 
 ```yaml
 # config/adapters/outbound/mongodb.yaml
@@ -59,9 +188,23 @@ multitenant: false
 ```
 
 `uri: null` signifie que l'URI doit venir de `config/secrets.yaml`, de
-l'environnement ou de Vault.
+l'environnement ou de Vault. MongoDB convient à un état partagé document-first
+et à un schéma évolutif. Le port n'expose ni jointure relationnelle, ni
+transaction regroupant plusieurs appels repository.
 
-## MariaDB
+### DuckDB
+
+```yaml
+# config/adapters/outbound/duckdb.yaml
+multitenant: false
+path: data/
+```
+
+L'adapter matérialise l'entité dans une table DuckDB puis la persiste dans un
+fichier supporté. Il cible les démonstrations ou traitements analytiques
+locaux. Ne pas le choisir comme base applicative serveur partagée par défaut.
+
+### MariaDB
 
 ```yaml
 # config/adapters/outbound/mariadb.yaml
@@ -76,9 +219,12 @@ table_prefix: ""
 multitenant: false
 ```
 
-Mapper `adapters.mariadb.url` ou `adapters.mariadb.password` via secrets.
+Chaque entité est stockée dans une table générique avec les champs techniques
+et un payload JSON. Cet adapter réutilise les transactions du moteur pour
+chaque opération, sans exposer de modèle relationnel métier ni d'unité de
+travail multi-opérations.
 
-## PostgreSQL
+### PostgreSQL
 
 ```yaml
 # config/adapters/outbound/postgresql.yaml
@@ -94,66 +240,76 @@ table_prefix: ""
 multitenant: false
 ```
 
-PostgreSQL stocke chaque entité dans une table générique par type, avec
-`uuid`, les champs d'audit et le payload complet dans une colonne `JSONB`.
-Ce choix garde les use cases inchangés: ils continuent à dépendre uniquement du
-port `Repository[T]`.
+PostgreSQL suit le même port avec une table générique par type et un payload
+JSONB. L'adapter cible un serveur SQL durable et multi-processus. Les colonnes
+métier typées, Alembic, les joins et les contraintes SQL métier restent hors du
+contrat actuel.
 
-Utiliser PostgreSQL quand un service API, MCP ou agent a besoin d'une base
-serveur partagée, durable, multi-process, avec des garanties transactionnelles
-fortes à l'intérieur d'une même base. Contrairement à MongoDB, le backend reste
-relationnel; contrairement à MariaDB, le payload exploite `JSONB`; contrairement
-à DuckDB, il cible un runtime serveur.
+## Production
 
-Mapper `adapters.postgresql.url` ou `adapters.postgresql.password` via secrets,
-par exemple `POSTGRESQL_URL` et `POSTGRESQL_PASSWORD`. La CLI génère les
-mappings, mais ne génère pas d'URL ou de mot de passe en clair.
+Choisir l'adapter à partir des garanties nécessaires :
 
-Le mapping relationnel riche, les colonnes métier typées, Alembic, les joins et
-les contraintes SQL métier sont des évolutions séparées.
+1. rester sur `memory` si le processus peut perdre son état et ne le partage
+   avec aucun autre runtime ;
+2. choisir `duckdb` si le fichier local et l'usage analytique embarqué sont des
+   contraintes explicites ;
+3. choisir `mongodb` pour un modèle document-first partagé et évolutif ;
+4. choisir `mariadb` lorsqu'un SI MariaDB existe déjà ;
+5. choisir `postgresql` pour un backend SQL serveur général avec payload JSONB.
 
-## DuckDB
+Les URI et mots de passe passent par la capability [`secrets`](secrets.md), par
+exemple `MONGODB_URI`, `MARIADB_URL`, `MARIADB_PASSWORD`, `POSTGRESQL_URL` ou
+`POSTGRESQL_PASSWORD`. Ne pas les écrire en clair dans les fichiers versionnés.
 
-```yaml
-# config/adapters/outbound/duckdb.yaml
-multitenant: false
-path: data/
-```
-
-DuckDB est utile pour une démo locale ou un traitement analytique léger. Ne
-l'utiliser en production que si le modèle de fichier local est explicitement
-voulu.
-
-## Utiliser Dans Un Service
-
-```python
-from arclith import Arclith
-from my_service.domain.models.todo import Todo
-
-app = Arclith("config")
-repository = app.repository(Todo)
-```
-
-Dans un projet métier, centraliser cet assemblage dans un container
-d'application pour partager le même repository entre API, MCP et agent.
-
-## Règles
-
-- Un adapter inbound ne doit jamais instancier un repository concret.
-- Les use cases parlent au port `Repository[T]`.
-- `memory` ne partage pas l'état entre processus API, MCP et agent.
-- Les URI et mots de passe passent par la capability [secrets](secrets.md),
-  par exemple `POSTGRESQL_URL` ou `POSTGRESQL_PASSWORD`.
-- La configuration choisit l'adapter actif; le code métier reste stable.
+Pour plusieurs réplicas API, MCP ou agent, sélectionner un adapter
+`multi_process: true`. Cette facet ne remplace pas la validation de la capacité
+du moteur, de son pool de connexions et de son déploiement à absorber la charge.
 
 ## Validation
 
+Vérifier le contrat des facets et la sortie CLI :
+
 ```bash
-uv run pytest
-uv run python -c "from arclith.infrastructure.config import load_config_dir; load_config_dir('config')"
+uv run --directory cli pytest tests/test_capabilities.py -q
+uv run --directory cli arclith-cli capabilities --json
 ```
+
+Avant contribution :
+
+```bash
+make quality
+make docs
+```
+
+## Troubleshooting
+
+### Deux Processus Ne Voient Pas Le Même État
+
+Vérifier `multi_process` dans la sortie JSON. `memory` et `duckdb` ne sont pas
+les choix par défaut pour partager l'état entre API, MCP, agents ou workers.
+
+### Une Facet Vaut `null`
+
+Les facets de cette matrice sont renseignées pour les adapters `repository`.
+Une autre capability peut retourner `null` tant qu'elle ne dispose pas d'une
+taxonomie adaptée à sa responsabilité.
+
+### Un Backend SQL N'Expose Pas De Joins Métier
+
+`mariadb` et `postgresql` implémentent aujourd'hui le port CRUD entity-first et
+stockent un payload JSON ou JSONB générique. Une application qui exige des
+requêtes relationnelles typées, des contraintes métier ou des transactions
+multi-agrégats doit définir un port applicatif dédié dans son propre domaine.
+
+## Projet
+
+Le [projet Todo](../tutorials/todo-list/index.md) utilise `memory` dans les tests
+et MongoDB pour partager les données entre les processus API, MCP et agent. Le
+[chapitre services locaux](../tutorials/todo-list/07-local-services.md) montre
+le passage de l'un à l'autre sans modifier les use cases.
 
 ## Suite
 
-Lire [secrets](secrets.md), puis [cache](cache.md) si plusieurs processus doivent
-partager l'état technique.
+Lire [`storage`](storage.md) pour les fichiers, [`vector-store`](vector-store.md)
+pour les projections de recherche, puis [`secrets`](secrets.md) pour les
+credentials des adapters serveur.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -156,8 +156,14 @@ Pour ajouter ou remplacer un adapter de repository:
 
 ```bash
 arclith-cli capabilities
+arclith-cli capabilities --json
 arclith-cli add-adapter
 ```
+
+La sortie JSON expose les garanties de chaque adapter repository. Utiliser la
+[matrice de choix repository](capabilities/repository.md) pour comparer runtime,
+multi-processus, transactions, stratégie de schéma, usages et limites avant de
+modifier l'adapter actif.
 
 Le wizard détecte les entités dans `src/<package>/domain/models/`, pose les questions nécessaires,
 génère les fichiers de l'adapter et met à jour la configuration.

--- a/journal/2026-09-03-repository-adapter-facets.md
+++ b/journal/2026-09-03-repository-adapter-facets.md
@@ -1,0 +1,48 @@
+# Facets et matrice de choix des adapters repository
+
+## Contexte
+
+L'issue #159 demande d'aider un développeur ou un agent de code à choisir un
+adapter repository à partir de garanties explicites. Le catalogue listait déjà
+`memory`, `mongodb`, `duckdb`, `mariadb` et `postgresql`, mais sa sortie JSON ne
+décrivait ni leur runtime, ni leur partage multi-processus, ni leurs compromis
+de transaction et de schéma.
+
+## Décisions
+
+- ajouter un objet `AdapterFacets` optionnel et typé à `AdapterSpec` ;
+- sérialiser une forme stable contenant modèle de stockage, runtime, maturité
+  production, partage multi-processus, transactions, stratégie de schéma,
+  usages recommandés et limites ;
+- renseigner les cinq adapters repository déjà présents sans modifier leur
+  configuration ni le contrat `Repository[T]` ;
+- conserver l'affichage texte compact et exposer le détail dans
+  `arclith-cli capabilities --json` ;
+- maintenir un seul port repository : SQL et NoSQL restent des familles
+  d'implémentation tant qu'aucune responsabilité relationnelle spécifique
+  n'entre dans le contrat ;
+- documenter explicitement les frontières avec `storage` et `vector-store`.
+
+## Impact
+
+Les consommateurs JSON peuvent comparer les adapters sans analyser du texte
+libre. Les autres capabilities sérialisent `facets: null`, ce qui permet une
+adoption progressive sans leur imposer la taxonomie de persistance.
+
+Il n'y a aucun changement de configuration, de dépendance, de port du domaine
+ou de comportement runtime.
+
+## Documentation
+
+La page `docs/capabilities/repository.md` suit désormais la structure canonique
+et contient deux matrices : choix fonctionnel et garanties techniques. L'index
+des capabilities et le quickstart historique renvoient vers cette décision.
+
+## Validation
+
+- tests ciblés du catalogue : 23 passés ;
+- `make quality` : 1 837 passés, 5 ignorés, couverture 90,64 % ;
+- `make precommit` : Ruff, mypy et Bandit passés ;
+- suite CLI complète : 149 passés, 1 ignoré ;
+- lint CLI ciblé : passé ;
+- `make docs` : build MkDocs strict passé.


### PR DESCRIPTION
## Contexte

Closes #159.

La capability `repository` listait les adapters disponibles sans exposer leurs garanties de choix dans le catalogue JSON. La distinction SQL/NoSQL reste une famille d implémentation du port commun `Repository[T]`.

## Changements

- ajoute `AdapterFacets`, une structure typée et sérialisable, optionnelle dans `AdapterSpec` ;
- renseigne les facets des adapters `memory`, `mongodb`, `duckdb`, `mariadb` et `postgresql` ;
- expose runtime, production, multi-processus, transactions, stratégie de schéma, usages et limites dans `arclith-cli capabilities --json` ;
- documente la matrice de choix et les frontières avec `storage` et `vector-store` ;
- ajoute les tests de forme et de sérialisation, ainsi que le journal de décision.

## Impact

- API/domaine/données/RabbitMQ/MCP : aucun changement ;
- configuration : aucun breaking change ;
- CLI : ajout du champ JSON `facets` (`null` hors adapters renseignés) ;
- dépendances, migrations et déploiement : aucun changement ;
- release : changement fonctionnel releasable du package CLI.

## Validation

- `make quality` : 1 837 passés, 5 ignorés, couverture 90,64 % ;
- `make precommit` : Ruff, mypy et Bandit passés ;
- `uv run --directory cli --frozen pytest tests -q` : 149 passés, 1 ignoré ;
- lint et format CLI ciblés : passés ;
- `make docs` : build MkDocs strict passé.

## Documentation

- page capability repository restructurée et complétée ;
- index capabilities et quickstart mis à jour ;
- journal `2026-09-03-repository-adapter-facets.md` ajouté ;
- ADR séparé non nécessaire : la décision reste locale au catalogue et reprend la frontière déjà portée par les ports existants.