### PR TITLE
feat: router les repositories par entité

### DIFF
--- a/arclith/infrastructure/repository_factory.py
+++ b/arclith/infrastructure/repository_factory.py
@@ -30,10 +30,12 @@ class RepositoryRegistry(Generic[T, R]):
         return self
 
     def build(self, config: AppConfig, entity_class: type[T], logger: Logger) -> R:
-        name = config.adapters.repository
+        name = config.adapters.repository_adapter_for(entity_class)
         if name not in self._factories:
+            entity_path = f"{entity_class.__module__}.{entity_class.__qualname__}"
             raise ValueError(
-                f"Repository adapter '{name}' not registered. "
+                f"Repository adapter '{name}' selected for '{entity_path}' "
+                "is not registered. "
                 f"Available: {sorted(self._factories)}."
             )
         return self._factories[name](config, entity_class, logger)

--- a/arclith/infrastructure/settings/app.py
+++ b/arclith/infrastructure/settings/app.py
@@ -51,6 +51,7 @@ class SoftDeleteSettings(SettingsModel):
 class AdaptersSettings(SettingsModel):
     logger: str = "console"
     repository: str = "memory"
+    repository_bindings: dict[str, str] = Field(default_factory=dict)
     observability: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
     mongodb: MongoDBSettings | None = None
     duckdb: DuckDBSettings | None = None
@@ -65,13 +66,23 @@ class AdaptersSettings(SettingsModel):
 
     @property
     def multitenant(self) -> bool:
-        settings = {
+        repository_settings = {
             "mongodb": self.mongodb,
             "duckdb": self.duckdb,
             "mariadb": self.mariadb,
             "postgresql": self.postgresql,
-        }.get(self.repository)
-        return bool(settings and settings.multitenant)
+        }
+        selected_adapters = {self.repository, *self.repository_bindings.values()}
+        return any(
+            settings is not None and settings.multitenant
+            for name in selected_adapters
+            if (settings := repository_settings.get(name)) is not None
+        )
+
+    def repository_adapter_for(self, entity_class: type[object]) -> str:
+        """Return the repository adapter selected for an entity class."""
+        entity_path = f"{entity_class.__module__}.{entity_class.__qualname__}"
+        return self.repository_bindings.get(entity_path, self.repository)
 
     @field_validator("logger")
     @classmethod
@@ -85,10 +96,10 @@ class AdaptersSettings(SettingsModel):
 
     @model_validator(mode="after")
     def validate_repository_config(self) -> "AdaptersSettings":
-        repository_section = _REPOSITORY_CONFIG_SECTIONS.get(self.repository)
-        if repository_section is not None and getattr(self, repository_section) is None:
-            raise ValueError(
-                f"repository={self.repository} mais aucune section [adapters.{repository_section}] dans config.yaml"
+        self._validate_repository_section("repository", self.repository)
+        for entity_path, adapter in self.repository_bindings.items():
+            self._validate_repository_section(
+                f"repository_bindings[{entity_path}]", adapter
             )
 
         for observability_adapter in self.observability.enabled:
@@ -102,6 +113,14 @@ class AdaptersSettings(SettingsModel):
                 )
         self._validate_observability_composition()
         return self
+
+    def _validate_repository_section(self, source: str, adapter: str) -> None:
+        repository_section = _REPOSITORY_CONFIG_SECTIONS.get(adapter)
+        if repository_section is not None and getattr(self, repository_section) is None:
+            raise ValueError(
+                f"{source}={adapter} mais aucune section "
+                f"[adapters.{repository_section}] dans config.yaml"
+            )
 
     def _validate_observability_composition(self) -> None:
         self._validate_langsmith_otel_mode()

--- a/cli/arclith_cli/adapter_templates.py
+++ b/cli/arclith_cli/adapter_templates.py
@@ -205,7 +205,8 @@ _repository_registry: RepositoryRegistry[{pascal}, {pascal}Repository] = (
 
 
 def build_{snake}_service(arclith: Arclith) -> tuple[{pascal}Service, Logger]:
-    arclith.logger.info("🗄️ Repository adapter selected", adapter=arclith.config.adapters.repository)
+    adapter = arclith.config.adapters.repository_adapter_for({pascal})
+    arclith.logger.info("🗄️ Repository adapter selected", adapter=adapter)
     repo: {pascal}Repository = arclith.repository({pascal}, registry=_repository_registry)
     return {pascal}Service(repo, arclith.logger, arclith.config.soft_delete.retention_days), arclith.logger
 """

--- a/cli/tests/test_adapter_templates.py
+++ b/cli/tests/test_adapter_templates.py
@@ -1,0 +1,20 @@
+from arclith_cli.adapter_templates import render_container
+
+
+def test_generated_container_logs_entity_repository_binding() -> None:
+    rendered = render_container(
+        "ChatThread",
+        "chat_thread",
+        ["mongodb"],
+        {
+            "application_import": "chat_service.application",
+            "domain_import": "chat_service.domain",
+            "adapters_import": "chat_service.adapters",
+        },
+    )
+
+    assert (
+        "adapter = arclith.config.adapters.repository_adapter_for(ChatThread)"
+        in rendered
+    )
+    assert "adapter=adapter)" in rendered

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -30,7 +30,7 @@ arclith-cli capabilities --json
 | [license](capabilities/license.md) | inbound | `role` | contrôler un droit d'accès |
 | [probe](capabilities/probe.md) | inbound | `server` | exposer `/health` et `/ready` |
 | [http](capabilities/http.md) | inbound | `idempotency`, `etag`, `cache-control` | durcir les conventions HTTP |
-| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | choisir les garanties et persister les entités métier |
+| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | choisir les garanties, router par entité et persister les entités métier |
 | [storage](capabilities/storage.md) | outbound | `filesystem`, `s3`, `azure-blob`, `gcs` | stocker fichiers et blobs |
 | [cache](capabilities/cache.md) | outbound | `memory`, `redis` | partager JWKS, tenants et idempotence |
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |
@@ -53,7 +53,7 @@ arclith-cli capabilities --json
 | Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis [vector-store](capabilities/vector-store.md) pour les indexer |
 | Observabilité locale | [OpenTelemetry de bout en bout](capabilities/opentelemetry.md), puis [observabilité production](production/observability.md) |
 | Fichiers et blobs | [storage](capabilities/storage.md), [quickstart filesystem](capabilities/storage/quickstart.md), puis [secrets](capabilities/secrets.md) pour les credentials |
-| Persistance métier | [repository et sa matrice de choix](capabilities/repository.md), puis [storage](capabilities/storage.md) ou [vector-store](capabilities/vector-store.md) pour les responsabilités distinctes |
+| Persistance métier | [repository, sa matrice et son routing multi-stores](capabilities/repository.md), puis [storage](capabilities/storage.md) ou [vector-store](capabilities/vector-store.md) pour les responsabilités distinctes |
 | Service production | [Baseline production](production/baseline.md), puis les pages de la section Production |
 | Déploiement | [Runtime Docker](runtime-docker.md), puis [Docker Compose](runtime-docker/docker-compose.md) |
 

--- a/docs/capabilities/repository.md
+++ b/docs/capabilities/repository.md
@@ -60,12 +60,15 @@ arclith-cli add-adapter \
   --yes
 ```
 
-L'adapter actif reste choisi par la configuration existante :
+L'adapter global reste choisi par la configuration existante :
 
 ```yaml
 # config/adapters/adapters.yaml
 repository: mongodb
 ```
+
+Il sert aussi de fallback pour toute entité qui n'a pas de binding explicite.
+Un service mono-store n'a donc rien à modifier.
 
 Les facets sont uniquement des métadonnées de choix dans le catalogue CLI.
 Elles ne changent ni ce fichier, ni le contrat du port, ni le comportement des
@@ -98,6 +101,81 @@ Le projet Todo montre le chemin complet :
 
 Le choix de l'adapter passe par `build_repository()` et `Arclith.repository()`.
 Les adapters inbound ne doivent jamais instancier une implémentation concrète.
+
+### Router Des Entités Vers Plusieurs Stores
+
+Un même service peut conserver le fallback global tout en sélectionnant un
+adapter pour certaines classes d'entité. La clé recommandée est toujours le
+chemin Python complet `<module>.<qualname>` :
+
+```yaml
+# config/adapters/adapters.yaml
+repository: mongodb
+
+repository_bindings:
+  my_service.domain.models.chat.ChatThread: mongodb
+  my_service.domain.models.chat.ChatMessage: mongodb
+  my_service.domain.models.identity.UserAccount: mariadb
+```
+
+Les sections configurant ces deux adapters restent dans leurs fichiers scoped :
+
+```yaml
+# config/adapters/outbound/mongodb.yaml
+uri: null
+db_name: chat_service
+collection_name: null
+multitenant: false
+```
+
+```yaml
+# config/adapters/outbound/mariadb.yaml
+url: null
+host: 127.0.0.1
+port: 3306
+database: identity_service
+user: app
+password: null
+driver: asyncmy
+table_prefix: identity_
+multitenant: false
+```
+
+L'assemblage public ne change pas :
+
+```python
+chat_threads = arclith.repository(ChatThread)  # mongodb
+chat_messages = arclith.repository(ChatMessage)  # mongodb
+users = arclith.repository(UserAccount)  # mariadb
+```
+
+Le routing est exact et déterministe. Arclith construit la clé avec
+`f"{entity_class.__module__}.{entity_class.__qualname__}"`. Il n'interprète pas
+les noms courts, ce qui évite les collisions entre deux classes portant le même
+nom. Si la classe n'est pas bindée, `repository` reste le fallback. Si elle est
+bindée vers un adapter absent du registry utilisé, la construction échoue au
+lieu de revenir silencieusement au fallback.
+
+Les adapters intégrés `mongodb`, `duckdb`, `mariadb` et `postgresql` exigent
+leur section de configuration dès qu'ils sont référencés par le fallback ou un
+binding. Un nom custom reste possible avec un `RepositoryRegistry` applicatif ;
+sa présence dans ce registry est contrôlée lors de la construction.
+
+Les use cases continuent à dépendre uniquement des ports :
+
+```python
+class StartChatUseCase:
+    def __init__(
+        self,
+        user_repository: Repository[UserAccount],
+        thread_repository: Repository[ChatThread],
+    ) -> None:
+        self.user_repository = user_repository
+        self.thread_repository = thread_repository
+```
+
+Le container connaît les classes et assemble les repositories. Le use case
+sait qu'il coordonne deux ports, mais ne connaît ni MongoDB ni MariaDB.
 
 ### Contrat JSON Des Facets
 
@@ -265,13 +343,41 @@ Pour plusieurs réplicas API, MCP ou agent, sélectionner un adapter
 `multi_process: true`. Cette facet ne remplace pas la validation de la capacité
 du moteur, de son pool de connexions et de son déploiement à absorber la charge.
 
+### Limites Transactionnelles Cross-store
+
+Le routing ne crée aucune transaction atomique entre deux bases :
+
+- placer dans le même aggregate et le même store les entités qui doivent
+  respecter un invariant fort dans une mutation atomique ;
+- coordonner des aggregates distincts dans la couche applicative ;
+- utiliser outbox, command bus, idempotence et compensation quand une opération
+  distribuée doit tolérer les échecs partiels ;
+- construire un query service, une projection ou un read model pour une lecture
+  combinée, sans cacher un join cross-store derrière `Repository[T]`.
+
+Le routing reste limité au bounded context du service. Traverser le domaine
+d'un autre service passe par son API, son MCP, ses événements ou son command
+bus, jamais par l'accès direct à son repository ou à sa base.
+
+### Multitenant
+
+Les bindings ne remplacent pas l'isolation tenant. Si le fallback ou au moins
+un adapter bindé porte `multitenant: true`, le pipeline tenant est activé pour
+le service. Les adapters tenant-aware tels que MongoDB, MariaDB et PostgreSQL
+continuent à lire leurs coordonnées dans le contexte tenant existant. Les
+bindings eux-mêmes ne contiennent ni URI ni credential.
+
 ## Validation
 
-Vérifier le contrat des facets et la sortie CLI :
+Vérifier le routing, la configuration, le contrat des facets et la sortie CLI :
 
 ```bash
-uv run --directory cli pytest tests/test_capabilities.py -q
-uv run --directory cli arclith-cli capabilities --json
+uv run --frozen pytest -q \
+  tests/units/infrastructure/test_config.py \
+  tests/units/infrastructure/test_repository_factory.py \
+  tests/units/test_arclith_repository.py
+uv run --directory cli --frozen pytest tests/test_capabilities.py -q
+uv run --directory cli --frozen arclith-cli capabilities --json
 ```
 
 Avant contribution :
@@ -300,6 +406,14 @@ taxonomie adaptée à sa responsabilité.
 stockent un payload JSON ou JSONB générique. Une application qui exige des
 requêtes relationnelles typées, des contraintes métier ou des transactions
 multi-agrégats doit définir un port applicatif dédié dans son propre domaine.
+
+### Un Binding Est Refusé
+
+Vérifier d'abord que la clé correspond exactement au module et au `qualname` de
+la classe. Pour un adapter intégré, vérifier ensuite que son fichier scoped est
+présent. Pour un adapter custom, enregistrer le même nom dans le
+`RepositoryRegistry` passé à `arclith.repository(...)`. Le message d'erreur de
+construction indique l'entité, l'adapter sélectionné et les adapters disponibles.
 
 ## Projet
 

--- a/journal/2026-09-03-repository-entity-routing.md
+++ b/journal/2026-09-03-repository-entity-routing.md
@@ -1,0 +1,52 @@
+# Routing Repository Par Entité
+
+## Contexte
+
+La configuration Arclith sélectionnait un unique adapter repository global.
+Cette convention reste adaptée aux services mono-store, mais empêchait un même
+bounded context de persister explicitement des aggregates distincts dans des
+stores différents sans écrire son propre mécanisme de sélection.
+
+## Décision
+
+- ajouter `adapters.repository_bindings`, indexé uniquement par le chemin Python
+  complet de la classe d'entité ;
+- conserver `adapters.repository` comme fallback backward-compatible ;
+- centraliser la résolution dans `AdaptersSettings.repository_adapter_for()` ;
+- faire consommer cette résolution par `RepositoryRegistry`, y compris pour les
+  registries applicatifs ;
+- valider la section de configuration de chaque adapter intégré référencé ;
+- échouer à la construction lorsqu'un binding sélectionne un adapter absent du
+  registry, sans fallback implicite ;
+- activer le pipeline tenant si au moins un adapter réellement sélectionné est
+  multitenant ;
+- garder `Repository[T]`, le domaine et les use cases inchangés.
+
+## Impact
+
+`Arclith.repository(Entity)` peut désormais assembler MongoDB, MariaDB, DuckDB,
+PostgreSQL, memory ou des adapters custom dans une même application. Les
+containers générés journalisent l'adapter effectivement sélectionné pour leur
+entité. Aucun nouveau port SQL/NoSQL, aucune dépendance et aucune transaction
+cross-store ne sont introduits.
+
+## Documentation
+
+`docs/capabilities/repository.md` présente la configuration complète
+MongoDB/MariaDB, le fallback, l'injection des ports, la validation, les limites
+transactionnelles, les frontières de bounded context et le comportement
+multitenant. L'index `docs/capabilities.md` rend ce routing découvrable. Un ADR
+séparé n'est pas nécessaire : ce choix étend le registry configurable déjà
+défini par ADR-010 sans modifier les frontières hexagonales.
+
+## Validation
+
+- tests ciblés configuration/factory/bootstrap repository : 143 passés, 4
+  ignorés car extras optionnels absents lors de ce run ciblé ;
+- test CLI du container généré : 1 passé ;
+- `make quality` : Ruff, Bandit, complexité et mypy passés, 1 850 tests passés,
+  5 intégrations externes ignorées et 90,65 % de couverture ;
+- `make precommit` : passé ;
+- suite CLI complète : 150 passés, 1 ignoré ;
+- lockfiles racine et CLI : valides avec `uv lock --check` ;
+- `make docs` : build MkDocs strict passée.

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from arclith.domain.models.entity import Entity
 from arclith.infrastructure.config import (
     AppConfig,
     CacheControlSettings,
@@ -26,11 +27,24 @@ from arclith.infrastructure.config import (
 )
 
 
+class BoundEntity(Entity):
+    pass
+
+
+class FallbackEntity(Entity):
+    pass
+
+
+def _entity_path(entity_class: type[Entity]) -> str:
+    return f"{entity_class.__module__}.{entity_class.__qualname__}"
+
+
 # ── AppConfig defaults ────────────────────────────────────────────────────────
 
 
 def test_default_config_uses_memory():
     assert AppConfig().adapters.repository == "memory"
+    assert AppConfig().adapters.repository_bindings == {}
     assert AppConfig().adapters.storage is None
     assert AppConfig().adapters.vector_store is None
     assert AppConfig().adapters.observability.enabled == []
@@ -42,6 +56,35 @@ def test_custom_repository_adapter_name_is_allowed():
 
     assert config.adapters.repository == "customdb"
     assert config.adapters.multitenant is False
+
+
+def test_repository_binding_selects_adapter_by_full_entity_path():
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "memory",
+                "repository_bindings": {_entity_path(BoundEntity): "customdb"},
+            }
+        }
+    )
+
+    assert config.adapters.repository_adapter_for(BoundEntity) == "customdb"
+    assert config.adapters.repository_adapter_for(FallbackEntity) == "memory"
+
+
+def test_repository_bindings_are_serialized_in_config():
+    entity_path = _entity_path(BoundEntity)
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository_bindings": {entity_path: "customdb"},
+            }
+        }
+    )
+
+    assert config.model_dump()["adapters"]["repository_bindings"] == {
+        entity_path: "customdb"
+    }
 
 
 def test_unknown_logger_adapter_is_rejected():
@@ -276,6 +319,26 @@ def test_load_config_dir_mongodb_scoped():
     assert config.adapters.repository == "mongodb"
     assert config.adapters.mongodb is not None
     assert config.adapters.mongodb.db_name == "mydb"
+
+
+def test_load_config_dir_repository_bindings():
+    entity_path = "my_service.domain.models.chat.ChatThread"
+    path = _make_config_dir(
+        {
+            "adapters/adapters.yaml": {
+                "repository": "memory",
+                "repository_bindings": {entity_path: "mongodb"},
+            },
+            "adapters/outbound/mongodb.yaml": {
+                "db_name": "chat_service",
+                "multitenant": False,
+            },
+        }
+    )
+
+    config = load_config_dir(path)
+
+    assert config.adapters.repository_bindings == {entity_path: "mongodb"}
 
 
 def test_load_config_dir_duckdb_scoped():
@@ -884,6 +947,33 @@ def test_mongodb_multitenant_no_uri_required():
     assert config.adapters.multitenant is True
 
 
+def test_bound_multitenant_repository_enables_tenant_pipeline():
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "memory",
+                "repository_bindings": {_entity_path(BoundEntity): "mongodb"},
+                "mongodb": {"db_name": "test", "multitenant": True},
+            }
+        }
+    )
+
+    assert config.adapters.multitenant is True
+
+
+def test_unselected_multitenant_repository_does_not_enable_tenant_pipeline():
+    config = AppConfig.model_validate(
+        {
+            "adapters": {
+                "repository": "memory",
+                "mongodb": {"db_name": "test", "multitenant": True},
+            }
+        }
+    )
+
+    assert config.adapters.multitenant is False
+
+
 def test_mariadb_settings_with_database():
     settings = MariaDBSettings(database="demo", port=3307, table_prefix="app_")
 
@@ -999,6 +1089,25 @@ def test_postgresql_requires_section():
         match=r"repository=postgresql mais aucune section \[adapters.postgresql\]",
     ):
         AppConfig.model_validate({"adapters": {"repository": "postgresql"}})
+
+
+@pytest.mark.parametrize("adapter", ["mongodb", "duckdb", "mariadb", "postgresql"])
+def test_repository_binding_requires_builtin_adapter_section(adapter: str):
+    entity_path = _entity_path(BoundEntity)
+
+    with pytest.raises(
+        ValidationError,
+        match=rf"repository_bindings\[{entity_path}\]={adapter}.*"
+        rf"\[adapters\.{adapter}\]",
+    ):
+        AppConfig.model_validate(
+            {
+                "adapters": {
+                    "repository": "memory",
+                    "repository_bindings": {entity_path: adapter},
+                }
+            }
+        )
 
 
 # ── load_config_file ──────────────────────────────────────────────────────────

--- a/tests/units/infrastructure/test_repository_factory.py
+++ b/tests/units/infrastructure/test_repository_factory.py
@@ -24,6 +24,18 @@ class Item(Entity):
     name: str = "item"
 
 
+class ChatThread(Entity):
+    pass
+
+
+class UserAccount(Entity):
+    pass
+
+
+def _entity_path(entity_class: type[Entity]) -> str:
+    return f"{entity_class.__module__}.{entity_class.__qualname__}"
+
+
 def test_memory_returns_in_memory_repository(logger):
     config = AppConfig(adapters=AdaptersSettings(repository="memory"))
     repo = build_repository(config, Item, logger)
@@ -48,6 +60,82 @@ def test_custom_repository_registry_builds_unknown_adapter(logger):
     repo = build_repository(config, Item, logger, registry=registry)
 
     assert repo is expected
+
+
+def test_repository_registry_routes_each_entity_to_its_binding(logger):
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="memory",
+            repository_bindings={
+                _entity_path(ChatThread): "mongodb",
+                _entity_path(UserAccount): "mariadb",
+            },
+            mongodb=MongoDBSettings(db_name="chat_service"),
+            mariadb=MariaDBSettings(database="identity_service"),
+        )
+    )
+    chat_repository = InMemoryRepository[ChatThread]()
+    user_repository = InMemoryRepository[UserAccount]()
+    selected: list[tuple[str, type[Entity]]] = []
+
+    def build_mongodb(config, entity_class, logger):
+        selected.append(("mongodb", entity_class))
+        return chat_repository
+
+    def build_mariadb(config, entity_class, logger):
+        selected.append(("mariadb", entity_class))
+        return user_repository
+
+    registry = (
+        RepositoryRegistry()
+        .register("mongodb", build_mongodb)
+        .register("mariadb", build_mariadb)
+    )
+
+    assert (
+        build_repository(config, ChatThread, logger, registry=registry)
+        is chat_repository
+    )
+    assert (
+        build_repository(config, UserAccount, logger, registry=registry)
+        is user_repository
+    )
+    assert selected == [("mongodb", ChatThread), ("mariadb", UserAccount)]
+
+
+def test_repository_registry_uses_global_fallback_for_unbound_entity(logger):
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="memory",
+            repository_bindings={_entity_path(ChatThread): "customdb"},
+        )
+    )
+    expected = InMemoryRepository[UserAccount]()
+    registry = RepositoryRegistry().register(
+        "memory", lambda config, entity_class, logger: expected
+    )
+
+    repository = build_repository(config, UserAccount, logger, registry=registry)
+
+    assert repository is expected
+
+
+def test_repository_registry_rejects_unknown_bound_adapter(logger):
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="memory",
+            repository_bindings={_entity_path(ChatThread): "missing"},
+        )
+    )
+    registry = RepositoryRegistry().register(
+        "memory", lambda config, entity_class, logger: InMemoryRepository()
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"missing.*{_entity_path(ChatThread)}.*not registered",
+    ):
+        build_repository(config, ChatThread, logger, registry=registry)
 
 
 def test_mongodb_returns_mongodb_repository(logger):

--- a/tests/units/test_arclith_repository.py
+++ b/tests/units/test_arclith_repository.py
@@ -1,0 +1,26 @@
+from arclith import Arclith, Entity, Repository, RepositoryRegistry
+from arclith.adapters.outbound.memory.repository import InMemoryRepository
+
+
+class BoundEntity(Entity):
+    pass
+
+
+def test_arclith_repository_routes_binding_through_application_registry(tmp_path):
+    entity_path = f"{BoundEntity.__module__}.{BoundEntity.__qualname__}"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "adapters:\n"
+        "  repository: memory\n"
+        "  repository_bindings:\n"
+        f"    {entity_path}: customdb\n",
+        encoding="utf-8",
+    )
+    expected = InMemoryRepository[BoundEntity]()
+    registry = RepositoryRegistry[BoundEntity, Repository[BoundEntity]]().register(
+        "customdb", lambda config, entity_class, logger: expected
+    )
+
+    repository = Arclith(config_path).repository(BoundEntity, registry=registry)
+
+    assert repository is expected


### PR DESCRIPTION
## Contexte

Closes #160.

Arclith ne pouvait sélectionner qu un adapter repository global. Un même bounded context doit pouvoir persister des aggregates distincts dans plusieurs stores sans faire dépendre le domaine ou les use cases de MongoDB, MariaDB, DuckDB, PostgreSQL ou memory.

## Changements

- ajoute `adapters.repository_bindings`, indexé par le chemin Python complet de chaque classe entité ;
- conserve `adapters.repository` comme fallback backward-compatible ;
- route `RepositoryRegistry.build()` vers le binding exact, y compris avec un registry applicatif ;
- valide les sections de configuration de tous les adapters intégrés référencés ;
- échoue explicitement lorsqu un binding cible un adapter absent du registry ;
- active le pipeline tenant lorsqu un fallback ou binding sélectionné est multitenant ;
- journalise dans les containers générés l adapter réellement sélectionné ;
- documente le cas MongoDB chat + MariaDB identité, les limites cross-store et les frontières de bounded context.

## Impact

- API publique : ajout non breaking de `AdaptersSettings.repository_adapter_for()` et du champ `repository_bindings` ;
- domaine et contrat `Repository[T]` : inchangés ;
- données et migrations : aucune migration, aucun changement de format persistant ;
- RabbitMQ, MCP, ports et autres capabilities : inchangés ;
- configuration : les services mono-store restent compatibles sans modification ;
- dépendances : aucune nouvelle dépendance ;
- release : changement fonctionnel releasable du package racine et ajustement du scaffold CLI.

## Validation

- tests ciblés racine : 143 passés, 4 skips optionnels ;
- `make quality` : Ruff, Bandit, complexité et mypy passés, 1 850 tests passés, 5 intégrations externes ignorées, couverture 90,65 % ;
- `make precommit` : passé ;
- `uv run --directory cli --frozen pytest -q` : 150 passés, 1 ignoré ;
- lint CLI complet et format ciblé : passés ;
- `uv lock --check` racine et CLI : passés ;
- `make docs` : build MkDocs strict passée.

## Documentation et exploitation

- page `docs/capabilities/repository.md` et index `docs/capabilities.md` mis à jour ;
- journal `journal/2026-09-03-repository-entity-routing.md` ajouté ;
- ADR séparé non applicable : extension directe du registry configurable défini par ADR-010 ;
- déploiement : aucune action ni migration ; configurer chaque section adapter et les secrets runtime avant activation des bindings.

## Risques restants

- aucune transaction atomique cross-store ; la coordination distribuée reste à la charge de la couche applicative ;
- les intégrations nécessitant des services externes restent couvertes par leurs tests dédiés et ont été ignorées localement en absence de ces services.
