### PR TITLE
feat: ajouter le mapping relationnel structuré

### DIFF
--- a/arclith/__init__.py
+++ b/arclith/__init__.py
@@ -56,6 +56,13 @@ from arclith.adapters.outbound.memory.repository import InMemoryRepository
 from arclith.adapters.outbound.memory.vector_store import MemoryVectorStore
 from arclith.adapters.outbound.mongodb.config import MongoDBConfig
 from arclith.adapters.outbound.qdrant import QdrantVectorStore
+from arclith.adapters.outbound.relational import (
+    RelationalColumn,
+    RelationalColumnKind,
+    RelationalEntityMapper,
+    RelationalIndex,
+    RelationalMapperRegistry,
+)
 from arclith.adapters.outbound.s3 import S3FileStorage, S3StorageConfig
 from arclith.application.channel import ChannelDispatcher
 from arclith.application.command_bus import CommandDispatcher, CommandEnvelope
@@ -257,6 +264,11 @@ __all__ = [
     "sign_slack_payload",
     "Entity",
     "Repository",
+    "RelationalColumn",
+    "RelationalColumnKind",
+    "RelationalEntityMapper",
+    "RelationalIndex",
+    "RelationalMapperRegistry",
     "EmbeddingPort",
     "EmbeddingText",
     "EmbeddingResult",

--- a/arclith/adapters/outbound/postgresql/config.py
+++ b/arclith/adapters/outbound/postgresql/config.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Literal
 from urllib.parse import quote_plus
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -17,12 +18,18 @@ class PostgreSQLConfig:
     schema: str = "public"
     driver: str = "asyncpg"
     table_prefix: str = ""
+    mapping_strategy: Literal["generic_json", "structured"] = "generic_json"
+    auto_create_schema: bool = True
 
     def __post_init__(self) -> None:
         _validate_port(self.port)
         _validate_identifier("schema", self.schema, allow_empty=False)
         _validate_identifier("table_prefix", self.table_prefix, allow_empty=True)
         _validate_driver(self.driver)
+        if self.mapping_strategy not in {"generic_json", "structured"}:
+            raise ValueError(
+                "PostgreSQL mapping_strategy must be 'generic_json' or 'structured'"
+            )
 
     def connection_url(self) -> str:
         if self.url:
@@ -51,6 +58,8 @@ class PostgreSQLConfig:
             table_prefix=_string_value(
                 params, "table_prefix", default=self.table_prefix
             ),
+            mapping_strategy=self.mapping_strategy,
+            auto_create_schema=self.auto_create_schema,
         )
 
 

--- a/arclith/adapters/outbound/postgresql/repository.py
+++ b/arclith/adapters/outbound/postgresql/repository.py
@@ -11,6 +11,7 @@ from uuid6 import UUID, uuid7
 from arclith.adapters.context import get_adapter_tenant_context
 from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
 from arclith.adapters.outbound.relational.mapping import (
+    _INTERNAL_COLUMN_PREFIX,
     RelationalColumn,
     RelationalEntityMapper,
     validate_relational_mapper,
@@ -22,6 +23,7 @@ from arclith.domain.ports.outbound.repository import Repository
 T = TypeVar("T", bound=Entity)
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PAGINATION_TOTAL_LABEL = f"{_INTERNAL_COLUMN_PREFIX}pagination_total"
 _EXTRA_MESSAGE = (
     "PostgreSQL repository requires the optional extra: arclith[postgresql]"
 )
@@ -378,7 +380,7 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
             _sqlalchemy_api()
             .select(
                 self._entity_selection(table),
-                _sqlalchemy_api().count().over().label("__total"),
+                _sqlalchemy_api().count().over().label(_PAGINATION_TOTAL_LABEL),
             )
             .where(table.c.deleted_at.is_(None))
             .order_by(table.c.created_at, table.c.uuid)
@@ -390,7 +392,7 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         async with engine.connect() as connection:
             rows = (await connection.execute(statement)).mappings().all()
 
-        total = int(rows[0]["__total"]) if rows else 0
+        total = int(rows[0][_PAGINATION_TOTAL_LABEL]) if rows else 0
         return [self._row_to_entity(row) for row in rows], total
 
     async def find_deleted(self) -> list[T]:

--- a/arclith/adapters/outbound/postgresql/repository.py
+++ b/arclith/adapters/outbound/postgresql/repository.py
@@ -11,7 +11,6 @@ from uuid6 import UUID, uuid7
 from arclith.adapters.context import get_adapter_tenant_context
 from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
 from arclith.adapters.outbound.relational.mapping import (
-    _INTERNAL_COLUMN_PREFIX,
     RelationalColumn,
     RelationalEntityMapper,
     validate_relational_mapper,
@@ -23,7 +22,7 @@ from arclith.domain.ports.outbound.repository import Repository
 T = TypeVar("T", bound=Entity)
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_PAGINATION_TOTAL_LABEL = f"{_INTERNAL_COLUMN_PREFIX}pagination_total"
+_PAGINATION_TOTAL_LABEL = "_arclith_pagination_total"
 _EXTRA_MESSAGE = (
     "PostgreSQL repository requires the optional extra: arclith[postgresql]"
 )

--- a/arclith/adapters/outbound/postgresql/repository.py
+++ b/arclith/adapters/outbound/postgresql/repository.py
@@ -10,6 +10,11 @@ from uuid6 import UUID, uuid7
 
 from arclith.adapters.context import get_adapter_tenant_context
 from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
+from arclith.adapters.outbound.relational.mapping import (
+    RelationalColumn,
+    RelationalEntityMapper,
+    validate_relational_mapper,
+)
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.logger import Logger
 from arclith.domain.ports.outbound.repository import Repository
@@ -24,13 +29,18 @@ _EXTRA_MESSAGE = (
 
 @dataclass(frozen=True)
 class _SQLAlchemyAPI:
+    boolean: Any
     column: Any
+    date: Any
     datetime: Any
+    float_: Any
+    index: Any
     integer: Any
     jsonb: Any
     metadata: Any
     string: Any
     table: Any
+    uuid: Any
     delete: Any
     count: Any
     create_schema: Any
@@ -44,12 +54,17 @@ class _SQLAlchemyAPI:
 def _sqlalchemy_api() -> _SQLAlchemyAPI:
     try:
         from sqlalchemy import (
+            Boolean,
             Column,
+            Date,
             DateTime,
+            Float,
+            Index,
             Integer,
             MetaData,
             String,
             Table,
+            Uuid,
             delete,
             func,
             insert,
@@ -63,13 +78,18 @@ def _sqlalchemy_api() -> _SQLAlchemyAPI:
         raise RuntimeError(_EXTRA_MESSAGE) from exc
 
     return _SQLAlchemyAPI(
+        boolean=Boolean,
         column=Column,
+        date=Date,
         datetime=DateTime,
+        float_=Float,
+        index=Index,
         integer=Integer,
         jsonb=JSONB,
         metadata=MetaData,
         string=String,
         table=Table,
+        uuid=Uuid,
         delete=delete,
         count=func.count,
         create_schema=CreateSchema,
@@ -86,14 +106,34 @@ def _require_asyncpg() -> None:
 
 
 class PostgreSQLRepository(Repository[T], Generic[T]):
-    """Generic PostgreSQL repository storing each entity as one JSONB document."""
+    """PostgreSQL repository using generic JSONB or an explicit typed mapper."""
 
     def __init__(
-        self, config: PostgreSQLConfig, entity_class: type[T], logger: Logger
+        self,
+        config: PostgreSQLConfig,
+        entity_class: type[T],
+        logger: Logger,
+        *,
+        mapper: RelationalEntityMapper[T] | None = None,
     ) -> None:
+        if config.mapping_strategy == "structured" and mapper is None:
+            raise ValueError(
+                "PostgreSQL structured mapping requires an explicit relational mapper"
+            )
+        if config.mapping_strategy == "generic_json" and mapper is not None:
+            raise ValueError(
+                "A relational mapper requires mapping_strategy='structured'"
+            )
+        if mapper is not None:
+            validate_relational_mapper(mapper)
+            if mapper.entity_class is not entity_class:
+                raise ValueError(
+                    "Relational mapper entity_class does not match the repository entity"
+                )
         self._config = config
         self._entity_class = entity_class
         self._logger = logger
+        self._mapper = mapper
         self._tables: dict[str, tuple[Any, Any]] = {}
         self._engines: dict[str, Any] = {}
         self._ready_tables: set[str] = set()
@@ -106,7 +146,15 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         return self._config.with_tenant_params(coords.params)
 
     def _table_key(self, config: PostgreSQLConfig) -> str:
-        return f"{config.schema}.{config.table_prefix}{self._entity_class.__name__.lower()}"
+        return f"{config.schema}.{self._table_name(config)}"
+
+    def _table_name(self, config: PostgreSQLConfig) -> str:
+        base_name = (
+            self._mapper.table_name
+            if self._mapper is not None
+            else self._entity_class.__name__.lower()
+        )
+        return f"{config.table_prefix}{base_name}"
 
     def _table_for(self, config: PostgreSQLConfig) -> tuple[Any, Any]:
         table_key = self._table_key(config)
@@ -115,12 +163,36 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         return self._tables[table_key]
 
     def _build_table(self, config: PostgreSQLConfig) -> tuple[Any, Any]:
-        table_name = f"{config.table_prefix}{self._entity_class.__name__.lower()}"
+        table_name = self._table_name(config)
         if not _IDENTIFIER_RE.fullmatch(table_name):
             raise ValueError(f"Invalid PostgreSQL table name: {table_name}")
 
         api = _sqlalchemy_api()
         metadata = api.metadata(schema=config.schema)
+        if self._mapper is not None:
+            table = api.table(
+                table_name,
+                metadata,
+                *(
+                    api.column(
+                        column.name,
+                        self._column_type(api, column),
+                        nullable=column.nullable,
+                        primary_key=column.primary_key,
+                        index=column.indexed,
+                        unique=column.unique,
+                    )
+                    for column in self._mapper.columns
+                ),
+            )
+            for index in self._mapper.indexes:
+                api.index(
+                    index.name,
+                    *(table.c[name] for name in index.columns),
+                    unique=index.unique,
+                )
+            return metadata, table
+
         table = api.table(
             table_name,
             metadata,
@@ -132,6 +204,21 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
             api.column("version", api.integer, nullable=False),
         )
         return metadata, table
+
+    @staticmethod
+    def _column_type(api: _SQLAlchemyAPI, column: RelationalColumn) -> Any:
+        types = {
+            "boolean": api.boolean,
+            "date": api.date,
+            "datetime": lambda: api.datetime(timezone=True),
+            "float": api.float_,
+            "integer": api.integer,
+            "json": api.jsonb,
+            "string": api.string,
+            "uuid": lambda: api.uuid(as_uuid=True),
+        }
+        column_type = types[column.kind]
+        return column_type() if callable(column_type) else column_type
 
     def _engine_for(self, url: str, table_name: str, driver: str) -> Any:
         if url not in self._engines:
@@ -173,10 +260,32 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         url = config.connection_url()
         metadata, table = self._table_for(config)
         engine = self._engine_for(url, table.name, config.driver)
-        await self._ensure_schema(engine, url, metadata, self._table_key(config))
+        if config.auto_create_schema:
+            await self._ensure_schema(engine, url, metadata, self._table_key(config))
         return engine, table
 
     def _entity_values(self, entity: T) -> dict[str, Any]:
+        if self._mapper is not None:
+            values = dict(self._mapper.to_record(entity))
+            expected = {column.name for column in self._mapper.columns}
+            actual = set(values)
+            missing = sorted(expected - actual)
+            unknown = sorted(actual - expected)
+            if missing or unknown:
+                details = []
+                if missing:
+                    details.append(f"missing: {', '.join(missing)}")
+                if unknown:
+                    details.append(f"unknown: {', '.join(unknown)}")
+                raise ValueError(
+                    "Structured relational record does not match declared columns "
+                    f"({'; '.join(details)})"
+                )
+            if values["uuid"] != entity.uuid:
+                raise ValueError(
+                    "Structured relational record uuid must match the entity uuid"
+                )
+            return values
         return {
             "uuid": str(entity.uuid),
             "data": entity.model_dump(mode="json"),
@@ -187,12 +296,28 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         }
 
     def _row_to_entity(self, row: Any) -> T:
+        if self._mapper is not None:
+            record = {
+                column.name: row[column.name] for column in self._mapper.columns
+            }
+            entity = self._mapper.from_record(record)
+            if not isinstance(entity, self._entity_class):
+                raise ValueError(
+                    "Relational mapper from_record() returned an unexpected entity type"
+                )
+            return entity
         payload = row["data"]
         if isinstance(payload, str):
             payload = json.loads(payload)
         if not isinstance(payload, dict):
             raise ValueError("PostgreSQL repository row payload must be a JSON object")
         return self._entity_class(**payload)
+
+    def _uuid_value(self, uuid: UUID) -> UUID | str:
+        return uuid if self._mapper is not None else str(uuid)
+
+    def _entity_selection(self, table: Any) -> Any:
+        return table if self._mapper is not None else table.c.data
 
     async def create(self, entity: T) -> T:
         engine, table = await self._engine_and_table()
@@ -204,8 +329,8 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
 
     async def read(self, uuid: UUID) -> T | None:
         engine, table = await self._engine_and_table()
-        statement = (
-            _sqlalchemy_api().select(table.c.data).where(table.c.uuid == str(uuid))
+        statement = _sqlalchemy_api().select(self._entity_selection(table)).where(
+            table.c.uuid == self._uuid_value(uuid)
         )
         async with engine.connect() as connection:
             row = (await connection.execute(statement)).mappings().first()
@@ -218,7 +343,7 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         statement = (
             _sqlalchemy_api()
             .update(table)
-            .where(table.c.uuid == str(entity.uuid))
+            .where(table.c.uuid == self._uuid_value(entity.uuid))
             .values(**values)
         )
         async with engine.begin() as connection:
@@ -227,7 +352,9 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
 
     async def delete(self, uuid: UUID) -> None:
         engine, table = await self._engine_and_table()
-        statement = _sqlalchemy_api().delete(table).where(table.c.uuid == str(uuid))
+        statement = _sqlalchemy_api().delete(table).where(
+            table.c.uuid == self._uuid_value(uuid)
+        )
         async with engine.begin() as connection:
             await connection.execute(statement)
 
@@ -235,7 +362,7 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         engine, table = await self._engine_and_table()
         statement = (
             _sqlalchemy_api()
-            .select(table.c.data)
+            .select(self._entity_selection(table))
             .where(table.c.deleted_at.is_(None))
             .order_by(table.c.created_at, table.c.uuid)
         )
@@ -249,7 +376,10 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         engine, table = await self._engine_and_table()
         statement = (
             _sqlalchemy_api()
-            .select(table.c.data, _sqlalchemy_api().count().over().label("__total"))
+            .select(
+                self._entity_selection(table),
+                _sqlalchemy_api().count().over().label("__total"),
+            )
             .where(table.c.deleted_at.is_(None))
             .order_by(table.c.created_at, table.c.uuid)
             .offset(offset)
@@ -267,7 +397,7 @@ class PostgreSQLRepository(Repository[T], Generic[T]):
         engine, table = await self._engine_and_table()
         statement = (
             _sqlalchemy_api()
-            .select(table.c.data)
+            .select(self._entity_selection(table))
             .where(table.c.deleted_at.is_not(None))
             .order_by(table.c.deleted_at, table.c.uuid)
         )

--- a/arclith/adapters/outbound/relational/__init__.py
+++ b/arclith/adapters/outbound/relational/__init__.py
@@ -1,0 +1,15 @@
+from arclith.adapters.outbound.relational.mapping import (
+    RelationalColumn,
+    RelationalColumnKind,
+    RelationalEntityMapper,
+    RelationalIndex,
+)
+from arclith.adapters.outbound.relational.registry import RelationalMapperRegistry
+
+__all__ = [
+    "RelationalColumn",
+    "RelationalColumnKind",
+    "RelationalEntityMapper",
+    "RelationalIndex",
+    "RelationalMapperRegistry",
+]

--- a/arclith/adapters/outbound/relational/mapping.py
+++ b/arclith/adapters/outbound/relational/mapping.py
@@ -187,7 +187,7 @@ def _validate_indexes(
 
 
 def _validate_identifier(kind: str, value: str) -> None:
-    if not _IDENTIFIER_RE.fullmatch(value):
+    if not isinstance(value, str) or not _IDENTIFIER_RE.fullmatch(value):
         raise ValueError(
             f"Relational {kind} name '{value}' must be a safe SQL identifier"
         )

--- a/arclith/adapters/outbound/relational/mapping.py
+++ b/arclith/adapters/outbound/relational/mapping.py
@@ -92,10 +92,10 @@ class RelationalEntityMapper(Protocol[T]):
     indexes: tuple[RelationalIndex, ...]
 
     def to_record(self, entity: T) -> Mapping[str, Any]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
     def from_record(self, record: Mapping[str, Any]) -> T:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover - protocol contract
 
 
 def validate_relational_mapper(

--- a/arclith/adapters/outbound/relational/mapping.py
+++ b/arclith/adapters/outbound/relational/mapping.py
@@ -21,6 +21,7 @@ RelationalColumnKind = Literal[
 ]
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_INTERNAL_COLUMN_PREFIX = "_arclith_"
 _SUPPORTED_COLUMN_KINDS = {
     "boolean",
     "date",
@@ -53,6 +54,11 @@ class RelationalColumn:
 
     def __post_init__(self) -> None:
         _validate_identifier("column", self.name)
+        if self.name.startswith(_INTERNAL_COLUMN_PREFIX):
+            raise ValueError(
+                f"Relational column name '{self.name}' uses the reserved "
+                f"'{_INTERNAL_COLUMN_PREFIX}' prefix"
+            )
         if self.kind not in _SUPPORTED_COLUMN_KINDS:
             supported = ", ".join(sorted(_SUPPORTED_COLUMN_KINDS))
             raise ValueError(

--- a/arclith/adapters/outbound/relational/mapping.py
+++ b/arclith/adapters/outbound/relational/mapping.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, TypeVar
+
+from arclith.domain.models.entity import Entity
+
+T = TypeVar("T", bound=Entity)
+
+RelationalColumnKind = Literal[
+    "boolean",
+    "date",
+    "datetime",
+    "float",
+    "integer",
+    "json",
+    "string",
+    "uuid",
+]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SUPPORTED_COLUMN_KINDS = {
+    "boolean",
+    "date",
+    "datetime",
+    "float",
+    "integer",
+    "json",
+    "string",
+    "uuid",
+}
+_REQUIRED_COLUMNS = {
+    "uuid": "uuid",
+    "created_at": "datetime",
+    "updated_at": "datetime",
+    "deleted_at": "datetime",
+    "version": "integer",
+}
+
+
+@dataclass(frozen=True)
+class RelationalColumn:
+    """Vendor-neutral declaration of one structured relational column."""
+
+    name: str
+    kind: RelationalColumnKind
+    nullable: bool = False
+    primary_key: bool = False
+    indexed: bool = False
+    unique: bool = False
+
+    def __post_init__(self) -> None:
+        _validate_identifier("column", self.name)
+        if self.kind not in _SUPPORTED_COLUMN_KINDS:
+            supported = ", ".join(sorted(_SUPPORTED_COLUMN_KINDS))
+            raise ValueError(
+                f"Unsupported relational column kind '{self.kind}'. "
+                f"Supported kinds: {supported}."
+            )
+
+
+@dataclass(frozen=True)
+class RelationalIndex:
+    """Vendor-neutral declaration of a possibly composite index."""
+
+    name: str
+    columns: tuple[str, ...]
+    unique: bool = False
+
+    def __post_init__(self) -> None:
+        _validate_identifier("index", self.name)
+        normalized_columns = tuple(self.columns)
+        object.__setattr__(self, "columns", normalized_columns)
+        if not normalized_columns:
+            raise ValueError(f"Relational index '{self.name}' must reference columns")
+        if len(set(normalized_columns)) != len(normalized_columns):
+            raise ValueError(
+                f"Relational index '{self.name}' must not repeat a column"
+            )
+        for column_name in normalized_columns:
+            _validate_identifier("index column", column_name)
+
+
+class RelationalEntityMapper(Protocol[T]):
+    """Application-owned conversion between an entity and a typed SQL record."""
+
+    entity_class: type[T]
+    table_name: str
+    columns: tuple[RelationalColumn, ...]
+    indexes: tuple[RelationalIndex, ...]
+
+    def to_record(self, entity: T) -> Mapping[str, Any]: ...
+
+    def from_record(self, record: Mapping[str, Any]) -> T: ...
+
+
+def validate_relational_mapper(
+    mapper: RelationalEntityMapper[T],
+) -> RelationalEntityMapper[T]:
+    """Validate the structural contract required by ``Repository[T]``."""
+
+    entity_class = mapper.entity_class
+    if not isinstance(entity_class, type) or not issubclass(entity_class, Entity):
+        raise ValueError("Relational mapper entity_class must inherit from Entity")
+    _validate_identifier("table", mapper.table_name)
+    columns_by_name = _validate_columns(mapper)
+    _validate_repository_columns(mapper.table_name, columns_by_name)
+    _validate_indexes(mapper, set(columns_by_name))
+    return mapper
+
+
+def _validate_columns(
+    mapper: RelationalEntityMapper[Any],
+) -> dict[str, RelationalColumn]:
+    columns = tuple(mapper.columns)
+    if not columns:
+        raise ValueError(f"Relational mapper '{mapper.table_name}' must declare columns")
+    if not all(isinstance(column, RelationalColumn) for column in columns):
+        raise ValueError("Relational mapper columns must be RelationalColumn values")
+
+    columns_by_name = {column.name: column for column in columns}
+    if len(columns_by_name) != len(columns):
+        raise ValueError(
+            f"Relational mapper '{mapper.table_name}' has duplicate column names"
+        )
+    return columns_by_name
+
+
+def _validate_repository_columns(
+    table_name: str,
+    columns_by_name: Mapping[str, RelationalColumn],
+) -> None:
+    missing = sorted(set(_REQUIRED_COLUMNS) - set(columns_by_name))
+    if missing:
+        raise ValueError(
+            f"Relational mapper '{table_name}' is missing Repository columns: "
+            f"{', '.join(missing)}"
+        )
+    for name, expected_kind in _REQUIRED_COLUMNS.items():
+        actual_kind = columns_by_name[name].kind
+        if actual_kind != expected_kind:
+            raise ValueError(
+                f"Relational mapper column '{name}' must use kind "
+                f"'{expected_kind}', got '{actual_kind}'"
+            )
+
+    primary_keys = [
+        column.name for column in columns_by_name.values() if column.primary_key
+    ]
+    if primary_keys != ["uuid"]:
+        raise ValueError(
+            "Relational mapper must declare 'uuid' as its only primary key"
+        )
+    if not columns_by_name["deleted_at"].nullable:
+        raise ValueError("Relational mapper column 'deleted_at' must be nullable")
+
+
+def _validate_indexes(
+    mapper: RelationalEntityMapper[Any],
+    column_names: set[str],
+) -> None:
+    indexes = tuple(mapper.indexes)
+    if not all(isinstance(index, RelationalIndex) for index in indexes):
+        raise ValueError("Relational mapper indexes must be RelationalIndex values")
+    index_names = [index.name for index in indexes]
+    if len(set(index_names)) != len(index_names):
+        raise ValueError(
+            f"Relational mapper '{mapper.table_name}' has duplicate index names"
+        )
+    for index in indexes:
+        unknown = sorted(set(index.columns) - column_names)
+        if unknown:
+            raise ValueError(
+                f"Relational index '{index.name}' references unknown columns: "
+                f"{', '.join(unknown)}"
+            )
+
+
+def _validate_identifier(kind: str, value: str) -> None:
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(
+            f"Relational {kind} name '{value}' must be a safe SQL identifier"
+        )
+
+
+__all__ = [
+    "RelationalColumn",
+    "RelationalColumnKind",
+    "RelationalEntityMapper",
+    "RelationalIndex",
+]

--- a/arclith/adapters/outbound/relational/mapping.py
+++ b/arclith/adapters/outbound/relational/mapping.py
@@ -91,9 +91,11 @@ class RelationalEntityMapper(Protocol[T]):
     columns: tuple[RelationalColumn, ...]
     indexes: tuple[RelationalIndex, ...]
 
-    def to_record(self, entity: T) -> Mapping[str, Any]: ...
+    def to_record(self, entity: T) -> Mapping[str, Any]:
+        raise NotImplementedError
 
-    def from_record(self, record: Mapping[str, Any]) -> T: ...
+    def from_record(self, record: Mapping[str, Any]) -> T:
+        raise NotImplementedError
 
 
 def validate_relational_mapper(

--- a/arclith/adapters/outbound/relational/registry.py
+++ b/arclith/adapters/outbound/relational/registry.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar, cast
+
+from arclith.adapters.outbound.relational.mapping import (
+    RelationalEntityMapper,
+    validate_relational_mapper,
+)
+from arclith.domain.models.entity import Entity
+
+T = TypeVar("T", bound=Entity)
+
+
+class RelationalMapperRegistry:
+    """Exact entity-class registry for application-provided relational mappers."""
+
+    def __init__(self) -> None:
+        self._mappers: dict[type[Entity], RelationalEntityMapper[Any]] = {}
+
+    def register(self, mapper: RelationalEntityMapper[T]) -> "RelationalMapperRegistry":
+        validate_relational_mapper(mapper)
+        entity_class = mapper.entity_class
+        if entity_class in self._mappers:
+            entity_path = _entity_path(entity_class)
+            raise ValueError(
+                f"A relational mapper is already registered for '{entity_path}'"
+            )
+        self._mappers[entity_class] = mapper
+        return self
+
+    def resolve(self, entity_class: type[T]) -> RelationalEntityMapper[T] | None:
+        mapper = self._mappers.get(entity_class)
+        return cast("RelationalEntityMapper[T] | None", mapper)
+
+    def require(self, entity_class: type[T]) -> RelationalEntityMapper[T]:
+        mapper = self.resolve(entity_class)
+        if mapper is None:
+            raise ValueError(
+                "Structured relational mapping requires a registered mapper for "
+                f"'{_entity_path(entity_class)}'"
+            )
+        return mapper
+
+
+def _entity_path(entity_class: type[Entity]) -> str:
+    return f"{entity_class.__module__}.{entity_class.__qualname__}"
+
+
+__all__ = ["RelationalMapperRegistry"]

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
+from arclith.adapters.outbound.relational.registry import RelationalMapperRegistry
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.channel import ChannelSender
 from arclith.domain.ports.outbound.embedding import EmbeddingPort
@@ -133,6 +134,7 @@ class Arclith:
         entity_class: type[T],
         *,
         registry: None = None,
+        mapper_registry: RelationalMapperRegistry | None = None,
     ) -> Repository[T]:
         pass
 
@@ -142,6 +144,7 @@ class Arclith:
         entity_class: type[T],
         *,
         registry: RepositoryRegistry[T, R],
+        mapper_registry: None = None,
     ) -> R:
         pass
 
@@ -150,12 +153,24 @@ class Arclith:
         entity_class: type[T],
         *,
         registry: RepositoryRegistry[T, R] | None = None,
+        mapper_registry: RelationalMapperRegistry | None = None,
     ) -> Repository[T] | R:
         from arclith.infrastructure.repository_factory import build_repository
 
-        repository = build_repository(
-            self.config, entity_class, self.logger, registry=registry
-        )
+        if registry is not None and mapper_registry is not None:
+            raise ValueError(
+                "mapper_registry cannot be combined with a custom RepositoryRegistry"
+            )
+        repository: Repository[T] | R
+        if registry is None:
+            repository = build_repository(
+                self.config,
+                entity_class,
+                self.logger,
+                mapper_registry=mapper_registry,
+            )
+        else:
+            repository = registry.build(self.config, entity_class, self.logger)
         settings = self.config.adapters.opentelemetry
         if (
             self.config.adapters.observability.is_enabled("opentelemetry")

--- a/arclith/arclith.py
+++ b/arclith/arclith.py
@@ -159,7 +159,9 @@ class Arclith:
 
         if registry is not None and mapper_registry is not None:
             raise ValueError(
-                "mapper_registry cannot be combined with a custom RepositoryRegistry"
+                "mapper_registry cannot be combined with a custom RepositoryRegistry; "
+                "capture it in the custom factory or extend "
+                "default_repository_registry()"
             )
         repository: Repository[T] | R
         if registry is None:

--- a/arclith/infrastructure/repository_factory.py
+++ b/arclith/infrastructure/repository_factory.py
@@ -6,6 +6,7 @@ from typing import Generic
 from typing import TypeVar
 from typing import overload
 
+from arclith.adapters.outbound.relational.registry import RelationalMapperRegistry
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.logger import Logger
 from arclith.domain.ports.outbound.repository import Repository
@@ -48,6 +49,7 @@ def build_repository(
     logger: Logger,
     *,
     registry: None = None,
+    mapper_registry: RelationalMapperRegistry | None = None,
 ) -> Repository[T]:
     pass
 
@@ -59,6 +61,7 @@ def build_repository(
     logger: Logger,
     *,
     registry: RepositoryRegistry[T, R],
+    mapper_registry: None = None,
 ) -> R:
     pass
 
@@ -69,16 +72,26 @@ def build_repository(
     logger: Logger,
     *,
     registry: RepositoryRegistry[T, R] | None = None,
+    mapper_registry: RelationalMapperRegistry | None = None,
 ) -> Repository[T] | R:
     if registry is None:
-        return default_repository_registry(entity_class).build(
+        return default_repository_registry(
+            entity_class, mapper_registry=mapper_registry
+        ).build(
             config, entity_class, logger
+        )
+    if mapper_registry is not None:
+        raise ValueError(
+            "mapper_registry cannot be combined with a custom RepositoryRegistry; "
+            "capture it in the custom factory or extend default_repository_registry()"
         )
     return registry.build(config, entity_class, logger)
 
 
 def default_repository_registry(
     _entity_class: type[T],
+    *,
+    mapper_registry: RelationalMapperRegistry | None = None,
 ) -> RepositoryRegistry[T, Repository[T]]:
     return (
         RepositoryRegistry[T, Repository[T]]()
@@ -86,7 +99,15 @@ def default_repository_registry(
         .register("mongodb", _build_mongodb_repository)
         .register("duckdb", _build_duckdb_repository)
         .register("mariadb", _build_mariadb_repository)
-        .register("postgresql", _build_postgresql_repository)
+        .register(
+            "postgresql",
+            lambda config, entity_class, logger: _build_postgresql_repository(
+                config,
+                entity_class,
+                logger,
+                mapper_registry=mapper_registry,
+            ),
+        )
     )
 
 
@@ -169,6 +190,8 @@ def _build_postgresql_repository(
     config: AppConfig,
     entity_class: type[T],
     logger: Logger,
+    *,
+    mapper_registry: RelationalMapperRegistry | None = None,
 ) -> Repository[T]:
     from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
     from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
@@ -176,6 +199,12 @@ def _build_postgresql_repository(
     postgresql = config.adapters.postgresql
     if postgresql is None:
         raise ValueError("PostgreSQL settings are required when repository=postgresql")
+
+    mapper = None
+    if postgresql.mapping_strategy == "structured":
+        if mapper_registry is None:
+            mapper_registry = RelationalMapperRegistry()
+        mapper = mapper_registry.require(entity_class)
 
     return PostgreSQLRepository(
         PostgreSQLConfig(
@@ -188,7 +217,10 @@ def _build_postgresql_repository(
             schema=postgresql.schema_name,
             driver=postgresql.driver,
             table_prefix=postgresql.table_prefix,
+            mapping_strategy=postgresql.mapping_strategy,
+            auto_create_schema=postgresql.auto_create_schema,
         ),
         entity_class,
         logger,
+        mapper=mapper,
     )

--- a/arclith/infrastructure/settings/repositories.py
+++ b/arclith/infrastructure/settings/repositories.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
@@ -76,6 +76,8 @@ class PostgreSQLSettings(_SQLRepositorySettings):
     port: int = 5432
     schema_name: str = Field(default="public", alias="schema")
     driver: str = "asyncpg"
+    mapping_strategy: Literal["generic_json", "structured"] = "generic_json"
+    auto_create_schema: bool = True
 
     @field_validator("schema_name")
     @classmethod

--- a/cli/arclith_cli/catalogs/persistence.py
+++ b/cli/arclith_cli/catalogs/persistence.py
@@ -11,7 +11,9 @@ from arclith_cli.catalogs.repository_facets import (
     MARIADB_FACETS,
     MEMORY_FACETS,
     MONGODB_FACETS,
-    POSTGRESQL_FACETS,
+)
+from arclith_cli.catalogs.repository_postgresql import (
+    POSTGRESQL_REPOSITORY_ADAPTER,
 )
 
 REPOSITORY_CAPABILITY = CapabilitySpec(
@@ -154,86 +156,7 @@ multitenant: false
             ),
             facets=MARIADB_FACETS,
         ),
-        AdapterSpec(
-            name="postgresql",
-            capability="repository",
-            layer="outbound",
-            description="Repository PostgreSQL async optionnel, pilote par SQLAlchemy et asyncpg, avec payload JSONB generique.",
-            config_path="config/adapters/outbound/postgresql.yaml",
-            config_template="""\
-url: null   # à mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complète
-host: {host}
-port: {port}
-database: {database}
-user: {user}
-password: null   # à mapper via config/secrets.yaml ou resolver env/vault
-schema: {schema}
-driver: {driver}
-table_prefix: "{table_prefix}"
-multitenant: {multitenant}
-""",
-            secret_mappings=(
-                SecretMappingSpec(
-                    field_path="adapters.postgresql.url",
-                    secret_key="POSTGRESQL_URL",
-                ),
-                SecretMappingSpec(
-                    field_path="adapters.postgresql.password",
-                    secret_key="POSTGRESQL_PASSWORD",
-                ),
-            ),
-            parameters=(
-                ParameterSpec(
-                    name="host",
-                    kind="string",
-                    prompt="host",
-                    default="127.0.0.1",
-                ),
-                ParameterSpec(
-                    name="port",
-                    kind="string",
-                    prompt="port",
-                    default="5432",
-                ),
-                ParameterSpec(
-                    name="database",
-                    kind="string",
-                    prompt="database",
-                    default_from_project_name=True,
-                ),
-                ParameterSpec(
-                    name="user",
-                    kind="string",
-                    prompt="user",
-                    default="app",
-                ),
-                ParameterSpec(
-                    name="schema",
-                    kind="string",
-                    prompt="schema",
-                    default="public",
-                ),
-                ParameterSpec(
-                    name="driver",
-                    kind="string",
-                    prompt="driver",
-                    default="asyncpg",
-                ),
-                ParameterSpec(
-                    name="table_prefix",
-                    kind="string",
-                    prompt="table_prefix",
-                    default="",
-                ),
-                ParameterSpec(
-                    name="multitenant",
-                    kind="boolean",
-                    prompt="multitenant",
-                    default=False,
-                ),
-            ),
-            facets=POSTGRESQL_FACETS,
-        ),
+        POSTGRESQL_REPOSITORY_ADAPTER,
     ),
 )
 

--- a/cli/arclith_cli/catalogs/repository_facets.py
+++ b/cli/arclith_cli/catalogs/repository_facets.py
@@ -77,11 +77,11 @@ POSTGRESQL_FACETS = AdapterFacets(
     schema_strategy="json_table",
     recommended_for=(
         "services nécessitant un SQL serveur robuste",
-        "état partagé multi-process avec payload JSONB",
+        "payload JSONB par défaut ou colonnes typées explicitement mappées",
     ),
     limits=(
-        "entité stockée comme payload JSONB générique",
-        "pas de relations, joins ou migrations métier via le port",
+        "le mapping structuré est opt-in et fourni par l'application",
+        "pas de relations, joins ou migrations automatiques via le port",
     ),
 )
 

--- a/cli/arclith_cli/catalogs/repository_postgresql.py
+++ b/cli/arclith_cli/catalogs/repository_postgresql.py
@@ -1,0 +1,107 @@
+from arclith_cli.capability_models import (
+    AdapterSpec,
+    ParameterSpec,
+    SecretMappingSpec,
+)
+from arclith_cli.catalogs.repository_facets import POSTGRESQL_FACETS
+
+POSTGRESQL_REPOSITORY_ADAPTER = AdapterSpec(
+    name="postgresql",
+    capability="repository",
+    layer="outbound",
+    description=(
+        "Repository PostgreSQL async optionnel avec JSONB par defaut ou "
+        "mapping structure explicite."
+    ),
+    config_path="config/adapters/outbound/postgresql.yaml",
+    config_template="""\
+url: null   # à mapper via config/secrets.yaml ou resolver env/vault si vous fournissez une URL complète
+host: {host}
+port: {port}
+database: {database}
+user: {user}
+password: null   # à mapper via config/secrets.yaml ou resolver env/vault
+schema: {schema}
+driver: {driver}
+table_prefix: "{table_prefix}"
+mapping_strategy: {mapping_strategy}
+auto_create_schema: {auto_create_schema}
+multitenant: {multitenant}
+""",
+    secret_mappings=(
+        SecretMappingSpec(
+            field_path="adapters.postgresql.url",
+            secret_key="POSTGRESQL_URL",
+        ),
+        SecretMappingSpec(
+            field_path="adapters.postgresql.password",
+            secret_key="POSTGRESQL_PASSWORD",
+        ),
+    ),
+    parameters=(
+        ParameterSpec(
+            name="host",
+            kind="string",
+            prompt="host",
+            default="127.0.0.1",
+        ),
+        ParameterSpec(
+            name="port",
+            kind="string",
+            prompt="port",
+            default="5432",
+        ),
+        ParameterSpec(
+            name="database",
+            kind="string",
+            prompt="database",
+            default_from_project_name=True,
+        ),
+        ParameterSpec(
+            name="user",
+            kind="string",
+            prompt="user",
+            default="app",
+        ),
+        ParameterSpec(
+            name="schema",
+            kind="string",
+            prompt="schema",
+            default="public",
+        ),
+        ParameterSpec(
+            name="driver",
+            kind="string",
+            prompt="driver",
+            default="asyncpg",
+        ),
+        ParameterSpec(
+            name="table_prefix",
+            kind="string",
+            prompt="table_prefix",
+            default="",
+        ),
+        ParameterSpec(
+            name="mapping_strategy",
+            kind="string",
+            prompt="mapping_strategy",
+            default="generic_json",
+            choices=("generic_json", "structured"),
+        ),
+        ParameterSpec(
+            name="auto_create_schema",
+            kind="boolean",
+            prompt="auto_create_schema",
+            default=True,
+        ),
+        ParameterSpec(
+            name="multitenant",
+            kind="boolean",
+            prompt="multitenant",
+            default=False,
+        ),
+    ),
+    facets=POSTGRESQL_FACETS,
+)
+
+__all__ = ["POSTGRESQL_REPOSITORY_ADAPTER"]

--- a/cli/arclith_cli/catalogs/repository_postgresql.py
+++ b/cli/arclith_cli/catalogs/repository_postgresql.py
@@ -10,8 +10,8 @@ POSTGRESQL_REPOSITORY_ADAPTER = AdapterSpec(
     capability="repository",
     layer="outbound",
     description=(
-        "Repository PostgreSQL async optionnel avec JSONB par defaut ou "
-        "mapping structure explicite."
+        "Repository PostgreSQL async optionnel avec JSONB par défaut ou "
+        "mapping structuré explicite."
     ),
     config_path="config/adapters/outbound/postgresql.yaml",
     config_template="""\

--- a/cli/tests/test_add_adapter.py
+++ b/cli/tests/test_add_adapter.py
@@ -234,6 +234,8 @@ def test_add_postgresql_adapter_uses_catalog_params(tmp_path: Path) -> None:
             "schema": "app",
             "driver": "asyncpg",
             "table_prefix": "todo_",
+            "mapping_strategy": "structured",
+            "auto_create_schema": "false",
             "multitenant": "false",
         },
         yes=True,
@@ -267,6 +269,8 @@ def test_add_postgresql_adapter_uses_catalog_params(tmp_path: Path) -> None:
     assert "url: null" in postgresql_config
     assert "password: null" in postgresql_config
     assert 'table_prefix: "todo_"' in postgresql_config
+    assert "mapping_strategy: structured" in postgresql_config
+    assert "auto_create_schema: false" in postgresql_config
     assert "multitenant: false" in postgresql_config
 
     secrets = (project_dir / "config" / "secrets.yaml").read_text(encoding="utf-8")
@@ -300,6 +304,8 @@ def test_add_postgresql_adapter_generates_loadable_single_tenant_config(
     assert arclith.config.adapters.postgresql.url is None
     assert arclith.config.adapters.postgresql.database == "demo_shared"
     assert arclith.config.adapters.postgresql.schema_name == "public"
+    assert arclith.config.adapters.postgresql.mapping_strategy == "generic_json"
+    assert arclith.config.adapters.postgresql.auto_create_schema is True
     assert arclith.config.adapters.postgresql.multitenant is False
 
 

--- a/cli/tests/test_capabilities.py
+++ b/cli/tests/test_capabilities.py
@@ -45,6 +45,8 @@ def test_repository_capability_catalog_declares_standard_adapters() -> None:
         "schema",
         "driver",
         "table_prefix",
+        "mapping_strategy",
+        "auto_create_schema",
         "multitenant",
     ]
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -30,7 +30,7 @@ arclith-cli capabilities --json
 | [license](capabilities/license.md) | inbound | `role` | contrôler un droit d'accès |
 | [probe](capabilities/probe.md) | inbound | `server` | exposer `/health` et `/ready` |
 | [http](capabilities/http.md) | inbound | `idempotency`, `etag`, `cache-control` | durcir les conventions HTTP |
-| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | choisir les garanties, router par entité et persister les entités métier |
+| [repository](capabilities/repository.md) | outbound | `memory`, `mongodb`, `duckdb`, `mariadb`, `postgresql` | choisir les garanties, router par entité et opter pour un mapping PostgreSQL structuré |
 | [storage](capabilities/storage.md) | outbound | `filesystem`, `s3`, `azure-blob`, `gcs` | stocker fichiers et blobs |
 | [cache](capabilities/cache.md) | outbound | `memory`, `redis` | partager JWKS, tenants et idempotence |
 | [logger](capabilities/logger.md) | outbound | `console` | standardiser les logs |

--- a/docs/capabilities/repository.md
+++ b/docs/capabilities/repository.md
@@ -232,7 +232,7 @@ de persistance aux adapters inbound ou runtime.
 | `mongodb` | document / serveur | état métier partagé, modèle document-first ou évolutif | pas de modèle relationnel riche via le port |
 | `duckdb` | analytique embarqué / fichier | démonstrations et traitements analytiques locaux | pas une base applicative serveur multi-processus |
 | `mariadb` | relationnel avec payload JSON / serveur | intégration à un SI MariaDB existant | entité stockée en JSON, sans mapping relationnel métier riche |
-| `postgresql` | relationnel avec payload JSONB / serveur | SQL serveur robuste et état partagé | entité stockée en JSONB, sans mapping relationnel métier riche |
+| `postgresql` | JSONB par défaut, colonnes typées opt-in / serveur | SQL serveur robuste, contraintes et index ciblés | mapper et migrations structurées restent à la charge de l'application |
 
 ### Matrice Des Garanties
 
@@ -242,12 +242,17 @@ de persistance aux adapters inbound ou runtime.
 | `mongodb` | oui | oui | `limited` | `flexible` |
 | `duckdb` | non | non | `limited` | `structured_tables` |
 | `mariadb` | oui | oui | `strong` | `json_table` |
-| `postgresql` | oui | oui | `strong` | `json_table` |
+| `postgresql` | oui | oui | `strong` | `json_table` par défaut, `structured_tables` opt-in |
 
 `production_ready` décrit la cible de l'adapter Arclith, pas une certification
 automatique du déploiement. La haute disponibilité, les sauvegardes, la
 réplication, le chiffrement et les tests de charge restent à valider dans
 l'infrastructure du service.
+
+La facet PostgreSQL décrit le chemin par défaut `generic_json`. Une application
+peut sélectionner `structured` pour une entité sans changer le port
+`Repository[T]` ; le catalogue ne prétend pas qu'un unique schéma physique
+s'applique à toutes les configurations possibles.
 
 ### Memory
 
@@ -315,13 +320,174 @@ password: null
 schema: public
 driver: asyncpg
 table_prefix: ""
+mapping_strategy: generic_json
+auto_create_schema: true
 multitenant: false
 ```
 
 PostgreSQL suit le même port avec une table générique par type et un payload
-JSONB. L'adapter cible un serveur SQL durable et multi-processus. Les colonnes
-métier typées, Alembic, les joins et les contraintes SQL métier restent hors du
-contrat actuel.
+JSONB par défaut. L'adapter cible un serveur SQL durable et multi-processus.
+Une application peut opter explicitement pour des colonnes typées avec le
+mécanisme décrit ci-dessous. Les relations automatiques, les joins, une query
+DSL et la gestion des migrations restent hors du contrat Arclith.
+
+## Mapping Relationnel Structuré Optionnel
+
+### Quand L'utiliser
+
+Conserver `mapping_strategy: generic_json` tant qu'une entité est naturellement
+document-first et que les champs techniques suffisent pour les opérations du
+repository. C'est le comportement backward-compatible et le chemin recommandé
+pour démarrer.
+
+Choisir `structured` seulement lorsqu'un besoin vérifié exige une représentation
+relationnelle : contrainte `UNIQUE`, index métier, reporting SQL sur des colonnes
+typées, compatibilité avec une table existante ou optimisation d'une requête
+ciblée. Le mapper appartient alors à l'application et à son assemblage
+d'infrastructure ; l'entité métier n'importe ni SQLAlchemy ni PostgreSQL.
+
+Cette première itération exécute le mapping structuré uniquement dans l'adapter
+`postgresql`. MariaDB conserve son stockage JSON générique. Sa configuration
+n'accepte pas `mapping_strategy: structured` tant qu'un support équivalent n'a
+pas été implémenté et testé.
+
+### Déclarer Un Mapper
+
+Le contrat public est pur Python et peut être importé directement depuis
+`arclith` :
+
+```python
+from collections.abc import Mapping
+from typing import Any
+
+from arclith import (
+    Entity,
+    RelationalColumn,
+    RelationalIndex,
+)
+
+
+class UserAccount(Entity):
+    email: str
+    display_name: str
+
+
+class UserAccountMapper:
+    entity_class = UserAccount
+    table_name = "user_accounts"
+    columns = (
+        RelationalColumn("uuid", "uuid", primary_key=True),
+        RelationalColumn("email", "string", unique=True, indexed=True),
+        RelationalColumn("display_name", "string"),
+        RelationalColumn("created_at", "datetime", indexed=True),
+        RelationalColumn("updated_at", "datetime"),
+        RelationalColumn("deleted_at", "datetime", nullable=True, indexed=True),
+        RelationalColumn("version", "integer"),
+    )
+    indexes = (
+        RelationalIndex(
+            "ix_user_accounts_display_created",
+            ("display_name", "created_at"),
+        ),
+    )
+
+    def to_record(self, entity: UserAccount) -> Mapping[str, Any]:
+        return {
+            "uuid": entity.uuid,
+            "email": entity.email,
+            "display_name": entity.display_name,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def from_record(self, record: Mapping[str, Any]) -> UserAccount:
+        return UserAccount(**dict(record))
+```
+
+Les kinds supportés sont `uuid`, `string`, `integer`, `float`, `boolean`,
+`date`, `datetime` et `json`. PostgreSQL matérialise `json` en `JSONB` et les
+dates/heures avec un type timezone-aware.
+
+Pour préserver les opérations de `Repository[T]`, chaque mapper déclare les
+colonnes `uuid`, `created_at`, `updated_at`, `deleted_at` et `version` avec les
+kinds correspondants. `uuid` est l'unique clé primaire et `deleted_at` est
+nullable. Les noms de table, colonne et index sont des identifiants SQL sûrs ;
+les doublons et les index pointant vers une colonne inconnue sont refusés dès
+l'enregistrement.
+
+`to_record()` doit retourner exactement les colonnes déclarées et le même UUID
+que l'entité. `from_record()` doit restituer la classe d'entité attendue. Le
+mapper doit inclure tous les champs applicatifs ou d'audit que le service veut
+préserver ; Arclith ne génère pas implicitement les colonnes métier depuis le
+modèle Pydantic.
+
+### Enregistrer Et Câbler Le Mapper
+
+Le registre utilise l'identité exacte de la classe, sans import magique ni nom
+court :
+
+```python
+from arclith import RelationalMapperRegistry
+
+mapper_registry = RelationalMapperRegistry()
+mapper_registry.register(UserAccountMapper())
+
+users = arclith.repository(
+    UserAccount,
+    mapper_registry=mapper_registry,
+)
+```
+
+La configuration PostgreSQL associée sélectionne la stratégie :
+
+```yaml
+# config/adapters/outbound/postgresql.yaml
+database: identity_service
+schema: public
+table_prefix: "identity_"
+mapping_strategy: structured
+auto_create_schema: false
+```
+
+Avec ce préfixe, le mapper ci-dessus cible la table
+`public.identity_user_accounts`. Si `structured` est sélectionné sans mapper
+enregistré pour `UserAccount`, la construction du repository échoue avec le
+chemin Python complet de la classe. Les autres entités peuvent continuer à
+utiliser le fallback ou un adapter distinct via `repository_bindings`.
+
+`mapper_registry` s'applique au registry repository intégré. Une application
+qui fournit déjà son propre `RepositoryRegistry` peut partir de
+`default_repository_registry(EntityClass, mapper_registry=...)`, y enregistrer
+ses factories supplémentaires, puis le passer comme `registry`. Cela garde une
+source de wiring unique et évite deux registries concurrents dans le même appel.
+
+### Création De Schéma Et Migrations
+
+`auto_create_schema: true` conserve le comportement PostgreSQL historique :
+SQLAlchemy exécute uniquement `CREATE SCHEMA IF NOT EXISTS` si nécessaire, puis
+`create_all()` pour les tables absentes. Ce mode est pratique en développement
+et dans les tests ; il ne modifie ni ne supprime une colonne existante.
+
+En production, utiliser `auto_create_schema: false` et appliquer les migrations
+avec l'outil choisi par l'application avant le démarrage. Dans ce mode, Arclith
+n'exécute aucune création implicite. Toute modification de `columns`,
+`indexes`, `unique`, `nullable`, `table_name`, `schema` ou `table_prefix` peut
+nécessiter une migration explicite.
+
+Arclith ne génère pas de révision Alembic, n'exécute pas d'`ALTER TABLE`, ne
+compare pas le mapper au schéma vivant et ne promet aucune migration destructive
+automatique. Le mapper décrit la forme attendue par l'adapter ; l'application
+reste propriétaire du cycle de vie du schéma.
+
+### Requêtes Métier Et Relations
+
+Le mapping structuré n'ajoute aucune méthode à `Repository[T]`. Un besoin tel
+que `find_by_email()` doit rester un port métier explicite implémenté par
+l'application. De même, les relations, le lazy loading et les joins automatiques
+ne font pas partie du mécanisme. Pour les agrégats et stores multiples, les
+limites transactionnelles décrites plus bas restent inchangées.
 
 ## Production
 
@@ -333,7 +499,9 @@ Choisir l'adapter à partir des garanties nécessaires :
    contraintes explicites ;
 3. choisir `mongodb` pour un modèle document-first partagé et évolutif ;
 4. choisir `mariadb` lorsqu'un SI MariaDB existe déjà ;
-5. choisir `postgresql` pour un backend SQL serveur général avec payload JSONB.
+5. choisir `postgresql` pour un backend SQL serveur général avec payload JSONB ;
+6. activer son mapping `structured` seulement si des colonnes, contraintes ou
+   index métier apportent une valeur mesurable.
 
 Les URI et mots de passe passent par la capability [`secrets`](secrets.md), par
 exemple `MONGODB_URI`, `MARIADB_URL`, `MARIADB_PASSWORD`, `POSTGRESQL_URL` ou
@@ -402,10 +570,21 @@ taxonomie adaptée à sa responsabilité.
 
 ### Un Backend SQL N'Expose Pas De Joins Métier
 
-`mariadb` et `postgresql` implémentent aujourd'hui le port CRUD entity-first et
-stockent un payload JSON ou JSONB générique. Une application qui exige des
+`mariadb` stocke un payload JSON générique ; `postgresql` utilise JSONB par
+défaut et accepte un mapper structuré explicite. Une application qui exige des
 requêtes relationnelles typées, des contraintes métier ou des transactions
 multi-agrégats doit définir un port applicatif dédié dans son propre domaine.
+Le mapping structuré PostgreSQL rend les colonnes disponibles à cet adapter
+applicatif, mais n'élargit pas le port générique.
+
+### Le Mapping Structuré Refuse De Démarrer
+
+Vérifier que la configuration PostgreSQL contient
+`mapping_strategy: structured`, que le `RelationalMapperRegistry` enregistre
+exactement la classe passée à `arclith.repository()`, et que ce registre est
+fourni via `mapper_registry`. Le message indique le chemin complet de l'entité
+sans mapper. Si la table n'existe pas et que `auto_create_schema` vaut `false`,
+appliquer la migration applicative avant de relancer le service.
 
 ### Un Binding Est Refusé
 

--- a/docs/capabilities/repository.md
+++ b/docs/capabilities/repository.md
@@ -415,7 +415,9 @@ colonnes `uuid`, `created_at`, `updated_at`, `deleted_at` et `version` avec les
 kinds correspondants. `uuid` est l'unique clé primaire et `deleted_at` est
 nullable. Les noms de table, colonne et index sont des identifiants SQL sûrs ;
 les doublons et les index pointant vers une colonne inconnue sont refusés dès
-l'enregistrement.
+l'enregistrement. Le préfixe de colonne `_arclith_` est réservé aux valeurs
+internes de l'adapter, notamment au total de pagination, et ne peut pas être
+utilisé par un mapper applicatif.
 
 `to_record()` doit retourner exactement les colonnes déclarées et le même UUID
 que l'entité. `from_record()` doit restituer la classe d'entité attendue. Le

--- a/journal/2026-09-04-relational-mapping.md
+++ b/journal/2026-09-04-relational-mapping.md
@@ -21,7 +21,9 @@ le domaine ne doit dépendre ni de SQLAlchemy ni d'un schéma physique.
   confie la création et l'évolution du schéma à ses migrations applicatives ;
 - exiger les colonnes techniques nécessaires au contrat `Repository[T]` et
   valider les identifiants, collisions et références d'index avant accès à la
-  base.
+  base ;
+- réserver le préfixe de colonne `_arclith_` aux labels internes de l'adapter
+  pour empêcher toute collision avec les colonnes applicatives.
 
 ## Conséquences
 
@@ -41,6 +43,7 @@ par défaut, et documentent l'opt-in structuré.
 - construction SQLAlchemy des colonnes, contraintes et index PostgreSQL ;
 - CRUD sur engine fake sans création implicite lorsque
   `auto_create_schema=false` ;
+- pagination structurée avec un label de total interne réservé ;
 - compatibilité de `build_repository()` et `Arclith.repository()` avec et sans
   registre de mappers ;
 - génération CLI et chargement de la configuration PostgreSQL ;

--- a/journal/2026-09-04-relational-mapping.md
+++ b/journal/2026-09-04-relational-mapping.md
@@ -1,0 +1,47 @@
+# Mapping relationnel structuré optionnel
+
+## Contexte
+
+L'issue #177 demande de conserver `Repository[T]` comme port CRUD commun tout
+en permettant à une application de matérialiser certaines entités PostgreSQL
+dans des colonnes typées. Le stockage JSONB existant doit rester le défaut et
+le domaine ne doit dépendre ni de SQLAlchemy ni d'un schéma physique.
+
+## Décision
+
+- ajouter un contrat pur Python `RelationalEntityMapper` et des déclarations
+  vendor-neutral de colonnes et d'index dans l'adapter outbound relationnel ;
+- résoudre les mappers par identité exacte de classe via
+  `RelationalMapperRegistry`, fourni explicitement par l'assemblage applicatif ;
+- supporter `mapping_strategy: structured` dans PostgreSQL seulement pour cette
+  première itération ; MariaDB conserve son payload JSON générique ;
+- garder `generic_json` et la création de schéma activée comme valeurs par
+  défaut afin de préserver le comportement PostgreSQL existant ;
+- permettre `auto_create_schema: false` afin qu'un déploiement de production
+  confie la création et l'évolution du schéma à ses migrations applicatives ;
+- exiger les colonnes techniques nécessaires au contrat `Repository[T]` et
+  valider les identifiants, collisions et références d'index avant accès à la
+  base.
+
+## Conséquences
+
+Le code métier et les use cases continuent à dépendre de `Repository[T]`.
+L'application garde la responsabilité de la conversion complète de l'entité,
+des ports de requêtes métier, des migrations et des contraintes cross-store.
+Arclith ne fournit ni génération automatique de mapper, ni relations, ni query
+DSL, ni `ALTER TABLE` implicite.
+
+Le catalogue CLI expose les deux options PostgreSQL dans la configuration
+générée. Les facets continuent à décrire `generic_json`, qui reste la stratégie
+par défaut, et documentent l'opt-in structuré.
+
+## Validation
+
+- tests unitaires du contrat, du registre, des validations et du round-trip ;
+- construction SQLAlchemy des colonnes, contraintes et index PostgreSQL ;
+- CRUD sur engine fake sans création implicite lorsque
+  `auto_create_schema=false` ;
+- compatibilité de `build_repository()` et `Arclith.repository()` avec et sans
+  registre de mappers ;
+- génération CLI et chargement de la configuration PostgreSQL ;
+- `make quality`, `make precommit` et `make docs` avant livraison.

--- a/tests/units/adapters/outbound/relational/test_mapping.py
+++ b/tests/units/adapters/outbound/relational/test_mapping.py
@@ -102,6 +102,11 @@ def test_column_declaration_rejects_unknown_kind() -> None:
         RelationalColumn("payload", cast(Any, "binary"))
 
 
+def test_column_declaration_rejects_internal_prefix() -> None:
+    with pytest.raises(ValueError, match=r"reserved '_arclith_' prefix"):
+        RelationalColumn("_arclith_pagination_total", "integer")
+
+
 def test_registry_rejects_unsafe_table_name() -> None:
     class UnsafeTableMapper(UserAccountMapper):
         table_name = "unsafe-name"

--- a/tests/units/adapters/outbound/relational/test_mapping.py
+++ b/tests/units/adapters/outbound/relational/test_mapping.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import pytest
 
+import arclith.domain as domain_package
 from arclith.adapters.outbound.relational import (
     RelationalColumn,
     RelationalEntityMapper,
@@ -133,7 +134,8 @@ def test_mapper_protocol_is_satisfied_statically() -> None:
 
 def test_domain_does_not_import_sqlalchemy() -> None:
     imported_modules: set[str] = set()
-    for source_path in Path("arclith/domain").rglob("*.py"):
+    domain_path = Path(domain_package.__file__).resolve().parent
+    for source_path in domain_path.rglob("*.py"):
         tree = ast.parse(source_path.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):

--- a/tests/units/adapters/outbound/relational/test_mapping.py
+++ b/tests/units/adapters/outbound/relational/test_mapping.py
@@ -85,9 +85,12 @@ def test_registry_rejects_mapper_collision() -> None:
     "declaration",
     [
         lambda: RelationalColumn("unsafe-name", "string"),
+        lambda: RelationalColumn(cast(Any, 42), "string"),
         lambda: RelationalIndex("unsafe-name", ("email",)),
+        lambda: RelationalIndex(cast(Any, 42), ("email",)),
         lambda: RelationalIndex("safe_name", ()),
         lambda: RelationalIndex("safe_name", ("email", "email")),
+        lambda: RelationalIndex("safe_name", (cast(Any, 42),)),
     ],
 )
 def test_column_and_index_declarations_reject_invalid_names_or_columns(

--- a/tests/units/adapters/outbound/relational/test_mapping.py
+++ b/tests/units/adapters/outbound/relational/test_mapping.py
@@ -1,0 +1,147 @@
+import ast
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from arclith.adapters.outbound.relational import (
+    RelationalColumn,
+    RelationalEntityMapper,
+    RelationalIndex,
+    RelationalMapperRegistry,
+)
+from arclith.domain.models.entity import Entity
+
+
+class UserAccount(Entity):
+    email: str
+    display_name: str
+
+
+class UserAccountMapper:
+    entity_class = UserAccount
+    table_name = "user_accounts"
+    columns = (
+        RelationalColumn("uuid", "uuid", primary_key=True),
+        RelationalColumn("email", "string", unique=True, indexed=True),
+        RelationalColumn("display_name", "string"),
+        RelationalColumn("created_at", "datetime", indexed=True),
+        RelationalColumn("updated_at", "datetime"),
+        RelationalColumn("deleted_at", "datetime", nullable=True, indexed=True),
+        RelationalColumn("version", "integer"),
+    )
+    indexes = (
+        RelationalIndex(
+            "ix_user_accounts_display_created",
+            ("display_name", "created_at"),
+        ),
+    )
+
+    def to_record(self, entity: UserAccount) -> Mapping[str, Any]:
+        return {
+            "uuid": entity.uuid,
+            "email": entity.email,
+            "display_name": entity.display_name,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def from_record(self, record: Mapping[str, Any]) -> UserAccount:
+        return UserAccount(**dict(record))
+
+
+def test_empty_registry_resolves_none_and_require_fails() -> None:
+    registry = RelationalMapperRegistry()
+
+    assert registry.resolve(UserAccount) is None
+    with pytest.raises(ValueError, match=r"registered mapper.*UserAccount"):
+        registry.require(UserAccount)
+
+
+def test_registry_registers_exact_entity_mapper_and_round_trips() -> None:
+    mapper = UserAccountMapper()
+    registry = RelationalMapperRegistry().register(mapper)
+    account = UserAccount(email="ada@example.net", display_name="Ada")
+
+    resolved = registry.require(UserAccount)
+    restored = resolved.from_record(resolved.to_record(account))
+
+    assert resolved is mapper
+    assert restored == account
+
+
+def test_registry_rejects_mapper_collision() -> None:
+    registry = RelationalMapperRegistry().register(UserAccountMapper())
+
+    with pytest.raises(ValueError, match=r"already registered.*UserAccount"):
+        registry.register(UserAccountMapper())
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        lambda: RelationalColumn("unsafe-name", "string"),
+        lambda: RelationalIndex("unsafe-name", ("email",)),
+        lambda: RelationalIndex("safe_name", ()),
+        lambda: RelationalIndex("safe_name", ("email", "email")),
+    ],
+)
+def test_column_and_index_declarations_reject_invalid_names_or_columns(
+    declaration,
+) -> None:
+    with pytest.raises(ValueError):
+        declaration()
+
+
+def test_column_declaration_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="Unsupported relational column kind"):
+        RelationalColumn("payload", cast(Any, "binary"))
+
+
+def test_registry_rejects_unsafe_table_name() -> None:
+    class UnsafeTableMapper(UserAccountMapper):
+        table_name = "unsafe-name"
+
+    with pytest.raises(ValueError, match="table name"):
+        RelationalMapperRegistry().register(UnsafeTableMapper())
+
+
+def test_registry_rejects_unknown_index_column() -> None:
+    class UnknownIndexColumnMapper(UserAccountMapper):
+        indexes = (RelationalIndex("ix_unknown", ("missing",)),)
+
+    with pytest.raises(ValueError, match=r"unknown columns: missing"):
+        RelationalMapperRegistry().register(UnknownIndexColumnMapper())
+
+
+def test_registry_requires_repository_lifecycle_columns() -> None:
+    class IncompleteMapper(UserAccountMapper):
+        columns = UserAccountMapper.columns[:-1]
+
+    with pytest.raises(ValueError, match=r"missing Repository columns: version"):
+        RelationalMapperRegistry().register(IncompleteMapper())
+
+
+def test_mapper_protocol_is_satisfied_statically() -> None:
+    mapper: RelationalEntityMapper[UserAccount] = UserAccountMapper()
+
+    assert mapper.entity_class is UserAccount
+
+
+def test_domain_does_not_import_sqlalchemy() -> None:
+    imported_modules: set[str] = set()
+    for source_path in Path("arclith/domain").rglob("*.py"):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_modules.add(node.module)
+
+    assert not any(
+        module == "sqlalchemy" or module.startswith("sqlalchemy.")
+        for module in imported_modules
+    )

--- a/tests/units/adapters/outbound/test_postgresql_config.py
+++ b/tests/units/adapters/outbound/test_postgresql_config.py
@@ -15,7 +15,11 @@ def test_connection_url_encodes_credentials() -> None:
 
 
 def test_with_tenant_params_accepts_aliases_and_schema() -> None:
-    config = PostgreSQLConfig(database="default").with_tenant_params(
+    config = PostgreSQLConfig(
+        database="default",
+        mapping_strategy="structured",
+        auto_create_schema=False,
+    ).with_tenant_params(
         {
             "db_name": "tenant",
             "username": "tenant_user",
@@ -30,6 +34,8 @@ def test_with_tenant_params_accepts_aliases_and_schema() -> None:
     assert config.password == "secret"
     assert config.schema == "tenant_schema"
     assert config.table_prefix == "tenant_"
+    assert config.mapping_strategy == "structured"
+    assert config.auto_create_schema is False
     assert (
         config.connection_url()
         == "postgresql+asyncpg://tenant_user:secret@127.0.0.1:5432/tenant"
@@ -81,3 +87,15 @@ def test_rejects_unsafe_identifiers(field_name: str, value: str) -> None:
 def test_connection_url_requires_database_when_url_is_missing() -> None:
     with pytest.raises(ValueError, match="database is required"):
         PostgreSQLConfig(database=None).connection_url()
+
+
+def test_mapping_defaults_preserve_generic_repository_behavior() -> None:
+    config = PostgreSQLConfig(database="demo")
+
+    assert config.mapping_strategy == "generic_json"
+    assert config.auto_create_schema is True
+
+
+def test_config_rejects_unknown_mapping_strategy() -> None:
+    with pytest.raises(ValueError, match="mapping_strategy"):
+        PostgreSQLConfig(database="demo", mapping_strategy="automatic")

--- a/tests/units/adapters/outbound/test_postgresql_repository.py
+++ b/tests/units/adapters/outbound/test_postgresql_repository.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Mapping
 from datetime import date, datetime, timezone
 import json
 from typing import Any
@@ -10,6 +11,7 @@ pytest.importorskip("sqlalchemy")
 
 from arclith.adapters.outbound.postgresql.config import PostgreSQLConfig
 from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+from arclith.adapters.outbound.relational import RelationalColumn, RelationalIndex
 from arclith.domain.models.entity import Entity
 
 
@@ -23,13 +25,70 @@ class RichItem(Entity):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class UserAccount(Entity):
+    email: str
+    display_name: str
+
+
+class UserAccountMapper:
+    entity_class = UserAccount
+    table_name = "user_accounts"
+    columns = (
+        RelationalColumn("uuid", "uuid", primary_key=True),
+        RelationalColumn("email", "string", unique=True, indexed=True),
+        RelationalColumn("display_name", "string"),
+        RelationalColumn("created_at", "datetime", indexed=True),
+        RelationalColumn("updated_at", "datetime"),
+        RelationalColumn("deleted_at", "datetime", nullable=True, indexed=True),
+        RelationalColumn("version", "integer"),
+    )
+    indexes = (
+        RelationalIndex(
+            "ix_user_accounts_display_created",
+            ("display_name", "created_at"),
+        ),
+    )
+
+    def to_record(self, entity: UserAccount) -> Mapping[str, Any]:
+        return {
+            "uuid": entity.uuid,
+            "email": entity.email,
+            "display_name": entity.display_name,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def from_record(self, record: Mapping[str, Any]) -> UserAccount:
+        return UserAccount(**dict(record))
+
+
+class FakeResult:
+    def __init__(self, *, first: Any = None, rows: list[Any] | None = None) -> None:
+        self._first = first
+        self._rows = rows or []
+
+    def mappings(self) -> "FakeResult":
+        return self
+
+    def first(self) -> Any:
+        return self._first
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
 class FakeConnection:
     def __init__(self, engine: "FakeEngine") -> None:
         self._engine = engine
 
-    async def execute(self, statement) -> None:
+    async def execute(self, statement) -> FakeResult:
         self._engine.executed_statements.append(statement)
         await asyncio.sleep(0)
+        if self._engine.results:
+            return self._engine.results.pop(0)
+        return FakeResult()
 
     async def run_sync(self, fn) -> None:
         self._engine.run_sync_calls += 1
@@ -54,8 +113,12 @@ class FakeEngine:
         self.begin_calls = 0
         self.run_sync_calls = 0
         self.executed_statements: list[Any] = []
+        self.results: list[FakeResult] = []
 
     def begin(self) -> FakeBegin:
+        return FakeBegin(self)
+
+    def connect(self) -> FakeBegin:
         return FakeBegin(self)
 
 
@@ -72,6 +135,97 @@ def test_build_table_uses_schema_prefix_and_jsonb(logger) -> None:
     assert table.name == "svc_item"
     assert table.c.uuid.type.length == 36
     assert table.c.data.type.__class__.__name__ == "JSONB"
+
+
+def test_build_structured_table_transmits_columns_constraints_and_indexes(
+    logger,
+) -> None:
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(
+            database="demo",
+            schema="app",
+            table_prefix="svc_",
+            mapping_strategy="structured",
+        ),
+        UserAccount,
+        logger,
+        mapper=UserAccountMapper(),
+    )
+
+    _metadata, table = repository._table_for(repository._config)
+
+    assert table.schema == "app"
+    assert table.name == "svc_user_accounts"
+    assert table.c.uuid.primary_key is True
+    assert table.c.uuid.type.__class__.__name__ == "Uuid"
+    assert table.c.email.unique is True
+    assert table.c.email.index is True
+    explicit_index = next(
+        index
+        for index in table.indexes
+        if index.name == "ix_user_accounts_display_created"
+    )
+    assert [column.name for column in explicit_index.columns] == [
+        "display_name",
+        "created_at",
+    ]
+
+
+async def test_structured_crud_uses_mapper_without_implicit_schema_creation(
+    logger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account = UserAccount(email="ada@example.net", display_name="Ada")
+    mapper = UserAccountMapper()
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(
+            database="demo",
+            mapping_strategy="structured",
+            auto_create_schema=False,
+        ),
+        UserAccount,
+        logger,
+        mapper=mapper,
+    )
+    engine = FakeEngine()
+    engine.results = [
+        FakeResult(),
+        FakeResult(first=dict(mapper.to_record(account))),
+        FakeResult(),
+        FakeResult(),
+    ]
+    monkeypatch.setattr(repository, "_engine_for", lambda *args: engine)
+
+    assert await repository.create(account) == account
+    assert await repository.read(account.uuid) == account
+    assert await repository.update(account) == account
+    await repository.delete(account.uuid)
+
+    assert engine.run_sync_calls == 0
+    assert [statement.__class__.__name__ for statement in engine.executed_statements] == [
+        "Insert",
+        "Select",
+        "Update",
+        "Delete",
+    ]
+
+
+def test_structured_record_must_match_declared_columns(logger) -> None:
+    class IncompleteMapper(UserAccountMapper):
+        def to_record(self, entity: UserAccount) -> Mapping[str, Any]:
+            record = dict(super().to_record(entity))
+            record.pop("version")
+            return record
+
+    account = UserAccount(email="ada@example.net", display_name="Ada")
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(database="demo", mapping_strategy="structured"),
+        UserAccount,
+        logger,
+        mapper=IncompleteMapper(),
+    )
+
+    with pytest.raises(ValueError, match=r"missing: version"):
+        repository._entity_values(account)
 
 
 async def test_ensure_schema_is_locked_per_url(logger) -> None:

--- a/tests/units/adapters/outbound/test_postgresql_repository.py
+++ b/tests/units/adapters/outbound/test_postgresql_repository.py
@@ -209,6 +209,37 @@ async def test_structured_crud_uses_mapper_without_implicit_schema_creation(
     ]
 
 
+async def test_structured_find_page_uses_reserved_total_label(
+    logger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account = UserAccount(email="ada@example.net", display_name="Ada")
+    mapper = UserAccountMapper()
+    repository = PostgreSQLRepository(
+        PostgreSQLConfig(database="demo", mapping_strategy="structured"),
+        UserAccount,
+        logger,
+        mapper=mapper,
+    )
+    engine = FakeEngine()
+    engine.results = [
+        FakeResult(
+            rows=[
+                {
+                    **dict(mapper.to_record(account)),
+                    "_arclith_pagination_total": 7,
+                }
+            ]
+        )
+    ]
+    monkeypatch.setattr(repository, "_engine_for", lambda *args: engine)
+
+    entities, total = await repository.find_page(offset=2, limit=1)
+
+    assert entities == [account]
+    assert total == 7
+    assert "_arclith_pagination_total" in str(engine.executed_statements[0])
+
+
 def test_structured_record_must_match_declared_columns(logger) -> None:
     class IncompleteMapper(UserAccountMapper):
         def to_record(self, entity: UserAccount) -> Mapping[str, Any]:

--- a/tests/units/infrastructure/test_config.py
+++ b/tests/units/infrastructure/test_config.py
@@ -1065,6 +1065,24 @@ def test_postgresql_settings_with_database():
     assert settings.port == 5433
     assert settings.schema_name == "app"
     assert settings.table_prefix == "svc_"
+    assert settings.mapping_strategy == "generic_json"
+    assert settings.auto_create_schema is True
+
+
+def test_postgresql_settings_accepts_structured_mapping_without_auto_create():
+    settings = PostgreSQLSettings(
+        database="demo",
+        mapping_strategy="structured",
+        auto_create_schema=False,
+    )
+
+    assert settings.mapping_strategy == "structured"
+    assert settings.auto_create_schema is False
+
+
+def test_postgresql_settings_rejects_unknown_mapping_strategy():
+    with pytest.raises(ValidationError, match="mapping_strategy"):
+        PostgreSQLSettings(database="demo", mapping_strategy="automatic")
 
 
 def test_postgresql_settings_serializes_schema_alias():

--- a/tests/units/infrastructure/test_repository_factory.py
+++ b/tests/units/infrastructure/test_repository_factory.py
@@ -1,9 +1,15 @@
 import subprocess
 import sys
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
+from arclith.adapters.outbound.relational import (
+    RelationalColumn,
+    RelationalMapperRegistry,
+)
 from arclith.domain.models.entity import Entity
 from arclith.domain.ports.outbound.repository import Repository
 from arclith.infrastructure.config import (
@@ -17,6 +23,7 @@ from arclith.infrastructure.config import (
 from arclith.infrastructure.repository_factory import (
     RepositoryRegistry,
     build_repository,
+    default_repository_registry,
 )
 
 
@@ -30,6 +37,33 @@ class ChatThread(Entity):
 
 class UserAccount(Entity):
     pass
+
+
+class ItemMapper:
+    entity_class = Item
+    table_name = "items"
+    columns = (
+        RelationalColumn("uuid", "uuid", primary_key=True),
+        RelationalColumn("name", "string", indexed=True),
+        RelationalColumn("created_at", "datetime", indexed=True),
+        RelationalColumn("updated_at", "datetime"),
+        RelationalColumn("deleted_at", "datetime", nullable=True, indexed=True),
+        RelationalColumn("version", "integer"),
+    )
+    indexes = ()
+
+    def to_record(self, entity: Item) -> Mapping[str, Any]:
+        return {
+            "uuid": entity.uuid,
+            "name": entity.name,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def from_record(self, record: Mapping[str, Any]) -> Item:
+        return Item(**dict(record))
 
 
 def _entity_path(entity_class: type[Entity]) -> str:
@@ -196,6 +230,93 @@ def test_postgresql_returns_postgresql_repository(logger):
     )
     repo = build_repository(config, Item, logger)
     assert isinstance(repo, PostgreSQLRepository)
+    assert repo._mapper is None
+    assert repo._config.mapping_strategy == "generic_json"
+
+
+def test_postgresql_structured_requires_registered_mapper(logger):
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("asyncpg")
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="postgresql",
+            postgresql=PostgreSQLSettings(
+                database="test", mapping_strategy="structured"
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"registered mapper.*Item"):
+        build_repository(config, Item, logger)
+
+
+def test_postgresql_structured_uses_application_mapper_registry(logger):
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("asyncpg")
+    from arclith.adapters.outbound.postgresql.repository import PostgreSQLRepository
+
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="postgresql",
+            postgresql=PostgreSQLSettings(
+                database="test",
+                mapping_strategy="structured",
+                auto_create_schema=False,
+            ),
+        )
+    )
+    mapper = ItemMapper()
+    mapper_registry = RelationalMapperRegistry().register(mapper)
+
+    repo = build_repository(
+        config,
+        Item,
+        logger,
+        mapper_registry=mapper_registry,
+    )
+
+    assert isinstance(repo, PostgreSQLRepository)
+    assert repo._mapper is mapper
+    assert repo._config.auto_create_schema is False
+
+
+def test_default_repository_registry_preserves_structured_mapper_wiring(logger):
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("asyncpg")
+    config = AppConfig(
+        adapters=AdaptersSettings(
+            repository="postgresql",
+            postgresql=PostgreSQLSettings(
+                database="test", mapping_strategy="structured"
+            ),
+        )
+    )
+    mapper = ItemMapper()
+    mapper_registry = RelationalMapperRegistry().register(mapper)
+    repository_registry = default_repository_registry(
+        Item,
+        mapper_registry=mapper_registry,
+    )
+
+    repo = build_repository(config, Item, logger, registry=repository_registry)
+
+    assert repo._mapper is mapper
+
+
+def test_mapper_registry_cannot_be_combined_with_custom_repository_registry(logger):
+    config = AppConfig(adapters=AdaptersSettings(repository="memory"))
+    repository_registry = RepositoryRegistry().register(
+        "memory", lambda config, entity_class, logger: InMemoryRepository()
+    )
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        build_repository(
+            config,
+            Item,
+            logger,
+            registry=repository_registry,
+            mapper_registry=RelationalMapperRegistry(),
+        )
 
 
 def test_import_arclith_does_not_require_sql_repository_extras():

--- a/tests/units/test_arclith_repository.py
+++ b/tests/units/test_arclith_repository.py
@@ -1,6 +1,8 @@
 from collections.abc import Mapping
 from typing import Any
 
+import pytest
+
 from arclith import (
     Arclith,
     Entity,
@@ -82,3 +84,25 @@ def test_arclith_repository_wires_relational_mapper_registry(tmp_path):
 
     assert repository._mapper is mapper
     assert repository._config.auto_create_schema is False
+
+
+def test_arclith_repository_exposes_factory_registry_guidance(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "adapters:\n  repository: memory\n",
+        encoding="utf-8",
+    )
+    registry = RepositoryRegistry[BoundEntity, Repository[BoundEntity]]().register(
+        "memory", lambda config, entity_class, logger: InMemoryRepository()
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"capture it in the custom factory or extend "
+        r"default_repository_registry\(\)",
+    ):
+        Arclith(config_path).repository(
+            BoundEntity,
+            registry=registry,
+            mapper_registry=RelationalMapperRegistry(),
+        )

--- a/tests/units/test_arclith_repository.py
+++ b/tests/units/test_arclith_repository.py
@@ -1,9 +1,44 @@
-from arclith import Arclith, Entity, Repository, RepositoryRegistry
+from collections.abc import Mapping
+from typing import Any
+
+from arclith import (
+    Arclith,
+    Entity,
+    RelationalColumn,
+    RelationalMapperRegistry,
+    Repository,
+    RepositoryRegistry,
+)
 from arclith.adapters.outbound.memory.repository import InMemoryRepository
 
 
 class BoundEntity(Entity):
     pass
+
+
+class BoundEntityMapper:
+    entity_class = BoundEntity
+    table_name = "bound_entities"
+    columns = (
+        RelationalColumn("uuid", "uuid", primary_key=True),
+        RelationalColumn("created_at", "datetime", indexed=True),
+        RelationalColumn("updated_at", "datetime"),
+        RelationalColumn("deleted_at", "datetime", nullable=True, indexed=True),
+        RelationalColumn("version", "integer"),
+    )
+    indexes = ()
+
+    def to_record(self, entity: BoundEntity) -> Mapping[str, Any]:
+        return {
+            "uuid": entity.uuid,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+            "deleted_at": entity.deleted_at,
+            "version": entity.version,
+        }
+
+    def from_record(self, record: Mapping[str, Any]) -> BoundEntity:
+        return BoundEntity(**dict(record))
 
 
 def test_arclith_repository_routes_binding_through_application_registry(tmp_path):
@@ -24,3 +59,26 @@ def test_arclith_repository_routes_binding_through_application_registry(tmp_path
     repository = Arclith(config_path).repository(BoundEntity, registry=registry)
 
     assert repository is expected
+
+
+def test_arclith_repository_wires_relational_mapper_registry(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "adapters:\n"
+        "  repository: postgresql\n"
+        "  postgresql:\n"
+        "    database: demo\n"
+        "    mapping_strategy: structured\n"
+        "    auto_create_schema: false\n",
+        encoding="utf-8",
+    )
+    mapper = BoundEntityMapper()
+    mapper_registry = RelationalMapperRegistry().register(mapper)
+
+    repository = Arclith(config_path).repository(
+        BoundEntity,
+        mapper_registry=mapper_registry,
+    )
+
+    assert repository._mapper is mapper
+    assert repository._config.auto_create_schema is False


### PR DESCRIPTION
## Contexte

Dépôt : `karned-rekipe/arclith`, branche cible : `main`.

Closes #177.

Arclith sait déjà persister une entité PostgreSQL dans un payload JSONB générique. Cette PR ajoute l'opt-in relationnel structuré demandé par #177 sans modifier le port métier `Repository[T]`, sans introduire d'ORM dans le domaine et sans migration automatique cachée.

## Changements principaux

- ajoute le contrat pur Python `RelationalEntityMapper`, les déclarations `RelationalColumn` / `RelationalIndex` et un `RelationalMapperRegistry` résolu par classe exacte ;
- valide les identifiants SQL, collisions, index, types et colonnes lifecycle nécessaires au contrat repository ;
- câble `mapper_registry` dans `build_repository()` et `Arclith.repository()` tout en conservant les factories `RepositoryRegistry` à trois arguments ;
- ajoute à PostgreSQL `mapping_strategy: generic_json|structured` et `auto_create_schema`, avec JSONB et création de schéma conservés par défaut ;
- construit les tables SQLAlchemy typées, contraintes uniques et index déclarés pour la stratégie structurée ;
- garantit qu'`auto_create_schema: false` n'exécute aucune création implicite ;
- expose les options dans le catalogue et la génération `arclith-cli` ;
- sépare le catalogue PostgreSQL pour respecter la limite de 600 lignes par module.

## Impact

- API publique : nouveaux types relationnels exportés et paramètre optionnel `mapper_registry`; appels existants inchangés.
- Domaine : aucun import SQLAlchemy/PostgreSQL et aucun changement de `Repository[T]`.
- Données/schéma : `generic_json` reste le défaut backward-compatible. `structured` est limité à PostgreSQL dans cette itération. En production, `auto_create_schema: false` délègue le schéma aux migrations applicatives.
- Configuration : deux nouvelles clés PostgreSQL optionnelles, avec valeurs par défaut compatibles.
- Dépendances : aucune nouvelle dépendance de production ; l'extra PostgreSQL existant est réutilisé.
- RabbitMQ, MCP, ports inbound, vector store et storage : aucun impact.
- Release : commit `feat:` releasable ; aucun bump de version manuel dans cette PR.

## Validation

- `make quality` : 2 163 tests passés, 5 ignorés, couverture totale 91,19 % ; lint, sécurité, complexité et mypy passés ;
- `make precommit` passé ;
- `make docs` passé en mode strict ;
- `uv run --directory cli --frozen pytest -q` : 155 tests passés, 1 ignoré ;
- tests ciblés runtime : 196 passés ;
- `uv lock --check` et `uv lock --directory cli --check` passés ;
- `git diff --check` passé.

Les tests couvrent le registre vide, l'enregistrement/résolution, les collisions, les identifiants, le round-trip, le fallback JSONB, l'absence de mapper, le wiring des registries, la table/contraintes/index SQLAlchemy, le CRUD avec engine fake, l.absence de création implicite et la protection du label interne de pagination.

## Documentation et migrations

- documentation Pages mise à jour dans le catalogue et la page Repository ;
- journal ajouté : `journal/2026-09-04-relational-mapping.md` ;
- ADR séparé non nécessaire : la décision et ses limites sont contenues dans la documentation de capability et le journal ;
- aucune migration fournie volontairement : le mapper décrit le schéma attendu, l'application reste responsable d'Alembic ou de son outil de migration.

## Risques restants

Les chemins SQL sont vérifiés via la construction SQLAlchemy et un engine fake, sans serveur PostgreSQL réel obligatoire en CI. Les migrations, requêtes métier spécialisées, relations et support MariaDB structuré restent explicitement hors scope.
