### PR TITLE
feat: add provider-neutral channel contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Contrat channel provider-neutral** — modèles stricts, ports d'identité/idempotence/envoi,
+  dispatcher applicatif et erreurs communes pour les canaux conversationnels bidirectionnels.
+- **Adapter channel memory** — fake déterministe sans dépendance, claim atomique en processus,
+  factory publique, configuration scoped et catalogue `arclith-cli channel/memory`.
+
+### Changed
+
+- **Layout bidirectionnel** — la configuration et le layout canoniques reconnaissent désormais
+  `adapters/bidirectional` pour les adapters assurant réception et envoi.
+
 ---
 
 ## [0.22.0] — 2026-09-03

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Arclith
 
 Framework Python 3.13 pour construire des microservices hexagonaux avec domaine, ports, use cases,
-adapters, FastAPI, FastMCP, bus, agents, configuration, observabilité et runtime Docker.
+adapters, FastAPI, FastMCP, bus, canaux conversationnels, agents, configuration, observabilité et
+runtime Docker.
 
 ```bash
 uvx --from arclith-cli arclith-cli init my-service --dir .

--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -1,5 +1,9 @@
 from typing import TYPE_CHECKING
 
+from arclith.adapters.bidirectional.memory import (
+    MemoryChannel,
+    MemoryChannelIdentityResolver,
+)
 from arclith.adapters.inbound.schemas.base_schema import BaseSchema
 from arclith.adapters.outbound.azure_blob import (
     AzureBlobFileStorage,
@@ -16,11 +20,38 @@ from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
 from arclith.adapters.outbound.qdrant import QdrantVectorStore
 from arclith.adapters.outbound.s3 import S3FileStorage, S3StorageConfig
+from arclith.application.channel import ChannelDispatcher
 from arclith.application.command_bus import CommandDispatcher, CommandEnvelope
 from arclith.application.services.base_service import BaseService
 from arclith.arclith import Arclith
+from arclith.domain.errors.channel import (
+    ChannelDeliveryFailed,
+    ChannelError,
+    ChannelIdentityNotResolved,
+    ChannelRateLimited,
+    ChannelUnauthorized,
+    ChannelUnavailable,
+    InvalidChannelSignature,
+    UnsupportedChannelEvent,
+)
+from arclith.domain.models.channel import (
+    ChannelAttachment,
+    ChannelDeliveryReceipt,
+    ChannelDispatchResult,
+    ChannelHandlerResult,
+    ChannelIdentity,
+    ChannelIncomingMessage,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
 from arclith.domain.models.entity import Entity
+from arclith.domain.ports.inbound.channel import ChannelMessageHandler
 from arclith.domain.ports.inbound.command_bus import CommandHandler
+from arclith.domain.ports.outbound.channel import (
+    ChannelEventStore,
+    ChannelIdentityResolver,
+    ChannelSender,
+)
 from arclith.domain.ports.outbound.command_bus import CommandPublisher
 from arclith.domain.ports.outbound.embedding import (
     EmbeddingAuthenticationError,
@@ -83,6 +114,11 @@ from arclith.infrastructure.config import (
     load_config_dir,
     load_config_file,
 )
+from arclith.infrastructure.channel_factory import (
+    ChannelSenderRegistry,
+    build_channel_sender,
+    default_channel_sender_registry,
+)
 from arclith.infrastructure.embedding_factory import (
     EmbeddingRegistry,
     build_embedding,
@@ -119,6 +155,32 @@ if TYPE_CHECKING:  # pragma: no cover - for static type checkers only
     from arclith.adapters.outbound.console.logger import ConsoleLogger  # noqa: F401
 
 __all__ = [
+    "ChannelAttachment",
+    "ChannelDeliveryFailed",
+    "ChannelDeliveryReceipt",
+    "ChannelDispatcher",
+    "ChannelDispatchResult",
+    "ChannelError",
+    "ChannelEventStore",
+    "ChannelHandlerResult",
+    "ChannelIdentity",
+    "ChannelIdentityNotResolved",
+    "ChannelIdentityResolver",
+    "ChannelIncomingMessage",
+    "ChannelMessageHandler",
+    "ChannelOutgoingMessage",
+    "ChannelRateLimited",
+    "ChannelSender",
+    "ChannelSenderRegistry",
+    "ChannelUnauthorized",
+    "ChannelUnavailable",
+    "InvalidChannelSignature",
+    "MemoryChannel",
+    "MemoryChannelIdentityResolver",
+    "ResolvedChannelIdentity",
+    "UnsupportedChannelEvent",
+    "build_channel_sender",
+    "default_channel_sender_registry",
     "Entity",
     "Repository",
     "EmbeddingPort",

--- a/arclith/adapters/bidirectional/memory/__init__.py
+++ b/arclith/adapters/bidirectional/memory/__init__.py
@@ -1,0 +1,6 @@
+from arclith.adapters.bidirectional.memory.channel import (
+    MemoryChannel,
+    MemoryChannelIdentityResolver,
+)
+
+__all__ = ["MemoryChannel", "MemoryChannelIdentityResolver"]

--- a/arclith/adapters/bidirectional/memory/channel.py
+++ b/arclith/adapters/bidirectional/memory/channel.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+from arclith.domain.errors.channel import ChannelIdentityNotResolved
+from arclith.domain.models.channel import (
+    ChannelDeliveryReceipt,
+    ChannelIdentity,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+from arclith.domain.ports.outbound.channel import (
+    ChannelEventStore,
+    ChannelIdentityResolver,
+    ChannelSender,
+)
+
+IdentityKey = tuple[str, str, str | None, str | None]
+
+
+def _identity_key(identity: ChannelIdentity) -> IdentityKey:
+    return (
+        identity.provider,
+        identity.external_user_id,
+        identity.external_tenant_id,
+        identity.external_workspace_id,
+    )
+
+
+class MemoryChannelIdentityResolver(ChannelIdentityResolver):
+    """Explicit in-memory identity mapping for deterministic tests and POCs."""
+
+    def __init__(self) -> None:
+        self._mappings: dict[IdentityKey, ResolvedChannelIdentity] = {}
+
+    def register(
+        self,
+        identity: ChannelIdentity,
+        resolved: ResolvedChannelIdentity,
+    ) -> None:
+        self._mappings[_identity_key(identity)] = resolved
+
+    async def resolve(self, identity: ChannelIdentity) -> ResolvedChannelIdentity:
+        try:
+            return self._mappings[_identity_key(identity)]
+        except KeyError:
+            raise ChannelIdentityNotResolved(
+                "No application mapping for external channel identity"
+            ) from None
+
+
+class MemoryChannel(ChannelEventStore, ChannelSender):
+    """Dependency-free sender and atomic event store for tests and local POCs."""
+
+    def __init__(
+        self,
+        *,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        utc_clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._monotonic_clock = monotonic_clock
+        self._utc_clock = utc_clock or (lambda: datetime.now(timezone.utc))
+        self._claims: dict[tuple[str, str], float] = {}
+        self._sent_messages: list[ChannelOutgoingMessage] = []
+        self._receipts: list[ChannelDeliveryReceipt] = []
+        self._lock = asyncio.Lock()
+
+    @property
+    def sent_messages(self) -> tuple[ChannelOutgoingMessage, ...]:
+        return tuple(self._sent_messages)
+
+    @property
+    def receipts(self) -> tuple[ChannelDeliveryReceipt, ...]:
+        return tuple(self._receipts)
+
+    async def claim(
+        self,
+        provider: str,
+        event_id: str,
+        *,
+        ttl_seconds: int,
+    ) -> bool:
+        if ttl_seconds <= 0:
+            raise ValueError("channel event ttl_seconds must be greater than zero")
+        key = (provider, event_id)
+        async with self._lock:
+            now = self._monotonic_clock()
+            self._discard_expired_claims(now)
+            if key in self._claims:
+                return False
+            self._claims[key] = now + ttl_seconds
+            return True
+
+    async def release(self, provider: str, event_id: str) -> None:
+        async with self._lock:
+            self._claims.pop((provider, event_id), None)
+
+    async def send(self, message: ChannelOutgoingMessage) -> ChannelDeliveryReceipt:
+        async with self._lock:
+            receipt = ChannelDeliveryReceipt(
+                message_id=message.message_id,
+                provider_message_id=f"memory-{len(self._receipts) + 1:04d}",
+                status="delivered",
+                timestamp=self._utc_clock(),
+            )
+            self._sent_messages.append(message)
+            self._receipts.append(receipt)
+            return receipt
+
+    def _discard_expired_claims(self, now: float) -> None:
+        expired = [key for key, expires_at in self._claims.items() if expires_at <= now]
+        for key in expired:
+            del self._claims[key]

--- a/arclith/application/__init__.py
+++ b/arclith/application/__init__.py
@@ -1,0 +1,3 @@
+from arclith.application.channel import ChannelDispatcher
+
+__all__ = ["ChannelDispatcher"]

--- a/arclith/application/channel.py
+++ b/arclith/application/channel.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from arclith.domain.models.channel import (
+    ChannelDispatchResult,
+    ChannelIncomingMessage,
+)
+from arclith.domain.ports.inbound.channel import ChannelMessageHandler
+from arclith.domain.ports.outbound.channel import (
+    ChannelEventStore,
+    ChannelIdentityResolver,
+    ChannelSender,
+)
+
+
+class ChannelDispatcher:
+    """Dispatch normalized messages without imposing an inbound transport."""
+
+    def __init__(
+        self,
+        handler: ChannelMessageHandler,
+        identity_resolver: ChannelIdentityResolver,
+        event_store: ChannelEventStore,
+        sender: ChannelSender,
+        *,
+        event_ttl_seconds: int = 86_400,
+    ) -> None:
+        if event_ttl_seconds <= 0:
+            raise ValueError("channel event_ttl_seconds must be greater than zero")
+        self._handler = handler
+        self._identity_resolver = identity_resolver
+        self._event_store = event_store
+        self._sender = sender
+        self._event_ttl_seconds = event_ttl_seconds
+
+    async def dispatch(self, message: ChannelIncomingMessage) -> ChannelDispatchResult:
+        claimed = await self._event_store.claim(
+            message.channel,
+            message.provider_event_id,
+            ttl_seconds=self._event_ttl_seconds,
+        )
+        if not claimed:
+            return ChannelDispatchResult(status="duplicate")
+
+        try:
+            identity = await self._identity_resolver.resolve(message.sender)
+            handled = await self._handler.handle(message, identity)
+        except BaseException:
+            await self._event_store.release(
+                message.channel,
+                message.provider_event_id,
+            )
+            raise
+
+        if handled.status == "accepted":
+            return ChannelDispatchResult(status="accepted", identity=identity)
+
+        receipts = []
+        for response in handled.responses:
+            receipts.append(await self._sender.send(response))
+        return ChannelDispatchResult(
+            status="completed",
+            identity=identity,
+            receipts=tuple(receipts),
+        )

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from arclith.domain.models.entity import Entity
+from arclith.domain.ports.outbound.channel import ChannelSender
 from arclith.domain.ports.outbound.embedding import EmbeddingPort
 from arclith.domain.ports.outbound.file_storage import FileStoragePort
 from arclith.domain.ports.outbound.logger import Logger, LogLevel
@@ -28,6 +29,7 @@ from arclith.infrastructure.config import (
     load_config_dir,
     load_config_file,
 )
+from arclith.infrastructure.channel_factory import ChannelSenderRegistry
 from arclith.infrastructure.embedding_factory import EmbeddingRegistry
 from arclith.infrastructure.file_storage_factory import FileStorageRegistry
 from arclith.infrastructure.langgraph_bootstrap import (
@@ -179,6 +181,23 @@ class Arclith:
         from arclith.infrastructure.file_storage_factory import build_file_storage
 
         return build_file_storage(self.config, self.logger, registry=registry)
+
+    def channel_sender(
+        self,
+        adapter: str,
+        *,
+        registry: ChannelSenderRegistry | None = None,
+    ) -> ChannelSender:
+        """Build an outbound sender for an explicitly configured channel adapter."""
+
+        from arclith.infrastructure.channel_factory import build_channel_sender
+
+        return build_channel_sender(
+            self.config,
+            self.logger,
+            adapter,
+            registry=registry,
+        )
 
     def embedding(
         self,

--- a/arclith/domain/errors/__init__.py
+++ b/arclith/domain/errors/__init__.py
@@ -1,0 +1,21 @@
+from arclith.domain.errors.channel import (
+    ChannelDeliveryFailed,
+    ChannelError,
+    ChannelIdentityNotResolved,
+    ChannelRateLimited,
+    ChannelUnauthorized,
+    ChannelUnavailable,
+    InvalidChannelSignature,
+    UnsupportedChannelEvent,
+)
+
+__all__ = [
+    "ChannelDeliveryFailed",
+    "ChannelError",
+    "ChannelIdentityNotResolved",
+    "ChannelRateLimited",
+    "ChannelUnauthorized",
+    "ChannelUnavailable",
+    "InvalidChannelSignature",
+    "UnsupportedChannelEvent",
+]

--- a/arclith/domain/errors/channel.py
+++ b/arclith/domain/errors/channel.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+class ChannelError(Exception):
+    """Base error exposed by channel adapters and application services."""
+
+
+class InvalidChannelSignature(ChannelError):
+    """Raised when a provider signature is missing, stale, or invalid."""
+
+
+class ChannelUnauthorized(ChannelError):
+    """Raised when provider or application authorization rejects a message."""
+
+
+class UnsupportedChannelEvent(ChannelError):
+    """Raised when an adapter cannot normalize a provider event."""
+
+
+class ChannelIdentityNotResolved(ChannelError):
+    """Raised when an external identity has no explicit application mapping."""
+
+
+class ChannelRateLimited(ChannelError):
+    """Raised when a provider rate-limits an outbound delivery."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class ChannelDeliveryFailed(ChannelError):
+    """Raised when a provider rejects or fails an outbound delivery."""
+
+
+class ChannelUnavailable(ChannelError):
+    """Raised when a provider or transport is unavailable."""

--- a/arclith/domain/models/__init__.py
+++ b/arclith/domain/models/__init__.py
@@ -1,0 +1,21 @@
+from arclith.domain.models.channel import (
+    ChannelAttachment,
+    ChannelDeliveryReceipt,
+    ChannelDispatchResult,
+    ChannelHandlerResult,
+    ChannelIdentity,
+    ChannelIncomingMessage,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+
+__all__ = [
+    "ChannelAttachment",
+    "ChannelDeliveryReceipt",
+    "ChannelDispatchResult",
+    "ChannelHandlerResult",
+    "ChannelIdentity",
+    "ChannelIncomingMessage",
+    "ChannelOutgoingMessage",
+    "ResolvedChannelIdentity",
+]

--- a/arclith/domain/models/channel.py
+++ b/arclith/domain/models/channel.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Annotated, Literal
+from urllib.parse import urlsplit
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    NonNegativeInt,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+from uuid6 import uuid7
+
+from arclith.domain.models.json import validate_finite_json
+
+NonEmptyString = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
+ChannelDeliveryStatus = Literal["accepted", "sent", "delivered", "failed"]
+ChannelHandlerStatus = Literal["completed", "accepted"]
+ChannelDispatchStatus = Literal["completed", "accepted", "duplicate"]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _validate_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("channel timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc)
+
+
+def _has_unsafe_storage_key_syntax(value: str) -> bool:
+    return (
+        "\\" in value
+        or value.startswith("/")
+        or value.endswith("/")
+        or "//" in value
+        or bool(PureWindowsPath(value).drive)
+        or PurePosixPath(value).as_posix() != value
+    )
+
+
+class _ChannelModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @field_validator("metadata", check_fields=False)
+    @classmethod
+    def metadata_must_be_strict_json(
+        cls,
+        value: dict[str, JsonValue],
+    ) -> dict[str, JsonValue]:
+        validate_finite_json(value)
+        return value
+
+
+class ChannelAttachment(_ChannelModel):
+    """Provider-neutral attachment metadata without embedded binary content."""
+
+    kind: NonEmptyString
+    name: NonEmptyString | None = None
+    content_type: NonEmptyString | None = None
+    url: str | None = None
+    storage_key: str | None = None
+    size: NonNegativeInt | None = None
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("url")
+    @classmethod
+    def url_must_be_credential_free_http(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        parsed = urlsplit(normalized)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "channel attachment url must be a credential-free HTTP URL"
+            )
+        return normalized
+
+    @field_validator("storage_key")
+    @classmethod
+    def storage_key_must_be_relative(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if (
+            not normalized
+            or normalized != value
+            or _has_unsafe_storage_key_syntax(normalized)
+            or any(part in {"", ".", ".."} for part in normalized.split("/"))
+        ):
+            raise ValueError(
+                "channel attachment storage_key must be a normalized relative POSIX path"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def exactly_one_locator_is_required(self) -> "ChannelAttachment":
+        if (self.url is None) == (self.storage_key is None):
+            raise ValueError(
+                "channel attachment requires exactly one of url or storage_key"
+            )
+        return self
+
+
+class ChannelIdentity(_ChannelModel):
+    """Identity asserted by a provider before application-level resolution."""
+
+    provider: NonEmptyString
+    external_user_id: NonEmptyString
+    display_name: NonEmptyString | None = None
+    external_tenant_id: NonEmptyString | None = None
+    external_workspace_id: NonEmptyString | None = None
+
+
+class ResolvedChannelIdentity(_ChannelModel):
+    """Explicit mapping from a provider identity to application coordinates."""
+
+    user_id: NonEmptyString
+    tenant_id: NonEmptyString | None = None
+
+
+class ChannelIncomingMessage(_ChannelModel):
+    """Normalized message delivered by a channel adapter to the application."""
+
+    channel: NonEmptyString
+    provider_event_id: NonEmptyString
+    conversation_id: NonEmptyString
+    thread_id: NonEmptyString | None = None
+    sender: ChannelIdentity
+    text: str | None = None
+    attachments: tuple[ChannelAttachment, ...] = ()
+    received_at: datetime = Field(default_factory=_utc_now)
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("received_at")
+    @classmethod
+    def received_at_must_be_utc(cls, value: datetime) -> datetime:
+        return _validate_utc_datetime(value)
+
+    @model_validator(mode="after")
+    def validate_content_and_provider(self) -> "ChannelIncomingMessage":
+        if self.text is not None and not self.text.strip():
+            raise ValueError("channel incoming text must not be blank")
+        if self.text is None and not self.attachments:
+            raise ValueError("channel incoming message requires text or attachments")
+        if self.channel != self.sender.provider:
+            raise ValueError("channel must match sender.provider")
+        return self
+
+
+class ChannelOutgoingMessage(_ChannelModel):
+    """Provider-neutral response passed to an outbound channel sender."""
+
+    message_id: NonEmptyString = Field(default_factory=lambda: str(uuid7()))
+    channel: NonEmptyString
+    conversation_id: NonEmptyString
+    thread_id: NonEmptyString | None = None
+    recipient_id: NonEmptyString | None = None
+    text: str | None = None
+    attachments: tuple[ChannelAttachment, ...] = ()
+    reply_to: NonEmptyString | None = None
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def text_or_attachments_are_required(self) -> "ChannelOutgoingMessage":
+        if self.text is not None and not self.text.strip():
+            raise ValueError("channel outgoing text must not be blank")
+        if self.text is None and not self.attachments:
+            raise ValueError("channel outgoing message requires text or attachments")
+        return self
+
+
+class ChannelDeliveryReceipt(_ChannelModel):
+    """Provider-neutral result for one outbound message delivery."""
+
+    message_id: NonEmptyString
+    provider_message_id: NonEmptyString | None = None
+    status: ChannelDeliveryStatus
+    timestamp: datetime = Field(default_factory=_utc_now)
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @field_validator("timestamp")
+    @classmethod
+    def timestamp_must_be_utc(cls, value: datetime) -> datetime:
+        return _validate_utc_datetime(value)
+
+
+class ChannelHandlerResult(_ChannelModel):
+    """Application result independent from any provider acknowledgement protocol."""
+
+    status: ChannelHandlerStatus = "completed"
+    responses: tuple[ChannelOutgoingMessage, ...] = ()
+
+    @model_validator(mode="after")
+    def accepted_result_has_no_immediate_responses(self) -> "ChannelHandlerResult":
+        if self.status == "accepted" and self.responses:
+            raise ValueError(
+                "accepted channel results cannot contain immediate responses"
+            )
+        return self
+
+
+class ChannelDispatchResult(_ChannelModel):
+    """Transport-neutral outcome returned by the channel dispatcher."""
+
+    status: ChannelDispatchStatus
+    identity: ResolvedChannelIdentity | None = None
+    receipts: tuple[ChannelDeliveryReceipt, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_status_payload(self) -> "ChannelDispatchResult":
+        if self.status == "duplicate" and (self.identity is not None or self.receipts):
+            raise ValueError(
+                "duplicate channel results cannot include identity or receipts"
+            )
+        if self.status == "accepted" and self.receipts:
+            raise ValueError(
+                "accepted channel results cannot include delivery receipts"
+            )
+        return self

--- a/arclith/domain/models/json.py
+++ b/arclith/domain/models/json.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import math
+
+from pydantic import JsonValue
+
+
+def validate_finite_json(value: JsonValue) -> JsonValue:
+    """Reject non-finite numbers that Python accepts but JSON does not."""
+
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("JSON numeric values must be finite")
+    if isinstance(value, list):
+        for item in value:
+            validate_finite_json(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            validate_finite_json(item)
+    return value

--- a/arclith/domain/ports/inbound/__init__.py
+++ b/arclith/domain/ports/inbound/__init__.py
@@ -1,1 +1,3 @@
+from arclith.domain.ports.inbound.channel import ChannelMessageHandler
 
+__all__ = ["ChannelMessageHandler"]

--- a/arclith/domain/ports/inbound/channel.py
+++ b/arclith/domain/ports/inbound/channel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from arclith.domain.models.channel import (
+    ChannelHandlerResult,
+    ChannelIncomingMessage,
+    ResolvedChannelIdentity,
+)
+
+
+class ChannelMessageHandler(ABC):
+    """Application port invoked after channel normalization and identity mapping."""
+
+    @abstractmethod
+    async def handle(
+        self,
+        message: ChannelIncomingMessage,
+        identity: ResolvedChannelIdentity,
+    ) -> ChannelHandlerResult:
+        """Invoke application use cases without depending on a provider SDK."""
+        raise NotImplementedError

--- a/arclith/domain/ports/outbound/__init__.py
+++ b/arclith/domain/ports/outbound/__init__.py
@@ -1,1 +1,11 @@
+from arclith.domain.ports.outbound.channel import (
+    ChannelEventStore,
+    ChannelIdentityResolver,
+    ChannelSender,
+)
 
+__all__ = [
+    "ChannelEventStore",
+    "ChannelIdentityResolver",
+    "ChannelSender",
+]

--- a/arclith/domain/ports/outbound/channel.py
+++ b/arclith/domain/ports/outbound/channel.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from arclith.domain.models.channel import (
+    ChannelDeliveryReceipt,
+    ChannelIdentity,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+
+
+class ChannelIdentityResolver(ABC):
+    """Map untrusted provider identities to application user and tenant IDs."""
+
+    @abstractmethod
+    async def resolve(self, identity: ChannelIdentity) -> ResolvedChannelIdentity:
+        raise NotImplementedError
+
+
+class ChannelEventStore(ABC):
+    """Atomically reserve provider events so concurrent retries run only once."""
+
+    @abstractmethod
+    async def claim(
+        self,
+        provider: str,
+        event_id: str,
+        *,
+        ttl_seconds: int,
+    ) -> bool:
+        """Return true only for the caller that atomically reserves the event."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def release(self, provider: str, event_id: str) -> None:
+        """Release a failed pre-dispatch reservation so the provider can retry."""
+        raise NotImplementedError
+
+
+class ChannelSender(ABC):
+    """Outbound port for sending provider-neutral channel responses."""
+
+    async def close(self) -> None:
+        """Release owned provider resources when the adapter has any."""
+        return None
+
+    @abstractmethod
+    async def send(self, message: ChannelOutgoingMessage) -> ChannelDeliveryReceipt:
+        raise NotImplementedError

--- a/arclith/domain/ports/outbound/vector_store.py
+++ b/arclith/domain/ports/outbound/vector_store.py
@@ -13,6 +13,8 @@ from pydantic import (
     field_validator,
 )
 
+from arclith.domain.models.json import validate_finite_json
+
 
 class VectorStoreError(Exception):
     """Base error exposed by vector-store adapters."""
@@ -53,18 +55,6 @@ class _VectorModel(_VectorStoreModel):
         return value
 
 
-def _validate_finite_json(value: JsonValue) -> JsonValue:
-    if isinstance(value, float) and not math.isfinite(value):
-        raise ValueError("JSON numeric values must be finite")
-    if isinstance(value, list):
-        for item in value:
-            _validate_finite_json(item)
-    elif isinstance(value, dict):
-        for item in value.values():
-            _validate_finite_json(item)
-    return value
-
-
 class VectorPoint(_VectorModel):
     """Provider-neutral vector and its JSON search projection."""
 
@@ -84,7 +74,7 @@ class VectorPoint(_VectorModel):
     def payload_must_be_strict_json(
         cls, value: dict[str, JsonValue]
     ) -> dict[str, JsonValue]:
-        _validate_finite_json(value)
+        validate_finite_json(value)
         return value
 
 
@@ -102,7 +92,7 @@ class VectorSearchQuery(_VectorModel):
     def filters_must_be_strict_json(
         cls, value: dict[str, JsonValue]
     ) -> dict[str, JsonValue]:
-        _validate_finite_json(value)
+        validate_finite_json(value)
         return value
 
     @field_validator("score_threshold")
@@ -134,7 +124,7 @@ class VectorSearchHit(_VectorStoreModel):
     def payload_must_be_strict_json(
         cls, value: dict[str, JsonValue]
     ) -> dict[str, JsonValue]:
-        _validate_finite_json(value)
+        validate_finite_json(value)
         return value
 
     @field_validator("score")

--- a/arclith/infrastructure/channel_factory.py
+++ b/arclith/infrastructure/channel_factory.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from arclith.domain.ports.outbound.channel import ChannelSender
+from arclith.domain.ports.outbound.logger import Logger
+from arclith.infrastructure.config import AppConfig
+
+ChannelSenderFactory = Callable[[AppConfig, Logger], ChannelSender]
+
+
+class ChannelSenderRegistry:
+    """Registry mapping channel adapter names to outbound sender factories."""
+
+    def __init__(self) -> None:
+        self._factories: dict[str, ChannelSenderFactory] = {}
+
+    def register(
+        self,
+        name: str,
+        factory: ChannelSenderFactory,
+    ) -> "ChannelSenderRegistry":
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("Channel adapter name must not be empty")
+        self._factories[normalized] = factory
+        return self
+
+    def build(
+        self,
+        adapter: str,
+        config: AppConfig,
+        logger: Logger,
+    ) -> ChannelSender:
+        if adapter not in self._factories:
+            raise ValueError(
+                f"Channel adapter '{adapter}' not registered. "
+                f"Available: {sorted(self._factories)}."
+            )
+        return self._factories[adapter](config, logger)
+
+
+def build_channel_sender(
+    config: AppConfig,
+    logger: Logger,
+    adapter: str,
+    *,
+    registry: ChannelSenderRegistry | None = None,
+) -> ChannelSender:
+    """Build one explicitly selected channel sender."""
+
+    normalized = adapter.strip()
+    if not normalized:
+        raise ValueError("Channel adapter name must not be empty")
+    active_registry = registry or default_channel_sender_registry()
+    return active_registry.build(normalized, config, logger)
+
+
+def default_channel_sender_registry() -> ChannelSenderRegistry:
+    return ChannelSenderRegistry().register("memory", _build_memory_channel)
+
+
+def _build_memory_channel(config: AppConfig, _logger: Logger) -> ChannelSender:
+    settings = config.adapters.channel.memory
+    if settings is None or not settings.enabled:
+        raise ValueError(
+            "adapters.channel.memory.enabled=true is required to build "
+            "the memory channel adapter"
+        )
+    from arclith.adapters.bidirectional.memory import MemoryChannel
+
+    return MemoryChannel()

--- a/arclith/infrastructure/config.py
+++ b/arclith/infrastructure/config.py
@@ -11,6 +11,7 @@ from arclith.infrastructure.settings import (  # noqa: F401
     AppSettings,
     CacheControlSettings,
     CacheSettings,
+    ChannelSettings,
     CommandBusAdapter,
     CommandBusSettings,
     DuckDBSettings,
@@ -36,6 +37,7 @@ from arclith.infrastructure.settings import (  # noqa: F401
     LicenseSettings,
     LMSettings,
     MariaDBSettings,
+    MemoryChannelSettings,
     McpSettings,
     MongoDBSettings,
     ObservabilityAdapter,
@@ -77,6 +79,7 @@ def _resolve_key_path(rel: Path) -> list[str]:
       config/adapters/adapters.yaml        → ["adapters"]
       config/adapters/outbound/<name>.yaml → ["adapters", "<name>"]
       config/adapters/inbound/<name>.yaml  → ["<alias>"] or ["<name>"]
+      config/adapters/bidirectional/<name>.yaml → ["adapters", "channel", "<name>"]
       config/<name>.yaml                   → ["<name>"]
     """
     parts = rel.with_suffix("").parts
@@ -91,12 +94,14 @@ def _resolve_key_path(rel: Path) -> list[str]:
             return ["adapters"]
         return []
 
-    # Three levels: config/adapters/{outbound|inbound}/<name>.yaml
+    # Three levels: config/adapters/{outbound|inbound|bidirectional}/<name>.yaml
     if len(parts) == 3 and parts[0] == "adapters":
         if parts[1] == "outbound":
             return ["adapters", parts[2]]
         if parts[1] == "inbound":
             return [_INBOUND_ALIAS.get(parts[2], parts[2])]
+        if parts[1] == "bidirectional":
+            return ["adapters", "channel", parts[2]]
 
     return []
 

--- a/arclith/infrastructure/project_layout.py
+++ b/arclith/infrastructure/project_layout.py
@@ -35,6 +35,7 @@ class ProjectLayout:
     adapters: PurePosixPath = field(init=False)
     inbound_adapters: PurePosixPath = field(init=False)
     outbound_adapters: PurePosixPath = field(init=False)
+    bidirectional_adapters: PurePosixPath = field(init=False)
     infrastructure: PurePosixPath = field(init=False)
 
     def __post_init__(self) -> None:
@@ -51,8 +52,12 @@ class ProjectLayout:
         object.__setattr__(self, "domain", package_root / "domain")
         object.__setattr__(self, "domain_models", package_root / "domain" / "models")
         object.__setattr__(self, "domain_ports", package_root / "domain" / "ports")
-        object.__setattr__(self, "inbound_ports", package_root / "domain" / "ports" / "inbound")
-        object.__setattr__(self, "outbound_ports", package_root / "domain" / "ports" / "outbound")
+        object.__setattr__(
+            self, "inbound_ports", package_root / "domain" / "ports" / "inbound"
+        )
+        object.__setattr__(
+            self, "outbound_ports", package_root / "domain" / "ports" / "outbound"
+        )
         object.__setattr__(self, "application", package_root / "application")
         object.__setattr__(
             self,
@@ -65,8 +70,17 @@ class ProjectLayout:
             package_root / "application" / "services",
         )
         object.__setattr__(self, "adapters", package_root / "adapters")
-        object.__setattr__(self, "inbound_adapters", package_root / "adapters" / "inbound")
-        object.__setattr__(self, "outbound_adapters", package_root / "adapters" / "outbound")
+        object.__setattr__(
+            self, "inbound_adapters", package_root / "adapters" / "inbound"
+        )
+        object.__setattr__(
+            self, "outbound_adapters", package_root / "adapters" / "outbound"
+        )
+        object.__setattr__(
+            self,
+            "bidirectional_adapters",
+            package_root / "adapters" / "bidirectional",
+        )
         object.__setattr__(self, "infrastructure", package_root / "infrastructure")
 
     @classmethod
@@ -110,10 +124,11 @@ class ProjectLayout:
         }
 
     def adapter_paths(self) -> dict[str, PurePosixPath]:
-        """Return canonical inbound/outbound adapter folders."""
+        """Return canonical inbound/outbound/bidirectional adapter folders."""
         return {
             "inbound": self.inbound_adapters,
             "outbound": self.outbound_adapters,
+            "bidirectional": self.bidirectional_adapters,
         }
 
     def package_paths(self) -> tuple[PurePosixPath, ...]:

--- a/arclith/infrastructure/settings/__init__.py
+++ b/arclith/infrastructure/settings/__init__.py
@@ -18,6 +18,10 @@ from arclith.infrastructure.settings.app import (
     SoftDeleteSettings,
     TenantSettings,
 )
+from arclith.infrastructure.settings.channel import (
+    ChannelSettings,
+    MemoryChannelSettings,
+)
 from arclith.infrastructure.settings.langgraph import (
     LangGraphCheckpointerSettings,
     LangGraphPersistenceSettings,
@@ -84,6 +88,7 @@ __all__ = [
     "AppSettings",
     "CacheControlSettings",
     "CacheSettings",
+    "ChannelSettings",
     "CommandBusAdapter",
     "CommandBusSettings",
     "DuckDBSettings",
@@ -109,6 +114,7 @@ __all__ = [
     "LangSmithTracingSettings",
     "LicenseSettings",
     "MariaDBSettings",
+    "MemoryChannelSettings",
     "McpSettings",
     "MongoDBSettings",
     "ObservabilityAdapter",

--- a/arclith/infrastructure/settings/app.py
+++ b/arclith/infrastructure/settings/app.py
@@ -6,6 +6,7 @@ from pydantic import Field, field_validator, model_validator
 
 from arclith.infrastructure.settings._base import SettingsModel
 
+from arclith.infrastructure.settings.channel import ChannelSettings
 from arclith.infrastructure.settings.embedding import EmbeddingSettings
 from arclith.infrastructure.settings.langgraph import LangGraphSettings
 from arclith.infrastructure.settings.langsmith import LangSmithSettings
@@ -60,6 +61,7 @@ class AdaptersSettings(SettingsModel):
     storage: StorageSettings | None = None
     embedding: EmbeddingSettings | None = None
     vector_store: VectorStoreSettings | None = None
+    channel: ChannelSettings = Field(default_factory=ChannelSettings)
     lm: LMSettings | None = None
     langsmith: LangSmithSettings | None = None
     opentelemetry: OpenTelemetrySettings | None = None

--- a/arclith/infrastructure/settings/channel.py
+++ b/arclith/infrastructure/settings/channel.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from arclith.infrastructure.settings._base import SettingsModel
+
+
+class MemoryChannelSettings(SettingsModel):
+    """Dependency-free channel adapter settings for tests and local POCs."""
+
+    enabled: bool = True
+
+
+class ChannelSettings(SettingsModel):
+    """Configuration sections for provider-neutral channel adapters."""
+
+    memory: MemoryChannelSettings | None = None
+
+    def configured_adapters(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in ("memory",)
+            if (settings := getattr(self, name)) is not None and settings.enabled
+        )

--- a/cli/arclith_cli/capabilities.py
+++ b/cli/arclith_cli/capabilities.py
@@ -19,6 +19,7 @@ from arclith_cli.catalogs.ai import (
     EMBEDDING_CAPABILITY,
     LLM_CAPABILITY,
 )
+from arclith_cli.catalogs.channels import CHANNEL_CAPABILITY
 from arclith_cli.catalogs.core import (
     CACHE_CAPABILITY,
     LOGGER_CAPABILITY,
@@ -53,6 +54,7 @@ __all__ = [
     "AdapterProfileSpec",
     "AdapterSpec",
     "CACHE_CAPABILITY",
+    "CHANNEL_CAPABILITY",
     "CAPABILITY_CATALOG",
     "COMMAND_BUS_CAPABILITY",
     "CapabilitySpec",
@@ -93,6 +95,7 @@ CAPABILITY_CATALOG = (
     PROBE_CAPABILITY,
     HTTP_CAPABILITY,
     COMMAND_BUS_CAPABILITY,
+    CHANNEL_CAPABILITY,
     RUNTIME_CAPABILITY,
     AUTH_CAPABILITY,
     TENANT_CAPABILITY,

--- a/cli/arclith_cli/catalogs/channels.py
+++ b/cli/arclith_cli/catalogs/channels.py
@@ -1,0 +1,23 @@
+from arclith_cli.capability_models import AdapterSpec, CapabilitySpec
+
+CHANNEL_CAPABILITY = CapabilitySpec(
+    name="channel",
+    layer="bidirectional",
+    description="Messages conversationnels entrants et sortants normalisés.",
+    activation_config_key=None,
+    adapters=(
+        AdapterSpec(
+            name="memory",
+            capability="channel",
+            layer="bidirectional",
+            description="Fake déterministe en mémoire pour tests et prototypes locaux.",
+            config_path="config/adapters/bidirectional/memory.yaml",
+            config_template="""\
+enabled: true
+""",
+            entity_scoped=False,
+        ),
+    ),
+)
+
+__all__ = ["CHANNEL_CAPABILITY"]

--- a/cli/arclith_cli/project_paths.py
+++ b/cli/arclith_cli/project_paths.py
@@ -33,6 +33,10 @@ class ProjectPaths:
         return self.package_root / "adapters" / "inbound"
 
     @property
+    def adapters_bidirectional(self) -> Path:
+        return self.package_root / "adapters" / "bidirectional"
+
+    @property
     def containers(self) -> Path:
         return self.package_root / "infrastructure" / "containers"
 
@@ -52,7 +56,11 @@ def detect_project_paths(project_dir: Path) -> ProjectPaths:
         )
         if model_candidates:
             package_root = model_candidates[0]
-            return ProjectPaths(root=project_dir, package_root=package_root, package_name=package_root.name)
+            return ProjectPaths(
+                root=project_dir,
+                package_root=package_root,
+                package_name=package_root.name,
+            )
 
         package_candidates = sorted(
             child
@@ -61,7 +69,11 @@ def detect_project_paths(project_dir: Path) -> ProjectPaths:
         )
         if package_candidates:
             package_root = package_candidates[0]
-            return ProjectPaths(root=project_dir, package_root=package_root, package_name=package_root.name)
+            return ProjectPaths(
+                root=project_dir,
+                package_root=package_root,
+                package_name=package_root.name,
+            )
 
     return ProjectPaths(root=project_dir, package_root=project_dir, package_name=None)
 
@@ -70,4 +82,7 @@ def _looks_like_package_root(path: Path) -> bool:
     if (path / "__init__.py").exists():
         return True
 
-    return any((path / layer).is_dir() for layer in ("domain", "application", "adapters", "infrastructure"))
+    return any(
+        (path / layer).is_dir()
+        for layer in ("domain", "application", "adapters", "infrastructure")
+    )

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -1032,6 +1032,32 @@ def test_add_command_bus_rabbitmq_adapter_rejects_unbounded_prefetch(
     assert not command_bus_path.exists()
 
 
+def test_add_memory_channel_generates_loadable_bidirectional_config(
+    tmp_path: Path,
+) -> None:
+    project_dir = _minimal_project(tmp_path)
+
+    for _ in range(2):
+        add_adapter_cmd(
+            project_dir=project_dir,
+            capability_name="channel",
+            adapter="memory",
+            yes=True,
+        )
+
+    from arclith import Arclith, MemoryChannel
+
+    config_path = project_dir / "config" / "adapters" / "bidirectional" / "memory.yaml"
+    app = Arclith(project_dir / "config")
+
+    assert config_path.read_text(encoding="utf-8") == "enabled: true\n"
+    assert app.config.adapters.channel.configured_adapters() == ("memory",)
+    assert isinstance(app.channel_sender("memory"), MemoryChannel)
+    assert not (
+        project_dir / "src" / "demo_service" / "adapters" / "bidirectional" / "memory"
+    ).exists()
+
+
 def test_add_keycloak_auth_adapter_generates_loadable_inbound_config(
     tmp_path: Path,
 ) -> None:

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -391,6 +391,22 @@ def test_command_bus_capability_catalog_declares_rabbitmq() -> None:
     ]
 
 
+def test_channel_capability_catalog_declares_memory_adapter() -> None:
+    capability = get_capability("channel")
+
+    assert capability is not None
+    assert capability.layer == "bidirectional"
+    assert capability.activation_config_key is None
+    assert capability.adapter_names() == ("memory",)
+    memory = capability.get_adapter("memory")
+    assert memory is not None
+    assert memory.layer == "bidirectional"
+    assert memory.config_path == "config/adapters/bidirectional/memory.yaml"
+    assert memory.dependency_extra is None
+    assert memory.entity_scoped is False
+    assert memory.parameters == ()
+
+
 def test_runtime_capability_catalog_declares_docker_image() -> None:
     capability = get_capability("runtime")
 
@@ -979,6 +995,14 @@ def test_capabilities_command_outputs_json_catalog() -> None:
         "dead_letter_exchange",
         "dead_letter_routing_key",
     ]
+    channel = payload_by_name["channel"]
+    assert channel["layer"] == "bidirectional"
+    assert [adapter["name"] for adapter in channel["adapters"]] == ["memory"]
+    memory_channel = channel["adapters"][0]
+    assert memory_channel["config_path"] == (
+        "config/adapters/bidirectional/memory.yaml"
+    )
+    assert memory_channel["dependency_extra"] is None
     runtime = payload_by_name["runtime"]
     assert runtime["layer"] == "runtime"
     assert [adapter["name"] for adapter in runtime["adapters"]] == ["docker-image"]

--- a/cli/tests/test_project_paths.py
+++ b/cli/tests/test_project_paths.py
@@ -14,6 +14,7 @@ def test_detect_project_paths_uses_src_package(tmp_path: Path):
     assert paths.domain_models == package_root / "domain" / "models"
     assert paths.application_use_cases == package_root / "application" / "use_cases"
     assert paths.adapters_outbound == package_root / "adapters" / "outbound"
+    assert paths.adapters_bidirectional == package_root / "adapters" / "bidirectional"
     assert paths.containers == package_root / "infrastructure" / "containers"
     assert paths.import_path("domain", "models", "recipe") == "my_service.domain.models.recipe"
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -40,6 +40,7 @@ arclith-cli capabilities --json
 | [vector-store](capabilities/vector-store.md) | outbound | `memory` | indexer et rechercher des projections vectorielles |
 | [observability](capabilities/observability.md) ([OpenTelemetry](capabilities/opentelemetry.md)) | outbound | `langsmith`, `opentelemetry` | traces, métriques, logs et agents |
 | [command-bus](capabilities/command-bus.md) | bidirectional | `rabbitmq` | consommer et publier des commandes |
+| [channel](capabilities/channel.md) | bidirectional | `memory` | normaliser une conversation, résoudre son identité et dédupliquer les événements |
 | [runtime](capabilities/runtime.md) | runtime | `docker-image` | générer le runtime conteneur |
 
 ## Parcours Fréquents
@@ -49,6 +50,7 @@ arclith-cli capabilities --json
 | API minimale | [Quickstart API](quickstarts/api.md), [formation API](tutorials/todo-list/04-api.md), puis [api/fastapi](capabilities/api.md) |
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |
+| Canal conversationnel | [Quickstart Channel](quickstarts/channel.md), puis [contrat channel](capabilities/channel.md) |
 | Agent local | [Quickstart Agent](quickstarts/agent.md), [formation agent](tutorials/todo-list/06-agent.md), puis [agent/langgraph](capabilities/agent.md) et [persistance](capabilities/agent-persistence.md) |
 | Pipeline RAG local | [embedding](capabilities/embedding.md) pour calculer les vecteurs, puis [vector-store](capabilities/vector-store.md) pour les indexer |
 | Observabilité locale | [OpenTelemetry de bout en bout](capabilities/opentelemetry.md), puis [observabilité production](production/observability.md) |

--- a/docs/capabilities/channel.md
+++ b/docs/capabilities/channel.md
@@ -1,0 +1,194 @@
+# Channel
+
+La capability bidirectionnelle `channel` relie une messagerie externe à un
+handler applicatif sans faire dépendre le domaine de son protocole ou de son
+SDK. Elle normalise les messages entrants et sortants, résout explicitement
+l'identité externe et déduplique les événements avant leur traitement.
+
+## Intention
+
+Utiliser `channel` pour recevoir une conversation depuis un webhook ou un
+fournisseur de messagerie, appeler les use cases du service, puis renvoyer une
+ou plusieurs réponses. Le contrat ne remplace ni un bus de commandes entre
+services, ni une file de travaux durables.
+
+## Position Hexagonale
+
+```text
+requête fournisseur
+  -> adapter bidirectionnel (authentifie et normalise)
+  -> ChannelDispatcher
+       -> ChannelEventStore.claim()
+       -> ChannelIdentityResolver.resolve()
+       -> ChannelMessageHandler.handle()
+       -> ChannelSender.send()
+  -> accusé de réception fournisseur
+```
+
+Le domaine ne connaît ni FastAPI, ni Slack, ni un format de signature. Un
+adapter fournisseur transforme son payload en `ChannelIncomingMessage` et
+traduit le résultat du dispatcher vers le statut de transport approprié.
+
+## Quickstart
+
+Le [quickstart Channel](../quickstarts/channel.md) exécute le flux complet avec
+l'adapter mémoire, sans compte externe ni dépendance optionnelle.
+
+## Formation
+
+Il n'existe pas encore de chapitre Channel dans le parcours Todo. Le quickstart
+montre le wiring minimal ; les adapters webhook et Slack documenteront ensuite
+leurs gestes de sécurité et de déploiement propres.
+
+## Contrat
+
+### Modèles
+
+| Type | Rôle |
+|---|---|
+| `ChannelIdentity` | identité externe affirmée par le fournisseur, encore non fiable pour l'application |
+| `ResolvedChannelIdentity` | utilisateur et tenant applicatifs obtenus par mapping explicite |
+| `ChannelIncomingMessage` | événement normalisé avec conversation, thread, texte ou pièces jointes |
+| `ChannelOutgoingMessage` | réponse provider-neutral destinée au même canal ou à une autre conversation |
+| `ChannelDeliveryReceipt` | résultat normalisé d'un envoi |
+| `ChannelHandlerResult` | résultat synchrone (`completed`) ou prise en charge différée (`accepted`) |
+| `ChannelDispatchResult` | résultat final `completed`, `accepted` ou `duplicate` |
+
+Les modèles Pydantic sont stricts, immuables et refusent les champs inconnus.
+Les timestamps doivent être timezone-aware et sont normalisés en UTC. Une pièce
+jointe transporte une URL HTTP(S) sans credentials, query ou fragment, ou une
+clé relative de la capability `storage`, jamais les octets ni un chemin absolu.
+Les dictionnaires
+`metadata` n'acceptent que des valeurs JSON ; chaque adapter doit en plus
+n'y copier que sa liste blanche documentée.
+
+### Ports
+
+```python
+from arclith import (
+    ChannelEventStore,
+    ChannelIdentityResolver,
+    ChannelMessageHandler,
+    ChannelSender,
+)
+```
+
+- `ChannelMessageHandler` est le port inbound implémenté par l'application ;
+- `ChannelIdentityResolver` interdit de traiter directement un identifiant
+  fournisseur comme un identifiant métier ;
+- `ChannelEventStore.claim()` réserve atomiquement `(provider, event_id)` avant
+  tout appel applicatif ;
+- `ChannelSender` envoie un `ChannelOutgoingMessage` et retourne un receipt.
+
+`ChannelDispatcher` libère la réservation si la résolution d'identité ou le
+handler échoue, afin qu'un retry puisse reprendre. Après un traitement
+applicatif réussi, la réservation est conservée même si l'envoi de la réponse
+échoue : rejouer automatiquement le handler pourrait dupliquer ses effets
+métier. La reprise d'un envoi sortant doit donc être conçue séparément par le
+service lorsque cette garantie est nécessaire.
+
+### Erreurs
+
+Les adapters exposent des erreurs communes :
+
+- `InvalidChannelSignature` ;
+- `ChannelUnauthorized` ;
+- `UnsupportedChannelEvent` ;
+- `ChannelIdentityNotResolved` ;
+- `ChannelRateLimited`, avec un éventuel `retry_after_seconds` ;
+- `ChannelDeliveryFailed` ;
+- `ChannelUnavailable`.
+
+Les erreurs ou payloads ne doivent jamais inclure de signature, token, contenu
+de secret ou URL contenant des credentials.
+
+## Adapters
+
+| Adapter | Usage | Durable | Multi-processus | Production |
+|---|---|---:|---:|---:|
+| `memory` | tests, exemples et prototypes locaux | non | non | non |
+| `webhook` | HTTP signé générique | selon le store injecté | selon le store | prévu par #170 |
+| `slack` | Slack Events API et réponses | selon le store injecté | selon le store | prévu par #171 |
+
+Le catalogue CLI ne propose actuellement que `memory`. Les lignes `webhook` et
+`slack` décrivent la trajectoire active ; elles ne sont pas encore installables
+tant que leurs issues ne sont pas livrées. Telegram, Email et Teams restent hors
+du périmètre actuel.
+
+```bash
+uvx --from arclith-cli arclith-cli add-adapter \
+  --capability channel \
+  --adapter memory \
+  --yes
+```
+
+La commande crée de façon idempotente :
+
+```yaml
+# config/adapters/bidirectional/memory.yaml
+enabled: true
+```
+
+La configuration est chargée sous `adapters.channel.memory`. Le layout
+canonique réserve `src/<package>/adapters/bidirectional/` aux adapters qui
+assurent à la fois réception et envoi.
+
+## Production
+
+L'adapter mémoire conserve claims et messages dans un seul processus. Un
+redémarrage oublie tout et plusieurs replicas ne partagent aucun état. Il ne
+doit donc pas assurer l'idempotence d'un endpoint public.
+
+Un adapter de production doit :
+
+1. authentifier le corps brut avant parsing ;
+2. borner la fraîcheur de la requête et résister au rejeu ;
+3. utiliser un claim atomique partagé entre replicas ;
+4. répondre dans le délai imposé par le fournisseur ;
+5. mapper explicitement l'identité externe ;
+6. limiter la taille du payload et des pièces jointes ;
+7. appliquer timeout, backoff et `Retry-After` aux envois ;
+8. journaliser uniquement IDs techniques, statuts et corrélation à cardinalité
+   bornée.
+
+`accepted` signifie que le service a durablement pris en charge le travail. Un
+adapter ne doit donc pas renvoyer ce statut avant d'avoir réellement persisté
+ou publié la suite du traitement.
+
+## Validation
+
+```bash
+uv run pytest -q \
+  tests/units/domain/models/test_channel.py \
+  tests/units/application/test_channel.py \
+  tests/units/adapters/bidirectional/memory/test_channel.py \
+  tests/units/infrastructure/test_channel_factory.py
+
+cd cli
+uv run --frozen pytest -q \
+  tests/test_capabilities.py \
+  tests/test_add_adapter.py
+```
+
+Vérifier aussi `make coverage`, `make precommit` et `make docs` avant livraison.
+
+## Troubleshooting
+
+| Symptôme | Cause probable | Action |
+|---|---|---|
+| `ChannelIdentityNotResolved` | aucun mapping exact pour l'identité externe | enregistrer ou injecter le mapping applicatif attendu |
+| résultat `duplicate` au premier essai visible | l'ID fournisseur a déjà été claim, éventuellement par un autre replica | corréler avec `provider_event_id` et inspecter le store partagé |
+| `adapters.channel.memory.enabled=true is required` | fichier absent ou adapter désactivé | générer `channel/memory` ou corriger le YAML scoped |
+| effets métier répétés | claim non atomique ou ID d'événement instable | corriger le `ChannelEventStore` et utiliser l'ID immuable du fournisseur |
+| réponse non rejouée après erreur d'envoi | le handler a déjà réussi et le claim est conservé | utiliser un outbox ou une file outbound dédiée |
+
+## Projet
+
+Dans un service consommateur, garder l'implémentation de
+`ChannelMessageHandler` dans `application/`, le resolver et le store partagés
+dans des adapters outbound adaptés au déploiement, et le parsing HTTP/SDK dans
+`adapters/bidirectional/<provider>/`. Aucun appel HTTP fournisseur ne doit
+partir de `domain/`.
+
+La suite active est le [webhook générique](https://github.com/karned-rekipe/arclith/issues/170),
+puis [Slack Events API](https://github.com/karned-rekipe/arclith/issues/171).

--- a/docs/quickstarts/channel.md
+++ b/docs/quickstarts/channel.md
@@ -1,0 +1,119 @@
+# Quickstart Channel
+
+Ajouter le fake mémoire et vérifier un message entrant, sa résolution
+d'identité et sa réponse, sans service externe.
+
+## Prérequis
+
+- Python 3.13 ;
+- `uv`.
+
+## Ajouter La Capability
+
+Depuis un projet Arclith existant :
+
+```bash
+uvx --from arclith-cli arclith-cli add-adapter \
+  --capability channel \
+  --adapter memory \
+  --yes
+```
+
+La commande crée `config/adapters/bidirectional/memory.yaml`.
+
+## Exécuter Le Flux
+
+```bash
+uv run python - <<'PY'
+import asyncio
+
+from arclith import (
+    ChannelDispatcher,
+    ChannelHandlerResult,
+    ChannelIdentity,
+    ChannelIncomingMessage,
+    ChannelMessageHandler,
+    ChannelOutgoingMessage,
+    MemoryChannel,
+    MemoryChannelIdentityResolver,
+    ResolvedChannelIdentity,
+)
+
+
+class EchoHandler(ChannelMessageHandler):
+    async def handle(self, message, identity):
+        return ChannelHandlerResult(
+            responses=(
+                ChannelOutgoingMessage(
+                    channel=message.channel,
+                    conversation_id=message.conversation_id,
+                    thread_id=message.thread_id,
+                    text=f"Reçu pour {identity.user_id}: {message.text}",
+                ),
+            )
+        )
+
+
+async def main():
+    external = ChannelIdentity(
+        provider="memory",
+        external_user_id="external-42",
+    )
+    resolver = MemoryChannelIdentityResolver()
+    resolver.register(
+        external,
+        ResolvedChannelIdentity(user_id="user-42", tenant_id="tenant-demo"),
+    )
+    channel = MemoryChannel()
+    dispatcher = ChannelDispatcher(EchoHandler(), resolver, channel, channel)
+
+    message = ChannelIncomingMessage(
+        channel="memory",
+        provider_event_id="event-1",
+        conversation_id="conversation-1",
+        sender=external,
+        text="bonjour",
+    )
+    result = await dispatcher.dispatch(message)
+    duplicate = await dispatcher.dispatch(message)
+
+    assert result.status == "completed"
+    assert result.identity.user_id == "user-42"
+    assert result.receipts[0].status == "delivered"
+    assert channel.sent_messages[0].text == "Reçu pour user-42: bonjour"
+    assert duplicate.status == "duplicate"
+    print("channel memory: OK")
+
+
+asyncio.run(main())
+PY
+```
+
+## Valider Le Bootstrap
+
+```bash
+uv run python - <<'PY'
+from arclith import Arclith, MemoryChannel
+
+app = Arclith("config")
+assert app.config.adapters.channel.configured_adapters() == ("memory",)
+assert isinstance(app.channel_sender("memory"), MemoryChannel)
+print("channel config: OK")
+PY
+```
+
+## Résultat
+
+Le premier dispatch appelle le handler et enregistre une réponse. Le second
+retourne `duplicate` sans rappeler l'application.
+
+## Limite
+
+Le fake mémoire est mono-processus et non durable. Pour un endpoint public,
+injecter un `ChannelEventStore` atomique partagé et suivre les exigences de la
+[capability Channel](../capabilities/channel.md).
+
+## Suite
+
+Lire la [référence Channel](../capabilities/channel.md), puis le
+[webhook générique](https://github.com/karned-rekipe/arclith/issues/170).

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -11,7 +11,7 @@ rapide en tutoriel complet.
       <h2 id="quickstarts-choose-title">Un flux, un objectif de validation</h2>
       <p>
         Commence par l'API pour voir le service tourner, puis ajoute les
-        surfaces dont ton projet a besoin : MCP, bus RabbitMQ ou agent LangGraph.
+        surfaces dont ton projet a besoin : MCP, bus RabbitMQ, canal conversationnel ou agent LangGraph.
       </p>
     </div>
 
@@ -43,6 +43,13 @@ rapide en tutoriel complet.
         <strong>Préparer LangGraph</strong>
         <p>Ajouter l'adapter agent, générer <code>langgraph.json</code> et tester l'Agent Server local.</p>
       </a>
+
+      <a class="academy-card" href="channel/">
+        <img src="../assets/academy/reference.png" alt="" decoding="async" loading="lazy" />
+        <span class="academy-card__kicker">Channel</span>
+        <strong>Tester une conversation</strong>
+        <p>Normaliser un message, résoudre son identité, répondre et vérifier la déduplication avec le fake mémoire.</p>
+      </a>
     </div>
   </section>
 
@@ -60,7 +67,8 @@ rapide en tutoriel complet.
       <a href="api/">1. API locale</a>
       <a href="mcp/">2. MCP HTTP</a>
       <a href="bus/">3. Bus RabbitMQ</a>
-      <a href="agent/">4. Agent LangGraph</a>
+      <a href="channel/">4. Channel mémoire</a>
+      <a href="agent/">5. Agent LangGraph</a>
       <a href="../learning/local-ai-validation/">Validation IA locale</a>
       <a href="../tutorials/todo-list/">Projet Todo complet</a>
     </div>

--- a/journal/2026-09-04-channel-contract.md
+++ b/journal/2026-09-04-channel-contract.md
@@ -1,0 +1,47 @@
+# Contrat Channel Provider-Neutral
+
+## Contexte
+
+L'issue #169 prépare des canaux conversationnels bidirectionnels sans lier les
+services Arclith à un fournisseur. Le premier incrément doit rendre le contrat
+testable et découvrable avant les adapters webhook (#170) et Slack (#171).
+Telegram, Email et Teams restent au backlog.
+
+## Décisions
+
+- séparer l'identité externe de l'identité utilisateur/tenant résolue ;
+- réserver atomiquement chaque couple `(provider, event_id)` avant le handler ;
+- libérer la réservation après une erreur de résolution ou de handler, mais la
+  conserver après un traitement métier réussi pour ne pas rejouer ses effets ;
+- garder le contrat indépendant du transport et traduire les accusés HTTP dans
+  les adapters fournisseurs ;
+- accepter uniquement des métadonnées JSON, ensuite réduites par chaque adapter
+  à une liste blanche documentée ;
+- partager la validation des nombres JSON finis avec le contrat vector-store ;
+- représenter les pièces jointes par une URL HTTP(S) sans credentials ou une
+  clé `storage` relative, sans octets ni chemin absolu ;
+- fournir un fake mémoire mono-processus et un registry de senders extensible ;
+- reconnaître `adapters/bidirectional` dans le layout, le chargeur et le
+  catalogue CLI.
+
+## Impact
+
+Le package principal gagne des modèles, ports, erreurs et un dispatcher sans
+nouvelle dépendance. Les services peuvent implémenter leur mapping d'identité et
+leur store atomique sans modifier le domaine. Le fake mémoire est réservé aux
+tests et POC ; il n'apporte ni durabilité ni coordination multi-replicas.
+
+## Documentation
+
+La page `docs/capabilities/channel.md` décrit le contrat, les garanties et les
+limites de production. `docs/quickstarts/channel.md` fournit un flux exécutable
+et les deux pages sont reliées depuis les index et la navigation MkDocs.
+
+## Validation
+
+- `make precommit` : Ruff, mypy et Bandit passent ;
+- `make coverage` : 1 941 tests passent, 5 intégrations sont ignorées et la
+  couverture atteint 90,94 % ;
+- `cd cli && uv run --frozen pytest -q` : 152 tests passent et 1 est ignoré ;
+- lint CLI, `make docs` strict et vérification des deux lockfiles passent ;
+- le quickstart mémoire et la sortie JSON du catalogue ont été exécutés.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - API: quickstarts/api.md
       - MCP: quickstarts/mcp.md
       - Bus: quickstarts/bus.md
+      - Channel: quickstarts/channel.md
       - Agent: quickstarts/agent.md
   - Foundations:
       - Préparer son poste: learning/setup.md
@@ -56,6 +57,7 @@ nav:
       - Agent: capabilities/agent.md
       - Persistance Agent: capabilities/agent-persistence.md
       - Command Bus: capabilities/command-bus.md
+      - Channel: capabilities/channel.md
       - Probe: capabilities/probe.md
       - Runtime: capabilities/runtime.md
       - Repository: capabilities/repository.md

--- a/tests/units/adapters/bidirectional/memory/test_channel.py
+++ b/tests/units/adapters/bidirectional/memory/test_channel.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from arclith.adapters.bidirectional.memory import (
+    MemoryChannel,
+    MemoryChannelIdentityResolver,
+)
+from arclith.domain.errors.channel import ChannelIdentityNotResolved
+from arclith.domain.models.channel import (
+    ChannelIdentity,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+
+
+def _identity() -> ChannelIdentity:
+    return ChannelIdentity(
+        provider="slack",
+        external_user_id="U123",
+        external_workspace_id="T123",
+    )
+
+
+async def test_memory_identity_resolver_requires_explicit_mapping() -> None:
+    resolver = MemoryChannelIdentityResolver()
+
+    with pytest.raises(ChannelIdentityNotResolved, match="No application mapping"):
+        await resolver.resolve(_identity())
+
+    expected = ResolvedChannelIdentity(user_id="user-1", tenant_id="tenant-a")
+    resolver.register(_identity(), expected)
+
+    assert await resolver.resolve(_identity()) == expected
+
+
+async def test_memory_channel_claim_is_atomic_for_concurrent_retries() -> None:
+    channel = MemoryChannel()
+
+    results = await asyncio.gather(
+        *(channel.claim("slack", "Ev123", ttl_seconds=60) for _ in range(20))
+    )
+
+    assert results.count(True) == 1
+    assert results.count(False) == 19
+
+
+async def test_memory_channel_releases_and_expires_claims() -> None:
+    now = [10.0]
+    channel = MemoryChannel(monotonic_clock=lambda: now[0])
+
+    assert await channel.claim("slack", "Ev123", ttl_seconds=5) is True
+    assert await channel.claim("slack", "Ev123", ttl_seconds=5) is False
+
+    await channel.release("slack", "Ev123")
+    assert await channel.claim("slack", "Ev123", ttl_seconds=5) is True
+
+    now[0] = 15.0
+    assert await channel.claim("slack", "Ev123", ttl_seconds=5) is True
+
+
+async def test_memory_channel_rejects_non_positive_ttl() -> None:
+    with pytest.raises(ValueError, match="greater than zero"):
+        await MemoryChannel().claim("slack", "Ev123", ttl_seconds=0)
+
+
+async def test_memory_channel_records_deterministic_deliveries() -> None:
+    fixed_time = datetime(2026, 9, 4, 10, tzinfo=timezone.utc)
+    channel = MemoryChannel(utc_clock=lambda: fixed_time)
+    first = ChannelOutgoingMessage(
+        message_id="msg-1",
+        channel="slack",
+        conversation_id="C123",
+        text="first",
+    )
+    second = first.model_copy(update={"message_id": "msg-2", "text": "second"})
+
+    first_receipt = await channel.send(first)
+    second_receipt = await channel.send(second)
+    await channel.close()
+
+    assert first_receipt.provider_message_id == "memory-0001"
+    assert second_receipt.provider_message_id == "memory-0002"
+    assert first_receipt.timestamp == fixed_time
+    assert channel.sent_messages == (first, second)
+    assert channel.receipts == (first_receipt, second_receipt)

--- a/tests/units/application/test_channel.py
+++ b/tests/units/application/test_channel.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from arclith.adapters.bidirectional.memory import MemoryChannel
+from arclith.application.channel import ChannelDispatcher
+from arclith.domain.models.channel import (
+    ChannelDeliveryReceipt,
+    ChannelHandlerResult,
+    ChannelIdentity,
+    ChannelIncomingMessage,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+from arclith.domain.ports.inbound.channel import ChannelMessageHandler
+from arclith.domain.ports.outbound.channel import (
+    ChannelIdentityResolver,
+    ChannelSender,
+)
+
+
+class StubIdentityResolver(ChannelIdentityResolver):
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls = 0
+
+    async def resolve(self, identity: ChannelIdentity) -> ResolvedChannelIdentity:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("identity unavailable")
+        return ResolvedChannelIdentity(user_id=f"app-{identity.external_user_id}")
+
+
+class StubHandler(ChannelMessageHandler):
+    def __init__(self, result: ChannelHandlerResult, *, fail: bool = False) -> None:
+        self.result = result
+        self.fail = fail
+        self.calls = 0
+
+    async def handle(
+        self,
+        message: ChannelIncomingMessage,
+        identity: ResolvedChannelIdentity,
+    ) -> ChannelHandlerResult:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("handler failed")
+        assert identity.user_id == "app-U123"
+        return self.result
+
+
+class FailingSender(ChannelSender):
+    async def send(self, message: ChannelOutgoingMessage) -> ChannelDeliveryReceipt:
+        raise RuntimeError("provider failed")
+
+
+def _incoming() -> ChannelIncomingMessage:
+    return ChannelIncomingMessage(
+        channel="slack",
+        provider_event_id="Ev123",
+        conversation_id="C123",
+        sender=ChannelIdentity(provider="slack", external_user_id="U123"),
+        text="ping",
+    )
+
+
+def _response() -> ChannelOutgoingMessage:
+    return ChannelOutgoingMessage(
+        channel="slack",
+        conversation_id="C123",
+        text="pong",
+    )
+
+
+async def test_channel_dispatcher_resolves_handles_and_sends_responses() -> None:
+    memory = MemoryChannel()
+    resolver = StubIdentityResolver()
+    response = _response()
+    handler = StubHandler(ChannelHandlerResult(responses=(response,)))
+    dispatcher = ChannelDispatcher(handler, resolver, memory, memory)
+
+    result = await dispatcher.dispatch(_incoming())
+
+    assert result.status == "completed"
+    assert result.identity == ResolvedChannelIdentity(user_id="app-U123")
+    assert len(result.receipts) == 1
+    assert result.receipts[0].status == "delivered"
+    assert memory.sent_messages == (response,)
+
+
+async def test_channel_dispatcher_returns_accepted_without_sending() -> None:
+    memory = MemoryChannel()
+    handler = StubHandler(ChannelHandlerResult(status="accepted"))
+    dispatcher = ChannelDispatcher(handler, StubIdentityResolver(), memory, memory)
+
+    result = await dispatcher.dispatch(_incoming())
+
+    assert result.status == "accepted"
+    assert result.receipts == ()
+    assert memory.sent_messages == ()
+
+
+async def test_channel_dispatcher_deduplicates_before_application_calls() -> None:
+    memory = MemoryChannel()
+    resolver = StubIdentityResolver()
+    handler = StubHandler(ChannelHandlerResult())
+    dispatcher = ChannelDispatcher(handler, resolver, memory, memory)
+
+    first = await dispatcher.dispatch(_incoming())
+    duplicate = await dispatcher.dispatch(_incoming())
+
+    assert first.status == "completed"
+    assert duplicate.status == "duplicate"
+    assert resolver.calls == 1
+    assert handler.calls == 1
+
+
+@pytest.mark.parametrize("failure", ["identity", "handler"])
+async def test_channel_dispatcher_releases_pre_dispatch_failures(failure: str) -> None:
+    memory = MemoryChannel()
+    resolver = StubIdentityResolver(fail=failure == "identity")
+    handler = StubHandler(ChannelHandlerResult(), fail=failure == "handler")
+    dispatcher = ChannelDispatcher(handler, resolver, memory, memory)
+
+    with pytest.raises(RuntimeError):
+        await dispatcher.dispatch(_incoming())
+
+    resolver.fail = False
+    handler.fail = False
+    result = await dispatcher.dispatch(_incoming())
+    assert result.status == "completed"
+
+
+async def test_channel_dispatcher_keeps_claim_after_outbound_failure() -> None:
+    memory = MemoryChannel()
+    handler = StubHandler(ChannelHandlerResult(responses=(_response(),)))
+    dispatcher = ChannelDispatcher(
+        handler,
+        StubIdentityResolver(),
+        memory,
+        FailingSender(),
+    )
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await dispatcher.dispatch(_incoming())
+
+    assert (await dispatcher.dispatch(_incoming())).status == "duplicate"
+    assert handler.calls == 1
+
+
+def test_channel_dispatcher_requires_positive_event_ttl() -> None:
+    memory = MemoryChannel()
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        ChannelDispatcher(
+            StubHandler(ChannelHandlerResult()),
+            StubIdentityResolver(),
+            memory,
+            memory,
+            event_ttl_seconds=0,
+        )

--- a/tests/units/domain/models/test_channel.py
+++ b/tests/units/domain/models/test_channel.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from arclith.domain.errors.channel import ChannelRateLimited
+from arclith.domain.models.channel import (
+    ChannelAttachment,
+    ChannelDeliveryReceipt,
+    ChannelDispatchResult,
+    ChannelHandlerResult,
+    ChannelIdentity,
+    ChannelIncomingMessage,
+    ChannelOutgoingMessage,
+    ResolvedChannelIdentity,
+)
+
+
+def _identity() -> ChannelIdentity:
+    return ChannelIdentity(provider="slack", external_user_id="U123")
+
+
+def _outgoing() -> ChannelOutgoingMessage:
+    return ChannelOutgoingMessage(
+        channel="slack",
+        conversation_id="C123",
+        text="pong",
+    )
+
+
+def test_channel_attachment_accepts_one_safe_locator() -> None:
+    by_url = ChannelAttachment(
+        kind="image",
+        url="https://files.example.test/a.png",
+        storage_key=None,
+        metadata={"width": 320},
+    )
+    by_key = ChannelAttachment(
+        kind="document",
+        url=None,
+        storage_key="tenant-a/report.pdf",
+    )
+
+    assert by_url.url == "https://files.example.test/a.png"
+    assert by_key.storage_key == "tenant-a/report.pdf"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"kind": "image"},
+        {
+            "kind": "image",
+            "url": "https://files.example.test/a.png",
+            "storage_key": "a.png",
+        },
+        {"kind": "image", "url": "file:///tmp/a.png"},
+        {"kind": "image", "url": "https://user:secret@example.test/a.png"},
+        {"kind": "image", "url": "https://example.test/a.png?token=secret"},
+        {"kind": "image", "storage_key": "../secret.txt"},
+        {"kind": "image", "storage_key": "/absolute/path"},
+        {"kind": "image", "storage_key": "C:/absolute/path"},
+    ],
+)
+def test_channel_attachment_rejects_unsafe_or_ambiguous_locator(
+    values: dict[str, str],
+) -> None:
+    with pytest.raises(ValidationError):
+        ChannelAttachment.model_validate(values)
+
+
+def test_channel_incoming_message_normalizes_aware_timestamps_to_utc() -> None:
+    message = ChannelIncomingMessage(
+        channel="slack",
+        provider_event_id="Ev123",
+        conversation_id="C123",
+        sender=_identity(),
+        text="hello",
+        received_at=datetime(2026, 9, 4, 12, tzinfo=timezone(timedelta(hours=2))),
+        metadata={"retry": False, "attempt": 1},
+    )
+
+    assert message.received_at == datetime(2026, 9, 4, 10, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"text": " "}, "blank"),
+        ({"text": None}, "text or attachments"),
+        ({"channel": "webhook"}, "sender.provider"),
+        ({"received_at": datetime(2026, 9, 4, 10)}, "timezone-aware"),
+    ],
+)
+def test_channel_incoming_message_rejects_invalid_contract(
+    overrides: dict[str, object],
+    match: str,
+) -> None:
+    values: dict[str, object] = {
+        "channel": "slack",
+        "provider_event_id": "Ev123",
+        "conversation_id": "C123",
+        "sender": _identity(),
+        "text": "hello",
+    }
+    values.update(overrides)
+
+    with pytest.raises(ValidationError, match=match):
+        ChannelIncomingMessage.model_validate(values)
+
+
+def test_channel_messages_accept_attachment_only_content() -> None:
+    attachment = ChannelAttachment(kind="image", storage_key="uploads/a.png")
+
+    incoming = ChannelIncomingMessage(
+        channel="slack",
+        provider_event_id="Ev123",
+        conversation_id="C123",
+        sender=_identity(),
+        attachments=(attachment,),
+    )
+    outgoing = ChannelOutgoingMessage(
+        channel="slack",
+        conversation_id="C123",
+        attachments=(attachment,),
+    )
+
+    assert incoming.text is None
+    assert outgoing.text is None
+
+
+def test_channel_outgoing_message_has_uuid7_identifier_and_rejects_blank_text() -> None:
+    message = _outgoing()
+
+    assert len(message.message_id) == 36
+    with pytest.raises(ValidationError, match="blank"):
+        ChannelOutgoingMessage(
+            channel="slack",
+            conversation_id="C123",
+            text=" ",
+        )
+    with pytest.raises(ValidationError, match="text or attachments"):
+        ChannelOutgoingMessage(channel="slack", conversation_id="C123")
+
+
+def test_channel_models_are_strict_and_frozen() -> None:
+    identity = _identity()
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        ChannelIdentity.model_validate(
+            {"provider": "slack", "external_user_id": "U123", "token": "secret"}
+        )
+    with pytest.raises(ValidationError, match="frozen_instance"):
+        identity.external_user_id = "U456"
+
+
+def test_channel_metadata_rejects_non_finite_nested_numbers() -> None:
+    with pytest.raises(ValidationError, match="must be finite"):
+        ChannelIncomingMessage(
+            channel="slack",
+            provider_event_id="Ev123",
+            conversation_id="C123",
+            sender=_identity(),
+            text="hello",
+            metadata={"provider": {"score": float("nan")}},
+        )
+
+
+def test_channel_result_invariants_reject_incompatible_payloads() -> None:
+    identity = ResolvedChannelIdentity(user_id="user-1", tenant_id="tenant-a")
+    receipt = ChannelDeliveryReceipt(
+        message_id="msg-1",
+        provider_message_id="provider-1",
+        status="delivered",
+    )
+
+    with pytest.raises(ValidationError, match="immediate responses"):
+        ChannelHandlerResult(status="accepted", responses=(_outgoing(),))
+    with pytest.raises(ValidationError, match="identity or receipts"):
+        ChannelDispatchResult(status="duplicate", identity=identity)
+    with pytest.raises(ValidationError, match="delivery receipts"):
+        ChannelDispatchResult(status="accepted", receipts=(receipt,))
+
+
+def test_channel_delivery_receipt_rejects_naive_timestamp() -> None:
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        ChannelDeliveryReceipt(
+            message_id="msg-1",
+            status="sent",
+            timestamp=datetime(2026, 9, 4, 10),
+        )
+
+
+def test_channel_rate_limit_exposes_retry_delay_without_changing_message() -> None:
+    error = ChannelRateLimited("slow down", retry_after_seconds=2.5)
+
+    assert str(error) == "slow down"
+    assert error.retry_after_seconds == 2.5

--- a/tests/units/infrastructure/test_channel_factory.py
+++ b/tests/units/infrastructure/test_channel_factory.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from arclith import Arclith
+from arclith.adapters.bidirectional.memory import MemoryChannel
+from arclith.domain.models.channel import ChannelDeliveryReceipt, ChannelOutgoingMessage
+from arclith.domain.ports.outbound.channel import ChannelSender
+from arclith.infrastructure.channel_factory import (
+    ChannelSenderRegistry,
+    build_channel_sender,
+)
+from arclith.infrastructure.config import AppConfig
+
+
+class StubSender(ChannelSender):
+    async def send(self, message: ChannelOutgoingMessage) -> ChannelDeliveryReceipt:
+        raise NotImplementedError
+
+
+def _memory_config(*, enabled: bool = True) -> AppConfig:
+    return AppConfig.model_validate(
+        {"adapters": {"channel": {"memory": {"enabled": enabled}}}}
+    )
+
+
+def test_build_channel_sender_returns_configured_memory_adapter(logger) -> None:
+    sender = build_channel_sender(_memory_config(), logger, "memory")
+
+    assert isinstance(sender, MemoryChannel)
+
+
+@pytest.mark.parametrize("config", [AppConfig(), _memory_config(enabled=False)])
+def test_build_channel_sender_requires_enabled_memory_config(config, logger) -> None:
+    with pytest.raises(ValueError, match="memory.enabled=true"):
+        build_channel_sender(config, logger, "memory")
+
+
+def test_channel_sender_registry_builds_custom_adapter(logger) -> None:
+    expected = StubSender()
+    registry = ChannelSenderRegistry().register(
+        "custom", lambda _config, _logger: expected
+    )
+
+    assert (
+        build_channel_sender(AppConfig(), logger, "custom", registry=registry)
+        is expected
+    )
+
+
+def test_channel_sender_registry_rejects_invalid_adapter_names(logger) -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        ChannelSenderRegistry().register(" ", lambda _config, _logger: StubSender())
+    with pytest.raises(ValueError, match="must not be empty"):
+        build_channel_sender(AppConfig(), logger, " ")
+    with pytest.raises(ValueError, match="not registered"):
+        build_channel_sender(AppConfig(), logger, "unknown")
+
+
+def test_arclith_builds_configured_channel_sender(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config" / "adapters" / "bidirectional"
+    config_dir.mkdir(parents=True)
+    (config_dir / "memory.yaml").write_text("enabled: true\n", encoding="utf-8")
+
+    sender = Arclith(tmp_path / "config").channel_sender("memory")
+
+    assert isinstance(sender, MemoryChannel)

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -98,20 +98,14 @@ def test_unknown_logger_adapter_is_rejected():
         {"unknown_section": {}},
         {"adapters": {"unknown_adapter": {}}},
         {"adapters": {"mongodb": {"db_name": "test", "database_name": "typo"}}},
-        {
-            "adapters": {
-                "postgresql": {"database": "test", "schema_nam": "typo"}
-            }
-        },
+        {"adapters": {"postgresql": {"database": "test", "schema_nam": "typo"}}},
     ],
     ids=["root", "adapters", "mongodb", "postgresql-alias"],
 )
 def test_unknown_configuration_keys_are_rejected(data):
     with pytest.raises(ValidationError) as exc_info:
         AppConfig.model_validate(data)
-    assert {error["type"] for error in exc_info.value.errors()} == {
-        "extra_forbidden"
-    }
+    assert {error["type"] for error in exc_info.value.errors()} == {"extra_forbidden"}
 
 
 def test_default_retention_is_none():
@@ -237,6 +231,23 @@ def test_load_config_dir_memory():
     path = _make_config_dir({"adapters/adapters.yaml": {"repository": "memory"}})
     config = load_config_dir(path)
     assert config.adapters.repository == "memory"
+
+
+def test_load_config_dir_bidirectional_memory_channel():
+    path = _make_config_dir({"adapters/bidirectional/memory.yaml": {"enabled": True}})
+
+    config = load_config_dir(path)
+
+    assert config.adapters.channel.memory is not None
+    assert config.adapters.channel.memory.enabled is True
+    assert config.adapters.channel.configured_adapters() == ("memory",)
+
+
+def test_channel_settings_are_disabled_by_default():
+    config = AppConfig()
+
+    assert config.adapters.channel.memory is None
+    assert config.adapters.channel.configured_adapters() == ()
 
 
 def test_load_config_dir_app_section():

--- a/tests/units/infrastructure/test_project_layout.py
+++ b/tests/units/infrastructure/test_project_layout.py
@@ -2,7 +2,11 @@ from pathlib import PurePosixPath
 
 import pytest
 
-from arclith.infrastructure.project_layout import ProjectLayout, ProjectLayoutKind, canonical_project_layout
+from arclith.infrastructure.project_layout import (
+    ProjectLayout,
+    ProjectLayoutKind,
+    canonical_project_layout,
+)
 
 
 def test_canonical_project_layout_uses_namespaced_src_layout():
@@ -13,14 +17,29 @@ def test_canonical_project_layout_uses_namespaced_src_layout():
     assert layout.domain == PurePosixPath("src/arclith_sample/domain")
     assert layout.domain_models == PurePosixPath("src/arclith_sample/domain/models")
     assert layout.domain_ports == PurePosixPath("src/arclith_sample/domain/ports")
-    assert layout.inbound_ports == PurePosixPath("src/arclith_sample/domain/ports/inbound")
-    assert layout.outbound_ports == PurePosixPath("src/arclith_sample/domain/ports/outbound")
+    assert layout.inbound_ports == PurePosixPath(
+        "src/arclith_sample/domain/ports/inbound"
+    )
+    assert layout.outbound_ports == PurePosixPath(
+        "src/arclith_sample/domain/ports/outbound"
+    )
     assert layout.application == PurePosixPath("src/arclith_sample/application")
-    assert layout.application_use_cases == PurePosixPath("src/arclith_sample/application/use_cases")
-    assert layout.application_services == PurePosixPath("src/arclith_sample/application/services")
+    assert layout.application_use_cases == PurePosixPath(
+        "src/arclith_sample/application/use_cases"
+    )
+    assert layout.application_services == PurePosixPath(
+        "src/arclith_sample/application/services"
+    )
     assert layout.adapters == PurePosixPath("src/arclith_sample/adapters")
-    assert layout.inbound_adapters == PurePosixPath("src/arclith_sample/adapters/inbound")
-    assert layout.outbound_adapters == PurePosixPath("src/arclith_sample/adapters/outbound")
+    assert layout.inbound_adapters == PurePosixPath(
+        "src/arclith_sample/adapters/inbound"
+    )
+    assert layout.outbound_adapters == PurePosixPath(
+        "src/arclith_sample/adapters/outbound"
+    )
+    assert layout.bidirectional_adapters == PurePosixPath(
+        "src/arclith_sample/adapters/bidirectional"
+    )
     assert layout.infrastructure == PurePosixPath("src/arclith_sample/infrastructure")
     assert layout.tests_root == PurePosixPath("tests")
     assert layout.config_root == PurePosixPath("config")
@@ -49,16 +68,22 @@ def test_project_layout_reports_port_and_adapter_paths():
     assert layout.adapter_paths() == {
         "inbound": PurePosixPath("src/arclith_sample/adapters/inbound"),
         "outbound": PurePosixPath("src/arclith_sample/adapters/outbound"),
+        "bidirectional": PurePosixPath("src/arclith_sample/adapters/bidirectional"),
     }
 
 
 def test_project_layout_builds_import_paths():
     layout = ProjectLayout.src("arclith_sample")
 
-    assert layout.import_path("domain", "models", "ingredient") == "arclith_sample.domain.models.ingredient"
+    assert (
+        layout.import_path("domain", "models", "ingredient")
+        == "arclith_sample.domain.models.ingredient"
+    )
 
 
-@pytest.mark.parametrize("package_name", ["ArclithSample", "arclith-sample", "1service", ""])
+@pytest.mark.parametrize(
+    "package_name", ["ArclithSample", "arclith-sample", "1service", ""]
+)
 def test_project_layout_rejects_non_package_names(package_name: str):
     with pytest.raises(ValueError, match="package_name"):
         ProjectLayout.src(package_name)


### PR DESCRIPTION
## Contexte

Refs #169. Ce premier incrément établit le socle commun requis par #170 et #171. L'issue #169 reste ouverte jusqu'à la livraison de ces deux enfants actifs ; Teams, Telegram et Email restent différés.

## Changements principaux

- ajoute les modèles channel stricts, les erreurs provider-neutral et les ports inbound/outbound ;
- sépare identité fournisseur et identité applicative, avec claim atomique avant handler ;
- ajoute ChannelDispatcher et le fake mémoire déterministe ;
- ajoute la factory publique, la configuration scoped et le layout adapters/bidirectional ;
- publie channel/memory dans le catalogue arclith-cli ;
- ajoute le quickstart, la fiche capability, le changelog et le journal d'architecture.

## Impact

- API publique : nouveaux modèles, ports, erreurs, dispatcher, registry et méthode Arclith.channel_sender() ;
- domaine : aucun SDK ou transport fournisseur ; métadonnées JSON finies et pièces jointes sans credentials ni chemins absolus ;
- données : aucune migration ; le fake mémoire n'est ni durable ni multi-processus ;
- RabbitMQ/MCP : aucun changement ;
- configuration : nouveau mapping config/adapters/bidirectional/<adapter>.yaml vers adapters.channel.<adapter> ;
- release : changement releasable de type feat pour arclith et arclith-cli.

## Validations

- make precommit ;
- make coverage : 1 941 passés, 5 ignorés, couverture 90,94 % ;
- make docs : build MkDocs strict réussi ;
- suite CLI : 152 passés, 1 ignoré ;
- lint CLI et uv lock --check dans les deux projets ;
- smoke du quickstart mémoire et sortie JSON du catalogue.

## Documentation et déploiement

- documentation Pages et navigation mises à jour ;
- journal/2026-09-04-channel-contract.md ajouté ;
- ADR séparé non nécessaire : le changement introduit la capability documentée sans modifier une décision transversale existante ;
- aucune migration ni action de déploiement.

## Risques restants

Les garanties HTTP, le store partagé de production, les signatures et les délais d'acquittement appartiennent aux adapters #170 et #171. Un échec d'envoi après succès métier conserve le claim afin de ne pas rejouer le handler ; une reprise durable de l'outbound exige un outbox ou une file dédiée côté consommateur.
