### PR TITLE
feat: guider le scaffold du coeur métier

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -58,7 +58,10 @@ template est régénéré côté CLI pour appliquer le contrat `runtime/docker-i
 
 ### `add-entity` — Ajouter une entité métier
 
-Crée uniquement le fichier minimal d'une entité dans `src/<package>/domain/models/`.
+Crée un squelette minimal et guidé dans `src/<package>/domain/models/`. Le fichier
+signale où déclarer les champs et invariants, rappelle les champs déjà fournis par
+`Entity` et renvoie vers les guides Arclith et Pydantic. L'exemple `Field(...)`
+reste commenté, donc aucun import inutilisé n'est ajouté.
 
 ```bash
 cd my-recipe-service
@@ -71,20 +74,40 @@ Fichier généré :
 src/<package>/domain/models/shopping_item.py
 ```
 
-La commande ne génère aucun CRUD, aucun port repository, aucun adapter et aucun endpoint. Elle pose seulement le point d'ancrage du modèle métier ; le développeur complète ensuite les champs et invariants de l'entité.
+La commande ne génère aucun CRUD, aucun port repository, aucun adapter et aucun
+endpoint. Elle pose seulement le point d'ancrage du modèle métier ; le
+développeur complète ensuite les champs et invariants de l'entité.
 
 ---
 
 ### `add-usecase` — Ajouter un cas d'usage
 
-Crée le port inbound minimal dans `src/<package>/domain/ports/inbound/`, puis le fichier minimal du
-cas d'usage dans `src/<package>/application/use_cases/`.
+Crée un port inbound guidé dans `src/<package>/domain/ports/inbound/`, puis le
+cas d'usage dans `src/<package>/application/use_cases/`. Sans option de liaison,
+la commande interactive propose les entités détectées par analyse AST, la
+création d'une nouvelle entité ou un cas d'usage transverse.
 
 ```bash
 cd my-recipe-service
+
+# Mode interactif : choisir une entité détectée, en créer une ou rester transverse
 arclith-cli add-usecase PlanShoppingList
-arclith-cli add-usecase find-by-name
+
+# Modes directs, complets pour les agents et la CI
+arclith-cli add-usecase CreateTodo --entity Todo
+arclith-cli add-usecase CreateRecipe --new-entity Recipe
+arclith-cli add-usecase RunMaintenance --no-entity
 ```
+
+| Option | Effet |
+|---|---|
+| `--entity Todo` | lie le use case à une entité détectée et échoue si elle est absente |
+| `--new-entity Todo` | crée l'entité si nécessaire, puis génère le use case lié |
+| `--no-entity` | génère un `Command`, un `Result` et un use case transverse sans repository |
+
+Ces options sont mutuellement exclusives. `--new-entity` réutilise une entité
+valide déjà présente, mais refuse un fichier homonyme qui ne déclare pas la
+classe `Entity` attendue.
 
 Fichier généré :
 
@@ -93,9 +116,17 @@ src/<package>/domain/ports/inbound/plan_shopping_list.py
 src/<package>/application/use_cases/plan_shopping_list.py
 ```
 
-Le nom peut être fourni en PascalCase, snake_case ou kebab-case. Le suffixe `UseCase` est normalisé : `PlanShoppingListUseCase` et `plan-shopping-list-use-case` génèrent tous les deux `PlanShoppingListUseCase`.
+Le nom peut être fourni en PascalCase, snake_case ou kebab-case. Le suffixe
+`UseCase` est normalisé : `PlanShoppingListUseCase` et
+`plan-shopping-list-use-case` génèrent tous les deux
+`PlanShoppingListUseCase`.
 
-Comme `add-entity`, cette commande ne câble pas FastAPI, FastMCP, LangGraph, un repository ou un service. Les adapters se branchent ensuite explicitement avec `add-adapter` et devraient dépendre du port inbound généré.
+Pour une entité principale, le squelette injecte explicitement
+`Repository[Entity]` et type `execute` avec un `Command` Pydantic et l'entité en
+retour. Le mode transverse génère plutôt un `Command` et un `Result` Pydantic,
+sans repository implicite. Aucun mode ne câble FastAPI, FastMCP ou LangGraph.
+Les exemples complets et les règles de séparation sont dans le
+[deep dive du scaffold CLI](https://karned-rekipe.github.io/arclith/deep-dives/cli-scaffold/).
 
 ---
 

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -7,36 +7,20 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from .entity_scanner import EntityInfo, scan_entities
 from .project_paths import ProjectPaths, detect_project_paths
 from .rename import EntityNames
+from .scaffold_templates import (
+    render_entity_inbound_port_template,
+    render_entity_template,
+    render_entity_use_case_template,
+    render_transverse_inbound_port_template,
+    render_transverse_use_case_template,
+)
 
 console = Console()
 
 _NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
-
-_ENTITY_TEMPLATE = """from arclith.domain.models.entity import Entity
-
-
-class {class_name}(Entity):
-    pass
-"""
-
-_INBOUND_PORT_TEMPLATE = """from abc import ABC, abstractmethod
-
-
-class {class_name}Port(ABC):
-    @abstractmethod
-    async def execute(self) -> None:
-        raise NotImplementedError
-"""
-
-_USE_CASE_TEMPLATE = """from {inbound_port_module} import {class_name}Port
-
-
-class {class_name}UseCase({class_name}Port):
-    async def execute(self) -> None:
-        raise NotImplementedError("Implement {class_name}UseCase.execute")
-"""
 
 _INTENT_INTERPRETER_TEMPLATE = """class {class_name}Interpreter:
     async def interpret(self, prompt: str) -> None:
@@ -55,7 +39,9 @@ class UseCaseNames:
         pascal = _strip_pascal_suffix(names.pascal)
         snake = _strip_snake_suffix(names.snake)
         if not pascal or not snake:
-            console.print(f"[red]✗[/red] Nom de cas d'usage invalide : [bold]{raw}[/bold].")
+            console.print(
+                f"[red]✗[/red] Nom de cas d'usage invalide : [bold]{raw}[/bold]."
+            )
             raise typer.Exit(1)
         return cls(pascal=pascal, snake=snake)
 
@@ -71,7 +57,9 @@ class IntentInterpreterNames:
         pascal = _strip_pascal_intent_interpreter_suffix(names.pascal)
         snake = _strip_snake_intent_interpreter_suffix(names.snake)
         if not pascal or not snake:
-            console.print(f"[red]✗[/red] Nom d'interpréteur d'intention invalide : [bold]{raw}[/bold].")
+            console.print(
+                f"[red]✗[/red] Nom d'interpréteur d'intention invalide : [bold]{raw}[/bold]."
+            )
             raise typer.Exit(1)
         return cls(pascal=pascal, snake=snake)
 
@@ -88,7 +76,9 @@ def add_entity_cmd(*, project_dir: Path | None = None, entity_name: str) -> Path
     _assert_missing(entity_file, project_dir)
 
     _ensure_package_dirs(paths, "domain", "models")
-    entity_file.write_text(_ENTITY_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    entity_file.write_text(
+        render_entity_template(class_name=names.pascal), encoding="utf-8"
+    )
     console.print(
         f"[green]✓[/green] Entité {names.pascal} créée : "
         f"[bold]{entity_file.relative_to(project_dir)}[/bold]"
@@ -96,7 +86,13 @@ def add_entity_cmd(*, project_dir: Path | None = None, entity_name: str) -> Path
     return entity_file
 
 
-def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Path:
+def add_usecase_cmd(
+    *,
+    project_dir: Path | None = None,
+    usecase_name: str,
+    entity_name: str | None = None,
+    new_entity_name: str | None = None,
+) -> Path:
     project_dir = project_dir or Path.cwd()
     usecase_name = usecase_name.strip()
     _assert_project_root(project_dir, command="add-usecase")
@@ -108,17 +104,43 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
     inbound_port_file = paths.inbound_ports / f"{names.snake}.py"
     _assert_missing(usecase_file, project_dir)
     _assert_missing(inbound_port_file, project_dir)
+    entity = _resolve_usecase_entity(
+        project_dir=project_dir,
+        paths=paths,
+        entity_name=entity_name,
+        new_entity_name=new_entity_name,
+    )
 
     _ensure_package_dirs(paths, "domain", "ports", "inbound")
     _ensure_package_dirs(paths, "application", "use_cases")
-    inbound_port_file.write_text(_INBOUND_PORT_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
-    usecase_file.write_text(
-        _USE_CASE_TEMPLATE.format(
+    inbound_port_module = paths.import_path("domain", "ports", "inbound", names.snake)
+    if entity is None:
+        inbound_port_content = render_transverse_inbound_port_template(
+            class_name=names.pascal
+        )
+        usecase_content = render_transverse_use_case_template(
             class_name=names.pascal,
-            inbound_port_module=paths.import_path("domain", "ports", "inbound", names.snake),
-        ),
-        encoding="utf-8",
-    )
+            inbound_port_module=inbound_port_module,
+        )
+    else:
+        entity_module = paths.import_path(
+            "domain",
+            "models",
+            entity.file_path.stem,
+        )
+        inbound_port_content = render_entity_inbound_port_template(
+            class_name=names.pascal,
+            entity_class=entity.pascal,
+            entity_module=entity_module,
+        )
+        usecase_content = render_entity_use_case_template(
+            class_name=names.pascal,
+            entity_class=entity.pascal,
+            entity_module=entity_module,
+            inbound_port_module=inbound_port_module,
+        )
+    inbound_port_file.write_text(inbound_port_content, encoding="utf-8")
+    usecase_file.write_text(usecase_content, encoding="utf-8")
     console.print(
         f"[green]✓[/green] Port inbound {names.pascal}Port créé : "
         f"[bold]{inbound_port_file.relative_to(project_dir)}[/bold]"
@@ -127,10 +149,89 @@ def add_usecase_cmd(*, project_dir: Path | None = None, usecase_name: str) -> Pa
         f"[green]✓[/green] Cas d'usage {names.pascal}UseCase créé : "
         f"[bold]{usecase_file.relative_to(project_dir)}[/bold]"
     )
+    if entity is not None:
+        console.print(
+            f"[green]✓[/green] Entité principale : [bold]{entity.pascal}[/bold]"
+        )
     return usecase_file
 
 
-def add_intent_interpreter_cmd(*, project_dir: Path | None = None, intent_name: str) -> Path:
+def _resolve_usecase_entity(
+    *,
+    project_dir: Path,
+    paths: ProjectPaths,
+    entity_name: str | None,
+    new_entity_name: str | None,
+) -> EntityInfo | None:
+    if entity_name is not None and new_entity_name is not None:
+        console.print(
+            "[red]✗[/red] Une seule entité peut être choisie : "
+            "utilisez [bold]entity_name[/bold] ou [bold]new_entity_name[/bold]."
+        )
+        raise typer.Exit(1)
+    if entity_name is not None:
+        return _require_existing_entity(project_dir, entity_name)
+    if new_entity_name is None:
+        return None
+
+    raw_name = new_entity_name.strip()
+    _assert_valid_name(raw_name, label="entité")
+    names = EntityNames.from_input(raw_name)
+    existing_entity = _find_entity(project_dir, names.pascal)
+    if existing_entity is not None:
+        return existing_entity
+
+    expected_file = paths.domain_models / f"{names.snake}.py"
+    if expected_file.exists():
+        console.print(
+            f"[red]✗[/red] Le fichier [bold]{expected_file.relative_to(project_dir)}[/bold] "
+            f"existe mais ne déclare pas [bold]class {names.pascal}(Entity)[/bold]."
+        )
+        raise typer.Exit(1)
+
+    add_entity_cmd(project_dir=project_dir, entity_name=raw_name)
+    created_entity = _find_entity(project_dir, names.pascal)
+    if (
+        created_entity is None
+    ):  # pragma: no cover - defensive check after our own template
+        console.print(
+            f"[red]✗[/red] Impossible de détecter l'entité créée {names.pascal}."
+        )
+        raise typer.Exit(1)
+    return created_entity
+
+
+def _require_existing_entity(project_dir: Path, raw_name: str) -> EntityInfo:
+    normalized_name = raw_name.strip()
+    _assert_valid_name(normalized_name, label="entité")
+    names = EntityNames.from_input(normalized_name)
+    entity = _find_entity(project_dir, names.pascal)
+    if entity is not None:
+        return entity
+
+    detected = ", ".join(item.pascal for item in scan_entities(project_dir)) or "aucune"
+    console.print(
+        f"[red]✗[/red] Entité introuvable : [bold]{names.pascal}[/bold]. "
+        f"Entités détectées : {detected}. Utilisez [bold]--new-entity {names.pascal}[/bold] "
+        "pour la créer."
+    )
+    raise typer.Exit(1)
+
+
+def _find_entity(project_dir: Path, pascal_name: str) -> EntityInfo | None:
+    return next(
+        (
+            entity
+            for entity in scan_entities(project_dir)
+            if entity.pascal == pascal_name
+        ),
+        None,
+    )
+
+
+def add_intent_interpreter_cmd(
+    *, project_dir: Path | None = None, intent_name: str
+) -> Path:
     project_dir = project_dir or Path.cwd()
     intent_name = intent_name.strip()
     _assert_project_root(project_dir, command="add-intent-interpreter")
@@ -142,7 +243,9 @@ def add_intent_interpreter_cmd(*, project_dir: Path | None = None, intent_name: 
     _assert_missing(intent_file, project_dir)
 
     _ensure_package_dirs(paths, "application", "intent_interpreters")
-    intent_file.write_text(_INTENT_INTERPRETER_TEMPLATE.format(class_name=names.pascal), encoding="utf-8")
+    intent_file.write_text(
+        _INTENT_INTERPRETER_TEMPLATE.format(class_name=names.pascal), encoding="utf-8"
+    )
     console.print(
         f"[green]✓[/green] Interpréteur d'intention {names.pascal}Interpreter créé : "
         f"[bold]{intent_file.relative_to(project_dir)}[/bold]"
@@ -152,7 +255,9 @@ def add_intent_interpreter_cmd(*, project_dir: Path | None = None, intent_name: 
 
 def _assert_project_root(project_dir: Path, *, command: str) -> None:
     if not project_dir.exists() or not project_dir.is_dir():
-        console.print(f"[red]✗[/red] Répertoire introuvable : [bold]{project_dir}[/bold].")
+        console.print(
+            f"[red]✗[/red] Répertoire introuvable : [bold]{project_dir}[/bold]."
+        )
         raise typer.Exit(1)
 
     has_project_marker = (
@@ -185,7 +290,9 @@ def _assert_missing(path: Path, project_dir: Path) -> None:
     if not path.exists():
         return
 
-    console.print(f"[red]✗[/red] Le fichier existe déjà : [bold]{path.relative_to(project_dir)}[/bold].")
+    console.print(
+        f"[red]✗[/red] Le fichier existe déjà : [bold]{path.relative_to(project_dir)}[/bold]."
+    )
     raise typer.Exit(1)
 
 
@@ -193,7 +300,11 @@ def _ensure_package_dirs(paths: ProjectPaths, *relative_parts: str) -> None:
     target_dir = paths.package_root.joinpath(*relative_parts)
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    stop_at = paths.package_root.parent if paths.package_name is not None else paths.package_root
+    stop_at = (
+        paths.package_root.parent
+        if paths.package_name is not None
+        else paths.package_root
+    )
     init_dirs = [target_dir]
     for parent in target_dir.parents:
         if parent == stop_at:

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -205,11 +205,15 @@ def _require_existing_entity(project_dir: Path, raw_name: str) -> EntityInfo:
     normalized_name = raw_name.strip()
     _assert_valid_name(normalized_name, label="entité")
     names = EntityNames.from_input(normalized_name)
-    entity = _find_entity(project_dir, names.pascal)
+    entities = scan_entities(project_dir)
+    entity = next(
+        (item for item in entities if item.pascal == names.pascal),
+        None,
+    )
     if entity is not None:
         return entity
 
-    detected = ", ".join(item.pascal for item in scan_entities(project_dir)) or "aucune"
+    detected = ", ".join(item.pascal for item in entities) or "aucune"
     console.print(
         f"[red]✗[/red] Entité introuvable : [bold]{names.pascal}[/bold]. "
         f"Entités détectées : {detected}. Utilisez [bold]--new-entity {names.pascal}[/bold] "

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -25,6 +25,7 @@ from .recipe import (
     snapshot_project_files,
 )
 from .recipe_cli import history_command, replay_command
+from .scaffold_interactive import resolve_usecase_entity_choice
 from .updater import run_update
 
 app = typer.Typer(
@@ -306,21 +307,58 @@ def add_usecase(
             help="Nom du cas d'usage. Exemple : PlanShoppingList, find_by_name, import-catalog",
         ),
     ] = None,
+    entity: Annotated[
+        str | None,
+        typer.Option(
+            "--entity",
+            help="Lier le cas d'usage à une entité existante.",
+        ),
+    ] = None,
+    new_entity: Annotated[
+        str | None,
+        typer.Option(
+            "--new-entity",
+            help="Créer l'entité si nécessaire, puis lier le cas d'usage.",
+        ),
+    ] = None,
+    no_entity: Annotated[
+        bool,
+        typer.Option(
+            "--no-entity",
+            help="Générer un cas d'usage transverse sans repository.",
+        ),
+    ] = False,
     no_record: Annotated[
         bool,
         typer.Option("--no-record", hidden=True),
     ] = False,
 ) -> None:
-    """Créer uniquement le fichier minimal d'un cas d'usage dans application/use_cases."""
+    """Créer un port inbound et un cas d'usage guidés, liés ou transverses."""
     resolved_name = usecase or _prompt_usecase()
     project_dir = Path.cwd()
+    entity_choice = resolve_usecase_entity_choice(
+        project_dir=project_dir,
+        entity_name=entity,
+        new_entity_name=new_entity,
+        no_entity=no_entity,
+    )
     before = snapshot_project_files(project_dir) if not no_record else {}
-    add_usecase_cmd(project_dir=project_dir, usecase_name=resolved_name)
+    add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name=resolved_name,
+        entity_name=entity_choice.entity_name,
+        new_entity_name=entity_choice.new_entity_name,
+    )
     if not no_record:
         _record_success(
             project_dir,
             command="add-usecase",
-            args={"usecase": resolved_name},
+            args={
+                "usecase": resolved_name,
+                "entity": entity_choice.entity_name,
+                "new_entity": entity_choice.new_entity_name,
+                "no_entity": entity_choice.no_entity,
+            },
             before=before,
         )
 

--- a/cli/arclith_cli/recipe.py
+++ b/cli/arclith_cli/recipe.py
@@ -265,6 +265,10 @@ def step_summary(step: RecipeStep) -> str:
         entities = args.get("entities") or []
         suffix = f" ({', '.join(map(str, entities))})" if entities else ""
         return f"{capability}/{adapter}{suffix}"
+    if step.command == "add-usecase":
+        usecase = str(args.get("usecase") or "usecase")
+        entity = args.get("entity") or args.get("new_entity")
+        return f"{usecase} ({entity})" if entity else f"{usecase} (transverse)"
     for key in ("entity", "usecase", "intent"):
         if key in args:
             return str(args[key])
@@ -325,7 +329,16 @@ def _execute_step(
     if step.command == "add-usecase":
         from arclith_cli.core_scaffold import add_usecase_cmd
 
-        add_usecase_cmd(project_dir=target_dir, usecase_name=str(args["usecase"]))
+        raw_entity = args.get("entity")
+        raw_new_entity = args.get("new_entity")
+        add_usecase_cmd(
+            project_dir=target_dir,
+            usecase_name=str(args["usecase"]),
+            entity_name=str(raw_entity) if raw_entity is not None else None,
+            new_entity_name=(
+                str(raw_new_entity) if raw_new_entity is not None else None
+            ),
+        )
         return
     if step.command == "add-intent-interpreter":
         from arclith_cli.core_scaffold import add_intent_interpreter_cmd

--- a/cli/arclith_cli/scaffold_interactive.py
+++ b/cli/arclith_cli/scaffold_interactive.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+
+from .entity_scanner import scan_entities
+
+console = Console()
+
+_ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+
+@dataclass(frozen=True)
+class UseCaseEntityChoice:
+    entity_name: str | None = None
+    new_entity_name: str | None = None
+    no_entity: bool = False
+
+
+def resolve_usecase_entity_choice(
+    *,
+    project_dir: Path,
+    entity_name: str | None,
+    new_entity_name: str | None,
+    no_entity: bool,
+) -> UseCaseEntityChoice:
+    provided_modes = sum(
+        value is not None and value is not False
+        for value in (entity_name, new_entity_name, no_entity)
+    )
+    if provided_modes > 1:
+        console.print(
+            "[red]✗[/red] Les options [bold]--entity[/bold], "
+            "[bold]--new-entity[/bold] et [bold]--no-entity[/bold] "
+            "sont mutuellement exclusives."
+        )
+        raise typer.Exit(1)
+    if entity_name is not None:
+        return UseCaseEntityChoice(entity_name=entity_name)
+    if new_entity_name is not None:
+        return UseCaseEntityChoice(new_entity_name=new_entity_name)
+    if no_entity:
+        return UseCaseEntityChoice(no_entity=True)
+
+    entities = scan_entities(project_dir)
+    if entities:
+        console.print("\n[bold]Entité principale du cas d'usage[/bold]")
+        labels = [entity.pascal for entity in entities]
+        labels.extend(
+            ("Créer une nouvelle entité", "Aucune entité / cas d'usage transverse")
+        )
+        selected = _prompt_numbered_choice(labels)
+        if selected <= len(entities):
+            return UseCaseEntityChoice(entity_name=entities[selected - 1].pascal)
+        if selected == len(entities) + 1:
+            return UseCaseEntityChoice(new_entity_name=_prompt_entity_name())
+        return UseCaseEntityChoice(no_entity=True)
+
+    console.print("\n[yellow]Aucune entité détectée.[/yellow]")
+    selected = _prompt_numbered_choice(
+        [
+            "Créer une nouvelle entité maintenant",
+            "Continuer avec un cas d'usage transverse",
+            "Annuler",
+        ]
+    )
+    if selected == 1:
+        return UseCaseEntityChoice(new_entity_name=_prompt_entity_name())
+    if selected == 2:
+        return UseCaseEntityChoice(no_entity=True)
+    console.print("[yellow]Création annulée.[/yellow]")
+    raise typer.Exit(0)
+
+
+def _prompt_numbered_choice(labels: list[str]) -> int:
+    for index, label in enumerate(labels, start=1):
+        console.print(f"  [cyan]{index}[/cyan]. {label}")
+    choice = Prompt.ask(
+        "  [bold green]Choix[/bold green]",
+        choices=[str(index) for index in range(1, len(labels) + 1)],
+        default="1",
+    )
+    return int(choice)
+
+
+def _prompt_entity_name() -> str:
+    while True:
+        value = Prompt.ask(
+            "  [bold green]Nom de la nouvelle entité[/bold green]"
+        ).strip()
+        if not value:
+            console.print("  [red]Le nom ne peut pas être vide.[/red]")
+        elif not _ENTITY_RE.match(value):
+            console.print(
+                "  [red]Caractères invalides.[/red] "
+                "[dim]Lettres, chiffres, _ et - uniquement. "
+                "Doit commencer par une lettre.[/dim]"
+            )
+        else:
+            return value

--- a/cli/arclith_cli/scaffold_templates.py
+++ b/cli/arclith_cli/scaffold_templates.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+
+def render_entity_template(*, class_name: str) -> str:
+    return f'''from __future__ import annotations
+
+from arclith.domain.models.entity import Entity
+
+# Guides:
+# - Arclith entity tutorial: https://github.com/karned-rekipe/arclith/blob/main/docs/tutorials/todo-list/02-create-entity.md
+# - Arclith architecture: https://github.com/karned-rekipe/arclith/blob/main/arclith/docs/architecture.md
+# - Pydantic models: https://docs.pydantic.dev/latest/concepts/models/
+# - Pydantic fields: https://docs.pydantic.dev/latest/concepts/fields/
+# - Pydantic validators: https://docs.pydantic.dev/latest/concepts/validators/
+
+
+class {class_name}(Entity):
+    """TODO: define the business fields and invariants for this entity.
+
+    Arclith Entity already provides uuid, audit fields, soft-delete fields,
+    and optimistic versioning.
+    """
+
+    # Example:
+    # title: str = Field(min_length=1, max_length=140)
+    pass
+'''
+
+
+def render_entity_inbound_port_template(
+    *,
+    class_name: str,
+    entity_class: str,
+    entity_module: str,
+) -> str:
+    return f'''from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+from {entity_module} import {entity_class}
+
+# Guides:
+# - Arclith use case tutorial: https://github.com/karned-rekipe/arclith/blob/main/docs/tutorials/todo-list/03-create-usecase.md
+# - Arclith architecture: https://github.com/karned-rekipe/arclith/blob/main/arclith/docs/architecture.md
+# - Pydantic models: https://docs.pydantic.dev/latest/concepts/models/
+# - Pydantic fields: https://docs.pydantic.dev/latest/concepts/fields/
+
+
+class {class_name}Command(BaseModel):
+    """TODO: define validated input data for this use case."""
+
+    pass
+
+
+class {class_name}Port(ABC):
+    @abstractmethod
+    async def execute(self, command: {class_name}Command) -> {entity_class}:
+        raise NotImplementedError
+'''
+
+
+def render_entity_use_case_template(
+    *,
+    class_name: str,
+    entity_class: str,
+    entity_module: str,
+    inbound_port_module: str,
+) -> str:
+    return f'''from __future__ import annotations
+
+from arclith.domain.ports.outbound.repository import Repository
+
+from {entity_module} import {entity_class}
+from {inbound_port_module} import {class_name}Command, {class_name}Port
+
+
+class {class_name}UseCase({class_name}Port):
+    def __init__(self, repository: Repository[{entity_class}]) -> None:
+        self._repository = repository
+
+    async def execute(self, command: {class_name}Command) -> {entity_class}:
+        """TODO: orchestrate business rules and persist or return the entity."""
+        raise NotImplementedError("Implement {class_name}UseCase.execute")
+'''
+
+
+def render_transverse_inbound_port_template(*, class_name: str) -> str:
+    return f'''from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+# Guides:
+# - Arclith use case tutorial: https://github.com/karned-rekipe/arclith/blob/main/docs/tutorials/todo-list/03-create-usecase.md
+# - Arclith architecture: https://github.com/karned-rekipe/arclith/blob/main/arclith/docs/architecture.md
+# - Pydantic models: https://docs.pydantic.dev/latest/concepts/models/
+# - Pydantic fields: https://docs.pydantic.dev/latest/concepts/fields/
+
+
+class {class_name}Command(BaseModel):
+    """TODO: define validated input data for this use case."""
+
+    pass
+
+
+class {class_name}Result(BaseModel):
+    """TODO: define output data for this use case."""
+
+    pass
+
+
+class {class_name}Port(ABC):
+    @abstractmethod
+    async def execute(self, command: {class_name}Command) -> {class_name}Result:
+        raise NotImplementedError
+'''
+
+
+def render_transverse_use_case_template(
+    *,
+    class_name: str,
+    inbound_port_module: str,
+) -> str:
+    return f'''from __future__ import annotations
+
+from {inbound_port_module} import (
+    {class_name}Command,
+    {class_name}Port,
+    {class_name}Result,
+)
+
+
+class {class_name}UseCase({class_name}Port):
+    async def execute(self, command: {class_name}Command) -> {class_name}Result:
+        """TODO: orchestrate this transverse use case."""
+        raise NotImplementedError("Implement {class_name}UseCase.execute")
+'''

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 import typer
 
-import arclith_cli.core_scaffold as core_scaffold
 from arclith_cli.core_scaffold import (
     add_entity_cmd,
     add_intent_interpreter_cmd,
@@ -318,7 +317,10 @@ def test_add_usecase_existing_entity_reuses_ast_scanner(
         calls.append(scanned_project)
         return [EntityInfo(pascal="Todo", snake="todo", file_path=entity_file)]
 
-    monkeypatch.setattr(core_scaffold, "scan_entities", fake_scan_entities)
+    monkeypatch.setattr(
+        "arclith_cli.core_scaffold.scan_entities",
+        fake_scan_entities,
+    )
 
     add_usecase_cmd(
         project_dir=project_dir,

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -334,8 +334,25 @@ def test_add_usecase_existing_entity_reuses_ast_scanner(
 def test_add_usecase_rejects_missing_existing_entity(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project_dir = _src_project(tmp_path)
+    calls: list[Path] = []
+
+    def fake_scan_entities(scanned_project: Path) -> list[EntityInfo]:
+        calls.append(scanned_project)
+        return [
+            EntityInfo(
+                pascal="Existing",
+                snake="existing",
+                file_path=project_dir / "src/demo_service/domain/models/existing.py",
+            )
+        ]
+
+    monkeypatch.setattr(
+        "arclith_cli.core_scaffold.scan_entities",
+        fake_scan_entities,
+    )
 
     with pytest.raises(typer.Exit):
         add_usecase_cmd(
@@ -346,7 +363,9 @@ def test_add_usecase_rejects_missing_existing_entity(
 
     output = capsys.readouterr().out
     assert "Entité introuvable" in output
+    assert "Entités détectées : Existing" in output
     assert "--new-entity Missing" in output
+    assert calls == [project_dir]
     assert not (
         project_dir / "src/demo_service/application/use_cases/create_todo.py"
     ).exists()

--- a/cli/tests/test_core_scaffold.py
+++ b/cli/tests/test_core_scaffold.py
@@ -5,7 +5,13 @@ from pathlib import Path
 import pytest
 import typer
 
-from arclith_cli.core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_usecase_cmd
+import arclith_cli.core_scaffold as core_scaffold
+from arclith_cli.core_scaffold import (
+    add_entity_cmd,
+    add_intent_interpreter_cmd,
+    add_usecase_cmd,
+)
+from arclith_cli.entity_scanner import EntityInfo
 from arclith_cli.init_project import init_project_cmd
 
 
@@ -14,25 +20,38 @@ def _src_project(tmp_path: Path, package_name: str = "demo_service") -> Path:
     package_root = project_dir / "src" / package_name
     package_root.mkdir(parents=True)
     (package_root / "__init__.py").write_text("", encoding="utf-8")
-    (project_dir / "pyproject.toml").write_text('[project]\nname = "demo-service"\n', encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "demo-service"\n', encoding="utf-8"
+    )
     return project_dir
 
 
-def test_add_entity_creates_minimal_entity_in_src_package(tmp_path: Path) -> None:
+def test_add_entity_creates_guided_entity_in_src_package(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
     generated = add_entity_cmd(project_dir=project_dir, entity_name="ShoppingItem")
 
-    assert generated == project_dir / "src" / "demo_service" / "domain" / "models" / "shopping_item.py"
-    assert generated.read_text(encoding="utf-8") == (
-        "from arclith.domain.models.entity import Entity\n"
-        "\n"
-        "\n"
-        "class ShoppingItem(Entity):\n"
-        "    pass\n"
+    assert (
+        generated
+        == project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "models"
+        / "shopping_item.py"
     )
+    content = generated.read_text(encoding="utf-8")
+    assert content.startswith("from __future__ import annotations\n")
+    assert "from arclith.domain.models.entity import Entity" in content
+    assert "class ShoppingItem(Entity):" in content
+    assert "TODO: define the business fields and invariants" in content
+    assert "docs/tutorials/todo-list/02-create-entity.md" in content
+    assert "docs.pydantic.dev/latest/concepts/validators/" in content
+    assert "from pydantic import Field" not in content
     assert (project_dir / "src" / "demo_service" / "domain" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "domain" / "models" / "__init__.py").exists()
+    assert (
+        project_dir / "src" / "demo_service" / "domain" / "models" / "__init__.py"
+    ).exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
 
@@ -46,20 +65,21 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert (generated / "Dockerfile").exists()
     assert (generated / ".dockerignore").exists()
     assert (generated / "arclith-run").exists()
-    assert (generated / "config" / "adapters" / "adapters.yaml").read_text(encoding="utf-8") == (
-        "logger: console\n"
-        "repository: memory\n"
-        "observability:\n"
-        "  enabled: []\n"
+    assert (generated / "config" / "adapters" / "adapters.yaml").read_text(
+        encoding="utf-8"
+    ) == ("logger: console\nrepository: memory\nobservability:\n  enabled: []\n")
+    assert "arclith[fastapi,mcp]>=0.23.0" in (generated / "pyproject.toml").read_text(
+        encoding="utf-8"
     )
-    assert "arclith[fastapi,mcp]>=0.23.0" in (generated / "pyproject.toml").read_text(encoding="utf-8")
     assert (package_root / "domain" / "models" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "inbound" / "__init__.py").exists()
     assert (package_root / "domain" / "ports" / "outbound" / "__init__.py").exists()
     assert (package_root / "application" / "use_cases" / "__init__.py").exists()
     assert (package_root / "adapters" / "inbound" / "__init__.py").exists()
     assert (package_root / "infrastructure" / "containers" / "__init__.py").exists()
-    assert sorted(path.name for path in (package_root / "domain" / "models").glob("*.py")) == ["__init__.py"]
+    assert sorted(
+        path.name for path in (package_root / "domain" / "models").glob("*.py")
+    ) == ["__init__.py"]
 
     dockerfile = (generated / "Dockerfile").read_text(encoding="utf-8")
     dockerignore = (generated / ".dockerignore").read_text(encoding="utf-8")
@@ -75,18 +95,26 @@ def test_init_project_creates_minimal_src_layout_without_entity(tmp_path: Path) 
     assert 'CMD ["api"]' in dockerfile
     assert "MODE=api" not in dockerfile
     assert "LANGGRAPH_PORT=2024" in dockerfile
-    assert re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
+    assert (
+        re.search(r"(?m)^ARG .*SECRET|^ARG .*TOKEN|^ARG .*PASSWORD", dockerfile) is None
+    )
     assert ".env" in dockerignore
     assert "secrets.yaml" in dockerignore
     assert "id_rsa" in dockerignore
     assert 'if [ -n "${ARCLITH_RUNTIME_MODE:-}" ]; then' in entrypoint
-    assert "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;" in entrypoint
+    assert (
+        "api|mcp|mcp_http|mcp_sse|bus|command_bus|command-bus|agent|all) shift ;;"
+        in entrypoint
+    )
     assert "bus|command_bus|command-bus)" in entrypoint
     assert "langgraph dev" in entrypoint
     assert '"${ARCLITH_AGENT_RUNTIME:-development}" = "durable"' in entrypoint
     assert "exec arclith-agent-runtime" in entrypoint
     assert '_VALID_MODES = {"api", "mcp_http", "mcp_sse", "all"}' in main
-    assert 'arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])' in main
+    assert (
+        'arclith.run_with_probes(_run_api, _run_mcp_http, transports=["api", "mcp_http"])'
+        in main
+    )
     assert arclith_run.stat().st_mode & stat.S_IXUSR
 
 
@@ -98,54 +126,103 @@ def test_init_project_refuses_existing_directory(tmp_path: Path) -> None:
         init_project_cmd(project_name="todo-list-service", directory=tmp_path)
 
 
-def test_add_usecase_creates_minimal_usecase_in_src_package(tmp_path: Path) -> None:
+def test_add_usecase_defaults_to_guided_transverse_usecase_for_python_callers(
+    tmp_path: Path,
+) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="PlanShoppingList")
+    generated = add_usecase_cmd(
+        project_dir=project_dir, usecase_name="PlanShoppingList"
+    )
 
-    assert generated == project_dir / "src" / "demo_service" / "application" / "use_cases" / "plan_shopping_list.py"
-    inbound_port = project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "plan_shopping_list.py"
-    assert inbound_port.read_text(encoding="utf-8") == (
-        "from abc import ABC, abstractmethod\n"
-        "\n"
-        "\n"
-        "class PlanShoppingListPort(ABC):\n"
-        "    @abstractmethod\n"
-        "    async def execute(self) -> None:\n"
-        "        raise NotImplementedError\n"
+    assert (
+        generated
+        == project_dir
+        / "src"
+        / "demo_service"
+        / "application"
+        / "use_cases"
+        / "plan_shopping_list.py"
     )
-    assert generated.read_text(encoding="utf-8") == (
-        "from demo_service.domain.ports.inbound.plan_shopping_list import PlanShoppingListPort\n"
-        "\n"
-        "\n"
-        "class PlanShoppingListUseCase(PlanShoppingListPort):\n"
-        "    async def execute(self) -> None:\n"
-        '        raise NotImplementedError("Implement PlanShoppingListUseCase.execute")\n'
+    inbound_port = (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "ports"
+        / "inbound"
+        / "plan_shopping_list.py"
     )
+    inbound_content = inbound_port.read_text(encoding="utf-8")
+    usecase_content = generated.read_text(encoding="utf-8")
+    assert "class PlanShoppingListCommand(BaseModel):" in inbound_content
+    assert "class PlanShoppingListResult(BaseModel):" in inbound_content
+    assert (
+        "async def execute(self, command: PlanShoppingListCommand) -> PlanShoppingListResult:"
+        in inbound_content
+    )
+    assert "docs/tutorials/todo-list/03-create-usecase.md" in inbound_content
+    assert "class PlanShoppingListUseCase(PlanShoppingListPort):" in usecase_content
+    assert "Repository" not in usecase_content
     assert (project_dir / "src" / "demo_service" / "domain" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "domain" / "ports" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "application" / "__init__.py").exists()
-    assert (project_dir / "src" / "demo_service" / "application" / "use_cases" / "__init__.py").exists()
+    assert (
+        project_dir / "src" / "demo_service" / "domain" / "ports" / "__init__.py"
+    ).exists()
+    assert (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "ports"
+        / "inbound"
+        / "__init__.py"
+    ).exists()
+    assert (
+        project_dir / "src" / "demo_service" / "application" / "__init__.py"
+    ).exists()
+    assert (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "application"
+        / "use_cases"
+        / "__init__.py"
+    ).exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
 
-def test_add_intent_interpreter_creates_minimal_interpreter_in_src_package(tmp_path: Path) -> None:
+def test_add_intent_interpreter_creates_minimal_interpreter_in_src_package(
+    tmp_path: Path,
+) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_intent_interpreter_cmd(project_dir=project_dir, intent_name="IngredientIntent")
+    generated = add_intent_interpreter_cmd(
+        project_dir=project_dir, intent_name="IngredientIntent"
+    )
 
     assert generated == (
-        project_dir / "src" / "demo_service" / "application" / "intent_interpreters" / "ingredient_intent.py"
+        project_dir
+        / "src"
+        / "demo_service"
+        / "application"
+        / "intent_interpreters"
+        / "ingredient_intent.py"
     )
     assert generated.read_text(encoding="utf-8") == (
         "class IngredientIntentInterpreter:\n"
         "    async def interpret(self, prompt: str) -> None:\n"
         '        raise NotImplementedError("Implement IngredientIntentInterpreter.interpret")\n'
     )
-    assert (project_dir / "src" / "demo_service" / "application" / "__init__.py").exists()
     assert (
-        project_dir / "src" / "demo_service" / "application" / "intent_interpreters" / "__init__.py"
+        project_dir / "src" / "demo_service" / "application" / "__init__.py"
+    ).exists()
+    assert (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "application"
+        / "intent_interpreters"
+        / "__init__.py"
     ).exists()
     assert not (project_dir / "src" / "demo_service" / "adapters").exists()
 
@@ -153,20 +230,192 @@ def test_add_intent_interpreter_creates_minimal_interpreter_in_src_package(tmp_p
 def test_add_usecase_strips_repeated_usecase_suffix(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
 
-    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="plan-shopping-list-use-case-usecase")
+    generated = add_usecase_cmd(
+        project_dir=project_dir, usecase_name="plan-shopping-list-use-case-usecase"
+    )
 
     assert generated.name == "plan_shopping_list.py"
-    assert "class PlanShoppingListUseCase(PlanShoppingListPort):" in generated.read_text(encoding="utf-8")
     assert (
-        "class PlanShoppingListPort(ABC):"
-        in (
-            project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "plan_shopping_list.py"
-        ).read_text(encoding="utf-8")
+        "class PlanShoppingListUseCase(PlanShoppingListPort):"
+        in generated.read_text(encoding="utf-8")
     )
+    assert "class PlanShoppingListPort(ABC):" in (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "ports"
+        / "inbound"
+        / "plan_shopping_list.py"
+    ).read_text(encoding="utf-8")
     assert "UseCaseUseCase" not in generated.read_text(encoding="utf-8")
 
 
-def test_add_intent_interpreter_strips_repeated_interpreter_suffix(tmp_path: Path) -> None:
+def test_add_usecase_links_existing_entity_with_typed_repository(
+    tmp_path: Path,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    add_entity_cmd(project_dir=project_dir, entity_name="Todo")
+
+    generated = add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateTodo",
+        entity_name="Todo",
+    )
+
+    inbound_port = project_dir / "src/demo_service/domain/ports/inbound/create_todo.py"
+    inbound_content = inbound_port.read_text(encoding="utf-8")
+    usecase_content = generated.read_text(encoding="utf-8")
+    assert "from demo_service.domain.models.todo import Todo" in inbound_content
+    assert "class CreateTodoCommand(BaseModel):" in inbound_content
+    assert (
+        "async def execute(self, command: CreateTodoCommand) -> Todo:"
+        in inbound_content
+    )
+    assert (
+        "from arclith.domain.ports.outbound.repository import Repository"
+        in usecase_content
+    )
+    assert (
+        "def __init__(self, repository: Repository[Todo]) -> None:" in usecase_content
+    )
+    assert (
+        "async def execute(self, command: CreateTodoCommand) -> Todo:"
+        in usecase_content
+    )
+
+
+def test_add_usecase_uses_detected_entity_filename_for_import(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+    entity_file = project_dir / "src/demo_service/domain/models/work_item.py"
+    entity_file.parent.mkdir(parents=True)
+    entity_file.write_text(
+        "from arclith.domain.models.entity import Entity\n\nclass Todo(Entity):\n    pass\n",
+        encoding="utf-8",
+    )
+
+    generated = add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateTodo",
+        entity_name="Todo",
+    )
+
+    assert (
+        "from demo_service.domain.models.work_item import Todo"
+        in generated.read_text(encoding="utf-8")
+    )
+
+
+def test_add_usecase_existing_entity_reuses_ast_scanner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    entity_file = project_dir / "src/demo_service/domain/models/todo.py"
+    calls: list[Path] = []
+
+    def fake_scan_entities(scanned_project: Path) -> list[EntityInfo]:
+        calls.append(scanned_project)
+        return [EntityInfo(pascal="Todo", snake="todo", file_path=entity_file)]
+
+    monkeypatch.setattr(core_scaffold, "scan_entities", fake_scan_entities)
+
+    add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateTodo",
+        entity_name="Todo",
+    )
+
+    assert calls == [project_dir]
+
+
+def test_add_usecase_rejects_missing_existing_entity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(
+            project_dir=project_dir,
+            usecase_name="CreateTodo",
+            entity_name="Missing",
+        )
+
+    output = capsys.readouterr().out
+    assert "Entité introuvable" in output
+    assert "--new-entity Missing" in output
+    assert not (
+        project_dir / "src/demo_service/application/use_cases/create_todo.py"
+    ).exists()
+
+
+def test_add_usecase_new_entity_creates_and_links_entity(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    generated = add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateTodo",
+        new_entity_name="Todo",
+    )
+
+    entity_file = project_dir / "src/demo_service/domain/models/todo.py"
+    assert "class Todo(Entity):" in entity_file.read_text(encoding="utf-8")
+    assert "Repository[Todo]" in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_new_entity_reuses_matching_existing_entity(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+    entity_file = add_entity_cmd(project_dir=project_dir, entity_name="Todo")
+    original = entity_file.read_text(encoding="utf-8")
+
+    generated = add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateTodo",
+        new_entity_name="Todo",
+    )
+
+    assert entity_file.read_text(encoding="utf-8") == original
+    assert "Repository[Todo]" in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_new_entity_rejects_mismatched_existing_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project_dir = _src_project(tmp_path)
+    entity_file = project_dir / "src/demo_service/domain/models/todo.py"
+    entity_file.parent.mkdir(parents=True)
+    entity_file.write_text("class SomethingElse:\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(
+            project_dir=project_dir,
+            usecase_name="CreateTodo",
+            new_entity_name="Todo",
+        )
+
+    output = capsys.readouterr().out
+    assert "existe mais ne déclare pas" in output
+    assert "class Todo(Entity)" in output
+    assert entity_file.read_text(encoding="utf-8") == "class SomethingElse:\n    pass\n"
+
+
+def test_add_usecase_rejects_two_entity_modes(tmp_path: Path) -> None:
+    project_dir = _src_project(tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(
+            project_dir=project_dir,
+            usecase_name="CreateTodo",
+            entity_name="Todo",
+            new_entity_name="Todo",
+        )
+
+
+def test_add_intent_interpreter_strips_repeated_interpreter_suffix(
+    tmp_path: Path,
+) -> None:
     project_dir = _src_project(tmp_path)
 
     generated = add_intent_interpreter_cmd(
@@ -182,7 +431,9 @@ def test_add_intent_interpreter_strips_repeated_interpreter_suffix(tmp_path: Pat
 def test_add_entity_supports_legacy_root_layout(tmp_path: Path) -> None:
     project_dir = tmp_path / "legacy-service"
     project_dir.mkdir(parents=True)
-    (project_dir / "pyproject.toml").write_text('[project]\nname = "legacy-service"\n', encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "legacy-service"\n', encoding="utf-8"
+    )
 
     generated = add_entity_cmd(project_dir=project_dir, entity_name="Recipe")
 
@@ -195,14 +446,24 @@ def test_add_entity_supports_legacy_root_layout(tmp_path: Path) -> None:
 def test_add_usecase_supports_legacy_root_layout(tmp_path: Path) -> None:
     project_dir = tmp_path / "legacy-service"
     project_dir.mkdir(parents=True)
-    (project_dir / "pyproject.toml").write_text('[project]\nname = "legacy-service"\n', encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "legacy-service"\n', encoding="utf-8"
+    )
 
-    generated = add_usecase_cmd(project_dir=project_dir, usecase_name="CreateRecipe")
+    add_entity_cmd(project_dir=project_dir, entity_name="Recipe")
+    generated = add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name="CreateRecipe",
+        entity_name="Recipe",
+    )
 
     assert generated == project_dir / "application" / "use_cases" / "create_recipe.py"
     assert (
-        "from domain.ports.inbound.create_recipe import CreateRecipePort\n"
+        "from domain.ports.inbound.create_recipe import CreateRecipeCommand, CreateRecipePort\n"
         in generated.read_text(encoding="utf-8")
+    )
+    assert "from domain.models.recipe import Recipe" in generated.read_text(
+        encoding="utf-8"
     )
     assert (project_dir / "domain" / "ports" / "inbound" / "create_recipe.py").exists()
     assert (project_dir / "domain" / "ports" / "inbound" / "__init__.py").exists()
@@ -230,7 +491,15 @@ def test_add_usecase_rejects_invalid_name(tmp_path: Path) -> None:
 
 def test_add_usecase_refuses_to_overwrite_existing_inbound_port(tmp_path: Path) -> None:
     project_dir = _src_project(tmp_path)
-    existing = project_dir / "src" / "demo_service" / "domain" / "ports" / "inbound" / "recipe.py"
+    existing = (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "ports"
+        / "inbound"
+        / "recipe.py"
+    )
     existing.parent.mkdir(parents=True)
     existing.write_text("class RecipePort:\n    pass\n", encoding="utf-8")
 
@@ -238,7 +507,35 @@ def test_add_usecase_refuses_to_overwrite_existing_inbound_port(tmp_path: Path) 
         add_usecase_cmd(project_dir=project_dir, usecase_name="Recipe")
 
     assert existing.read_text(encoding="utf-8") == "class RecipePort:\n    pass\n"
-    assert not (project_dir / "src" / "demo_service" / "application" / "use_cases" / "recipe.py").exists()
+    assert not (
+        project_dir / "src" / "demo_service" / "application" / "use_cases" / "recipe.py"
+    ).exists()
+
+
+def test_add_usecase_refuses_existing_port_before_creating_new_entity(
+    tmp_path: Path,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    existing = (
+        project_dir
+        / "src"
+        / "demo_service"
+        / "domain"
+        / "ports"
+        / "inbound"
+        / "create_todo.py"
+    )
+    existing.parent.mkdir(parents=True)
+    existing.write_text("class CreateTodoPort:\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        add_usecase_cmd(
+            project_dir=project_dir,
+            usecase_name="CreateTodo",
+            new_entity_name="Todo",
+        )
+
+    assert not (project_dir / "src/demo_service/domain/models/todo.py").exists()
 
 
 def test_add_intent_interpreter_rejects_invalid_name(tmp_path: Path) -> None:

--- a/cli/tests/test_e2e_scaffold.py
+++ b/cli/tests/test_e2e_scaffold.py
@@ -89,7 +89,7 @@ def test_init_scaffold_creates_blank_project_then_core_files(temp_workspace: Pat
     assert result.returncode == 0, f"add-entity failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
 
     result = subprocess.run(
-        ["arclith-cli", "add-usecase", "CreateTodo"],
+        ["arclith-cli", "add-usecase", "CreateTodo", "--entity", "Todo"],
         cwd=project_dir,
         capture_output=True,
         text=True,
@@ -247,6 +247,8 @@ def test_scaffold_and_run(temp_workspace: Path):
             "arclith-cli",
             "add-usecase",
             "PlanShoppingList",
+            "--entity",
+            "ShoppingItem",
         ],
         cwd=project_dir,
         capture_output=True,

--- a/cli/tests/test_recipe.py
+++ b/cli/tests/test_recipe.py
@@ -106,7 +106,7 @@ def test_core_commands_append_only_after_success(
 
     for arguments in (
         ["add-entity", "ShoppingItem"],
-        ["add-usecase", "PlanShoppingList"],
+        ["add-usecase", "PlanShoppingList", "--entity", "ShoppingItem"],
         ["add-intent-interpreter", "ShoppingIntent"],
     ):
         result = _invoke_in_project(monkeypatch, project_dir, arguments)
@@ -438,7 +438,7 @@ def test_replay_rebuilds_minimal_project_without_duplicate_steps(
     project_dir = _init_project(tmp_path, "source-service")
     for arguments in (
         ["add-entity", "Widget"],
-        ["add-usecase", "CreateWidget"],
+        ["add-usecase", "CreateWidget", "--entity", "Widget"],
         [
             "add-adapter",
             "--capability",

--- a/cli/tests/test_scaffold_cli.py
+++ b/cli/tests/test_scaffold_cli.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from arclith_cli.core_scaffold import add_entity_cmd
+from arclith_cli.main import app
+from arclith_cli.recipe import RECIPE_FILENAME, load_recipe
+
+runner = CliRunner()
+
+
+def _src_project(tmp_path: Path) -> Path:
+    project_dir = tmp_path / "demo-service"
+    package_root = project_dir / "src" / "demo_service"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "demo-service"\n',
+        encoding="utf-8",
+    )
+    return project_dir
+
+
+def _invoke(
+    monkeypatch: pytest.MonkeyPatch,
+    project_dir: Path,
+    arguments: list[str],
+    *,
+    input_text: str | None = None,
+):
+    monkeypatch.chdir(project_dir)
+    return runner.invoke(app, arguments, input=input_text)
+
+
+def test_add_usecase_entity_option_generates_linked_scaffold_and_recipe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    add_entity_cmd(project_dir=project_dir, entity_name="Todo")
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo", "--entity", "Todo"],
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = project_dir / "src/demo_service/application/use_cases/create_todo.py"
+    assert "Repository[Todo]" in generated.read_text(encoding="utf-8")
+    assert load_recipe(project_dir / RECIPE_FILENAME).steps[-1].args == {
+        "usecase": "CreateTodo",
+        "entity": "Todo",
+        "new_entity": None,
+        "no_entity": False,
+    }
+
+
+def test_add_usecase_new_entity_option_creates_both_scaffolds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo", "--new-entity", "Todo"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "src/demo_service/domain/models/todo.py").exists()
+    assert (
+        project_dir / "src/demo_service/application/use_cases/create_todo.py"
+    ).exists()
+
+
+def test_add_usecase_no_entity_option_generates_transverse_scaffold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "RunMaintenance", "--no-entity"],
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = (
+        project_dir / "src/demo_service/application/use_cases/run_maintenance.py"
+    )
+    assert "RunMaintenanceResult" in generated.read_text(encoding="utf-8")
+    assert "Repository" not in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_options_are_mutually_exclusive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo", "--entity", "Todo", "--no-entity"],
+    )
+
+    assert result.exit_code == 1
+    assert "mutuellement" in result.output
+    assert "exclusives" in result.output
+
+
+def test_add_usecase_interactive_selects_detected_entity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    add_entity_cmd(project_dir=project_dir, entity_name="Todo")
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo"],
+        input_text="1\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Todo" in result.output
+    generated = project_dir / "src/demo_service/application/use_cases/create_todo.py"
+    assert "Repository[Todo]" in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_interactive_can_create_entity_when_none_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo"],
+        input_text="1\nTodo\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Aucune entité détectée" in result.output
+    assert (project_dir / "src/demo_service/domain/models/todo.py").exists()
+
+
+def test_add_usecase_interactive_can_create_another_entity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+    add_entity_cmd(project_dir=project_dir, entity_name="Todo")
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateShoppingItem"],
+        input_text="2\nShoppingItem\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "src/demo_service/domain/models/shopping_item.py").exists()
+    generated = (
+        project_dir / "src/demo_service/application/use_cases/create_shopping_item.py"
+    )
+    assert "Repository[ShoppingItem]" in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_interactive_can_continue_without_entity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "RunMaintenance"],
+        input_text="2\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    generated = (
+        project_dir / "src/demo_service/application/use_cases/run_maintenance.py"
+    )
+    assert "Repository" not in generated.read_text(encoding="utf-8")
+
+
+def test_add_usecase_interactive_can_cancel_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = _src_project(tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project_dir,
+        ["add-usecase", "CreateTodo"],
+        input_text="3\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Création annulée" in result.output
+    assert not (
+        project_dir / "src/demo_service/application/use_cases/create_todo.py"
+    ).exists()
+    assert not (project_dir / RECIPE_FILENAME).exists()

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -47,6 +47,7 @@ arclith-cli capabilities --json
 
 | Besoin | Lire |
 |---|---|
+| Concevoir le cœur métier | [Scaffold CLI guidé](deep-dives/cli-scaffold.md), puis [formation Todo](tutorials/todo-list/02-create-entity.md) |
 | API minimale | [Quickstart API](quickstarts/api.md), [formation API](tutorials/todo-list/04-api.md), puis [api/fastapi](capabilities/api.md) |
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |

--- a/docs/deep-dives/cli-scaffold.md
+++ b/docs/deep-dives/cli-scaffold.md
@@ -1,0 +1,378 @@
+# Scaffold CLI Guidé
+
+## Intention
+
+`add-entity` et `add-usecase` accélèrent le démarrage du cœur métier sans
+inventer le métier. Les fichiers générés sont de courts repères modifiables :
+
+- ils indiquent où placer champs, invariants, commandes, queries et résultats ;
+- ils gardent le domaine indépendant des frameworks et des adapters ;
+- ils utilisent les vrais chemins d'import du package détecté ;
+- ils renvoient vers des exemples complets au lieu de les recopier dans chaque
+  projet.
+
+Le scaffold ne génère ni endpoint FastAPI, ni tool FastMCP, ni graphe
+LangGraph, ni mapping de base de données. Ces éléments viennent après le port
+inbound et le use case.
+
+## Commandes
+
+Créer une entité guidée :
+
+```bash
+arclith-cli add-entity Todo
+```
+
+Créer un use case lié à une entité détectée :
+
+```bash
+arclith-cli add-usecase CreateTodo --entity Todo
+```
+
+Créer l'entité et le use case lié en une commande :
+
+```bash
+arclith-cli add-usecase CreateTodo --new-entity Todo
+```
+
+Créer un use case transverse :
+
+```bash
+arclith-cli add-usecase ImportCatalog --no-entity
+```
+
+Sans option, `add-usecase` propose les entités trouvées par analyse AST, puis
+les choix « créer une nouvelle entité » et « transverse ». S'il n'existe aucune
+entité, le wizard permet aussi d'annuler sans écriture. Pour les scripts, les
+agents et la CI, toujours fournir l'une des trois options exclusives.
+
+## Position Hexagonale
+
+| Emplacement | Responsabilité | Exemples |
+|---|---|---|
+| `domain/models` | état et invariants métier | `Todo`, `TodoStatus` |
+| `domain/ports/inbound` | contrat offert aux entrées | `CreateTodoCommand`, `CreateTodoPort` |
+| `domain/ports/outbound` | besoin du cœur envers l'extérieur | `Repository[Todo]`, `TodoLookupPort` |
+| `application/use_cases` | orchestration d'un objectif | `CreateTodoUseCase` |
+| `adapters/inbound` | traduction HTTP, MCP, bus ou agent vers le port inbound | router, tool, handler, nœud |
+| `adapters/outbound` | implémentation des dépendances externes | MongoDB, API distante, filesystem |
+
+Un schéma de transport FastAPI ne devient pas automatiquement une commande du
+domaine. L'adapter valide son contrat public puis construit le `Command` ou la
+`Query` attendu par le port inbound.
+
+## Choisir Command, Query Et Result
+
+- Une `Command` demande une action ou une mutation : créer, terminer, importer.
+- Une `Query` demande une lecture sans intention de mutation : lister,
+  rechercher, consulter.
+- Une entité peut être retournée directement lorsque c'est le résultat métier
+  naturel d'une commande simple.
+- Un `Result` Pydantic explicite est préférable pour une pagination, un bilan
+  d'import ou une réponse composée.
+
+Le template lié utilise `Command -> Entity` comme point de départ fréquent. Le
+template transverse utilise `Command -> Result`. Les exemples suivants montrent
+comment les adapter vers `Query` ou vers un autre résultat.
+
+## Exemple 1 — CreateTodoUseCase
+
+Le port inbound porte les données validées, sans dépendre du transport :
+
+```python
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from todo_list_service.domain.models.todo import Todo
+
+
+class CreateTodoCommand(BaseModel):
+    title: str = Field(min_length=1, max_length=140)
+
+
+class CreateTodoPort(ABC):
+    @abstractmethod
+    async def execute(self, command: CreateTodoCommand) -> Todo:
+        raise NotImplementedError
+```
+
+Le use case orchestre la création et dépend du port repository générique :
+
+```python
+from arclith.domain.ports.outbound.repository import Repository
+
+from todo_list_service.domain.models.todo import Todo
+from todo_list_service.domain.ports.inbound.create_todo import (
+    CreateTodoCommand,
+    CreateTodoPort,
+)
+
+
+class CreateTodoUseCase(CreateTodoPort):
+    def __init__(self, repository: Repository[Todo]) -> None:
+        self._repository = repository
+
+    async def execute(self, command: CreateTodoCommand) -> Todo:
+        todo = Todo(title=command.title)
+        return await self._repository.create(todo)
+```
+
+## Exemple 2 — ListTodosUseCase
+
+Une lecture paginée mérite une `Query` et un `Result` explicites :
+
+```python
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from todo_list_service.domain.models.todo import Todo
+
+
+class ListTodosQuery(BaseModel):
+    page: int = Field(default=1, ge=1)
+    per_page: int = Field(default=20, ge=1, le=100)
+
+
+class ListTodosResult(BaseModel):
+    items: list[Todo]
+    total: int = Field(ge=0)
+
+
+class ListTodosPort(ABC):
+    @abstractmethod
+    async def execute(self, query: ListTodosQuery) -> ListTodosResult:
+        raise NotImplementedError
+```
+
+```python
+from arclith.domain.ports.outbound.repository import Repository
+
+from todo_list_service.domain.models.todo import Todo
+from todo_list_service.domain.ports.inbound.list_todos import (
+    ListTodosPort,
+    ListTodosQuery,
+    ListTodosResult,
+)
+
+
+class ListTodosUseCase(ListTodosPort):
+    def __init__(self, repository: Repository[Todo]) -> None:
+        self._repository = repository
+
+    async def execute(self, query: ListTodosQuery) -> ListTodosResult:
+        offset = (query.page - 1) * query.per_page
+        items, total = await self._repository.find_page(offset, query.per_page)
+        return ListTodosResult(items=items, total=total)
+```
+
+## Exemple 3 — CompleteTodoUseCase
+
+Une mutation charge l'entité, vérifie la version attendue, applique l'invariant
+dans le domaine, puis délègue l'audit et l'incrément de version au
+`UpdateUseCase` générique Arclith.
+
+```python
+from uuid6 import UUID
+
+from pydantic import BaseModel
+
+
+class CompleteTodoCommand(BaseModel):
+    todo_id: UUID
+    expected_version: int
+```
+
+```python
+class CompleteTodoUseCase:
+    def __init__(
+        self,
+        repository: Repository[Todo],
+        updater: UpdateUseCase[Todo],
+    ) -> None:
+        self._repository = repository
+        self._updater = updater
+
+    async def execute(self, command: CompleteTodoCommand) -> Todo:
+        todo = await self._repository.read(command.todo_id)
+        if todo is None:
+            raise TodoNotFound(command.todo_id)
+        if todo.version != command.expected_version:
+            raise TodoVersionConflict(command.todo_id)
+
+        completed = todo.complete()
+        return await self._updater.execute(completed)
+```
+
+`complete()` et les transitions autorisées appartiennent à `Todo`. La
+conversion d'une exception en HTTP 404 ou 409 appartient à l'adapter FastAPI.
+Le port `Repository[T]` partagé n'expose pas de compare-and-swap atomique entre
+processus. Si cette garantie est requise, définir un port outbound métier et
+une implémentation transactionnelle adaptée au store, sans gonfler le contrat
+générique.
+
+## Exemple 4 — ImportCatalogUseCase Transverse
+
+Un import coordonne plusieurs éléments et n'a pas nécessairement une entité
+principale. Il dépend de ports outbound décrivant ses besoins, pas d'un
+`Repository[Any]` artificiel.
+
+```python
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+
+class ImportCatalogCommand(BaseModel):
+    source_uri: str
+
+
+class ImportCatalogResult(BaseModel):
+    imported: int = Field(ge=0)
+    rejected: int = Field(ge=0)
+
+
+class ImportCatalogPort(ABC):
+    @abstractmethod
+    async def execute(
+        self,
+        command: ImportCatalogCommand,
+    ) -> ImportCatalogResult:
+        raise NotImplementedError
+```
+
+```python
+class ImportCatalogUseCase(ImportCatalogPort):
+    def __init__(
+        self,
+        source: CatalogSourcePort,
+        writer: CatalogWriterPort,
+    ) -> None:
+        self._source = source
+        self._writer = writer
+
+    async def execute(
+        self,
+        command: ImportCatalogCommand,
+    ) -> ImportCatalogResult:
+        records = await self._source.read(command.source_uri)
+        outcome = await self._writer.write(records)
+        return ImportCatalogResult(
+            imported=outcome.imported,
+            rejected=outcome.rejected,
+        )
+```
+
+## Exemple 5 — FindByNameUseCase Et Port Outbound Spécifique
+
+Ne pas ajouter `find_by_name`, `find_overdue` ou chaque requête métier au port
+`Repository[T]` partagé. Lorsqu'une recherche exprime un besoin du domaine,
+définir un petit port outbound dans le projet :
+
+```python
+from abc import ABC, abstractmethod
+
+from todo_list_service.domain.models.todo import Todo
+
+
+class TodoLookupPort(ABC):
+    @abstractmethod
+    async def find_by_name(self, normalized_name: str) -> list[Todo]:
+        raise NotImplementedError
+```
+
+```python
+class FindByNameUseCase:
+    def __init__(self, lookup: TodoLookupPort) -> None:
+        self._lookup = lookup
+
+    async def execute(self, query: FindByNameQuery) -> FindByNameResult:
+        normalized = query.name.strip().casefold()
+        items = await self._lookup.find_by_name(normalized)
+        return FindByNameResult(items=items)
+```
+
+L'adapter MongoDB, PostgreSQL ou distant implémente ensuite `TodoLookupPort`.
+Le contrat générique `Repository[T]` reste stable et centré sur le cycle de vie
+des entités.
+
+## Tests Unitaires
+
+Tester l'entité sans adapter pour prouver ses invariants :
+
+```python
+import pytest
+from pydantic import ValidationError
+
+
+def test_todo_rejects_blank_title() -> None:
+    with pytest.raises(ValidationError):
+        Todo(title="   ")
+```
+
+Tester le use case avec un fake ou l'adapter memory :
+
+```python
+import pytest
+from arclith.adapters.outbound.memory.repository import InMemoryRepository
+
+
+@pytest.mark.asyncio
+async def test_create_todo_persists_entity() -> None:
+    repository = InMemoryRepository[Todo]()
+    use_case = CreateTodoUseCase(repository)
+
+    created = await use_case.execute(CreateTodoCommand(title="Documenter"))
+
+    assert await repository.read(created.uuid) == created
+```
+
+Pour un port outbound spécifique, un fake minimal rend le test plus lisible
+qu'un mock d'un SDK MongoDB ou HTTP.
+
+## Validation Du Scaffold
+
+Dans le dépôt Arclith :
+
+```bash
+cd cli
+uv run pytest tests/test_core_scaffold.py tests/test_scaffold_cli.py -q
+cd ..
+make quality
+make docs
+```
+
+Dans le projet généré, compiler les fichiers puis écrire les tests métier avant
+de brancher les adapters :
+
+```bash
+uv run python -m compileall -q src
+uv run pytest -q
+```
+
+## Troubleshooting
+
+### Entité introuvable
+
+`--entity Todo` ne se fie pas au seul nom de fichier. Le scanner AST doit
+trouver une classe `Todo` qui hérite directement de `Entity`. Corriger la
+classe ou utiliser `--new-entity Todo` si le fichier n'existe pas.
+
+### Fichier homonyme incompatible
+
+`--new-entity Todo` refuse d'écraser `domain/models/todo.py` si ce fichier ne
+déclare pas l'entité attendue. Renommer ou corriger manuellement le fichier,
+puis relancer la commande.
+
+### Use case sans entité principale
+
+Utiliser `--no-entity`. Le résultat ne contient pas de `Repository[T]` injecté ;
+ajouter seulement les ports outbound réellement nécessaires à l'orchestration.
+
+## Suite
+
+- [Créer une entité Todo](../tutorials/todo-list/02-create-entity.md)
+- [Créer les use cases Todo](../tutorials/todo-list/03-create-usecase.md)
+- [Architecture Arclith](https://github.com/karned-rekipe/arclith/blob/main/arclith/docs/architecture.md)
+- [Décisions Arclith](../decisions.md)

--- a/docs/deep-dives/cli-scaffold.md
+++ b/docs/deep-dives/cli-scaffold.md
@@ -163,7 +163,10 @@ class ListTodosUseCase(ListTodosPort):
 
     async def execute(self, query: ListTodosQuery) -> ListTodosResult:
         offset = (query.page - 1) * query.per_page
-        items, total = await self._repository.find_page(offset, query.per_page)
+        items, total = await self._repository.find_page(
+            offset=offset,
+            limit=query.per_page,
+        )
         return ListTodosResult(items=items, total=total)
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ du cœur:
 arclith-cli init todo-list-service
 cd todo-list-service
 arclith-cli add-entity Todo
-arclith-cli add-usecase CreateTodo
+arclith-cli add-usecase CreateTodo --entity Todo
 ```
 
 Chaque commande mutante réussie enrichit `arclith.recipe.yaml`. Ce fichier
@@ -130,14 +130,18 @@ Pour ajouter seulement du cœur métier, sans CRUD ni adapter automatique :
 
 ```bash
 arclith-cli add-entity ShoppingItem
-arclith-cli add-usecase PlanShoppingList
+arclith-cli add-usecase PlanShoppingList --entity ShoppingItem
+arclith-cli add-usecase RunMaintenance --no-entity
 arclith-cli add-intent-interpreter ShoppingIntent
 ```
 
-Ces commandes créent des fichiers minimaux dans `src/<package>/domain/models/` et
-`src/<package>/domain/ports/inbound/`, `src/<package>/application/use_cases/` ou
-`src/<package>/application/intent_interpreters/`. Les champs, invariants et appels aux adapters
-restent du code métier à écrire dans le projet.
+`add-entity` ajoute un squelette guidé sans import inutilisé. `add-usecase`
+propose les entités détectées en interactif ; en mode direct, `--entity`,
+`--new-entity` et `--no-entity` rendent le choix explicite et sont mutuellement
+exclusifs. Les fichiers générés montrent le pattern
+`Command/Query -> UseCase -> Entity/Result`, mais les champs, invariants et
+appels aux ports restent du code métier à écrire dans le projet. Lire le
+[deep dive scaffold CLI](deep-dives/cli-scaffold.md) pour les exemples complets.
 
 L'adapter actif est déclaré dans:
 

--- a/docs/tutorials/todo-list/02-create-entity.md
+++ b/docs/tutorials/todo-list/02-create-entity.md
@@ -23,6 +23,36 @@ La CLI crée:
 src/todo_list_service/domain/models/todo.py
 ```
 
+Le fichier initial est volontairement exécutable sans import inutilisé :
+
+```python
+from __future__ import annotations
+
+from arclith.domain.models.entity import Entity
+
+# Guides:
+# - Arclith entity tutorial: https://github.com/karned-rekipe/arclith/blob/main/docs/tutorials/todo-list/02-create-entity.md
+# - Arclith architecture: https://github.com/karned-rekipe/arclith/blob/main/arclith/docs/architecture.md
+# - Pydantic models: https://docs.pydantic.dev/latest/concepts/models/
+# - Pydantic fields: https://docs.pydantic.dev/latest/concepts/fields/
+# - Pydantic validators: https://docs.pydantic.dev/latest/concepts/validators/
+
+
+class Todo(Entity):
+    """TODO: define the business fields and invariants for this entity.
+
+    Arclith Entity already provides uuid, audit fields, soft-delete fields,
+    and optimistic versioning.
+    """
+
+    # Example:
+    # title: str = Field(min_length=1, max_length=140)
+    pass
+```
+
+`Field` n'est pas importé tant que l'exemple reste commenté. L'ajouter depuis
+`pydantic` au moment de déclarer les vrais champs.
+
 Modifier `src/todo_list_service/domain/models/todo.py`:
 
 ```python

--- a/docs/tutorials/todo-list/03-create-usecase.md
+++ b/docs/tutorials/todo-list/03-create-usecase.md
@@ -16,6 +16,11 @@ Répondre au prompt:
 ```text
 Cas d'usage (ex : PlanShoppingList, find_by_name)
   Nom du cas d'usage: CreateTodo
+Entité principale du cas d'usage
+  1. Todo
+  2. Créer une nouvelle entité
+  3. Aucune entité / cas d'usage transverse
+  Choix [1]: 1
 ```
 
 Relancer le wizard pour le listing:
@@ -29,9 +34,28 @@ Répondre au prompt:
 ```text
 Cas d'usage (ex : PlanShoppingList, find_by_name)
   Nom du cas d'usage: ListTodos
+Entité principale du cas d'usage
+  1. Todo
+  2. Créer une nouvelle entité
+  3. Aucune entité / cas d'usage transverse
+  Choix [1]: 1
 ```
 
-La CLI crée:
+Le même résultat est reproductible sans prompt, notamment en CI ou depuis un
+agent de coding :
+
+```bash
+arclith-cli add-usecase CreateTodo --entity Todo
+arclith-cli add-usecase ListTodos --entity Todo
+```
+
+`--new-entity Todo` crée l'entité si nécessaire. `--no-entity` produit un
+`Command` et un `Result` Pydantic sans injecter de repository. Les trois options
+`--entity`, `--new-entity` et `--no-entity` sont mutuellement exclusives. Si
+aucune entité n'est détectée, le wizard permet d'en créer une, de continuer en
+transverse ou d'annuler sans écrire de fichier.
+
+La CLI crée des squelettes déjà typés :
 
 ```text
 src/todo_list_service/domain/ports/inbound/create_todo.py
@@ -40,12 +64,6 @@ src/todo_list_service/application/use_cases/create_todo.py
 src/todo_list_service/application/use_cases/list_todos.py
 ```
 
-
-Créer les packages applicatifs:
-
-```bash
-touch src/todo_list_service/application/use_cases/__init__.py
-```
 
 Modifier `src/todo_list_service/domain/ports/inbound/create_todo.py`:
 
@@ -293,8 +311,11 @@ uv run python -m pytest tests/test_todo_entity.py tests/test_todo_usecases.py
 ## Voie rapide
 
 ```bash
-arclith-cli add-usecase CreateTodo
-arclith-cli add-usecase ListTodos
+arclith-cli add-usecase CreateTodo --entity Todo
+arclith-cli add-usecase ListTodos --entity Todo
 ```
+
+Pour comparer les patterns `Command`, `Query`, `Result`, mutation et port
+outbound spécialisé, lire le [deep dive scaffold CLI](../../deep-dives/cli-scaffold.md).
 
 Étape suivante: [exposer une API](04-api.md).

--- a/journal/2026-09-04-guided-cli-scaffold.md
+++ b/journal/2026-09-04-guided-cli-scaffold.md
@@ -1,0 +1,53 @@
+# Scaffold CLI Guidé
+
+## Contexte
+
+Les commandes `add-entity` et `add-usecase` créaient des fichiers presque
+vides. Elles indiquaient le bon emplacement hexagonal, mais ne guidaient ni le
+choix d'une entité principale, ni la séparation entre DTO Pydantic, port inbound
+et orchestration applicative.
+
+## Décisions
+
+- conserver `add_entity_cmd()` et `add_usecase_cmd()` non interactifs pour les
+  appels Python et le replay ;
+- placer le wizard uniquement dans la couche CLI Typer ;
+- réutiliser le scanner AST des entités pour `--entity` et les choix du wizard ;
+- rendre `--entity`, `--new-entity` et `--no-entity` explicites et mutuellement
+  exclusifs ;
+- garder l'absence d'entité comme comportement backward-compatible de
+  `add_usecase_cmd()` et des anciennes recettes ;
+- générer des squelettes courts avec `Command`, `Query` ou `Result` Pydantic,
+  sans logique métier inventée ni import de framework entrant ;
+- ne pas importer `Field` tant que son exemple reste commenté ;
+- enregistrer le mode de liaison dans `arclith.recipe.yaml` pour un replay
+  déterministe.
+
+## Impact
+
+Un use case lié reçoit un `Repository[Entity]` explicite et retourne l'entité.
+Un use case transverse reçoit un `Command`, retourne un `Result` et n'injecte
+aucun repository par défaut. Les layouts canonique `src/<package>` et legacy
+root restent pris en charge.
+
+Aucune dépendance, aucun port Arclith partagé, aucun adapter, aucune
+configuration persistante et aucune API runtime ne changent.
+
+## Documentation
+
+Le README CLI, le quickstart, les étapes Todo `add-entity` et `add-usecase`,
+l'index des capabilities et la navigation Pages renvoient vers le nouveau deep
+dive `docs/deep-dives/cli-scaffold.md`. Celui-ci couvre création, lecture,
+mutation, use case transverse, port outbound métier et tests unitaires.
+
+## Validation
+
+- tests ciblés scaffold, recettes et E2E : 52 passés ;
+- suite CLI complète : 173 passés et 1 ignoré ;
+- `make quality` : Ruff, Bandit, complexité et mypy passés, 2 171 tests
+  passés, 5 intégrations externes ignorées et 91,19 % de couverture ;
+- `make precommit` : passé ;
+- `make docs` : build MkDocs strict passé ;
+- lockfiles racine et CLI : valides avec `uv lock --check` ;
+- smoke test consommateur : fichiers liés et transverses compilés et validés
+  par Ruff.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
               - 6. Docker Compose: runtime-docker/docker-compose.md
               - 7. Kubernetes: runtime-docker/kubernetes.md
       - Deep dives:
+          - Scaffold CLI: deep-dives/cli-scaffold.md
           - API: deep-dives/api.md
           - MCP: deep-dives/mcp.md
           - Bus: deep-dives/bus.md


### PR DESCRIPTION
## Contexte

Traite l'issue #211 dans le dépôt `karned-rekipe/arclith`, branche cible `main`.

Les commandes `add-entity` et `add-usecase` positionnaient correctement les fichiers, mais leurs squelettes n'explicitaient ni les invariants d'entité, ni le pattern `Command/Query -> UseCase -> Entity/Result`, ni le choix d'une entité principale.

Closes #211

## Changements principaux

- génère une entité guidée avec rappels courts et liens stables Arclith/Pydantic, sans import `Field` inutilisé ;
- ajoute `add-usecase --entity`, `--new-entity` et `--no-entity`, mutuellement exclusifs ;
- propose en interactif les entités détectées par le scanner AST, la création d'une entité, le mode transverse ou l'annulation ;
- génère un port et un use case typés, avec `Repository[Entity]` uniquement pour un use case lié ;
- conserve `add_usecase_cmd()` non interactif et compatible avec les anciennes recettes ; les nouvelles recettes enregistrent le mode choisi ;
- couvre les layouts `src/<package>` et legacy root, les imports réels, les erreurs et les refus d'écrasement.

## Impact

- **API publique CLI** : trois nouvelles options et nouveau wizard `add-usecase` ; en automatisation, le mode doit être explicite.
- **Domaine / ports** : aucun changement du contrat partagé `Repository[T]` ni des primitives Arclith.
- **Données / migrations** : aucun impact et aucune migration.
- **Adapters / RabbitMQ / MCP / runtime** : aucun changement.
- **Configuration / secrets** : aucun changement.
- **Release** : commit `feat:` releasable ; aucune publication ni modification de version dans cette PR.

## Documentation

- README CLI, quickstart et tutoriel Todo alignés ;
- nouveau deep dive `docs/deep-dives/cli-scaffold.md` avec les exemples Create, List, Complete, Import transverse et port outbound `FindByName` ;
- index des capabilities et navigation MkDocs mis à jour ;
- journal `journal/2026-09-04-guided-cli-scaffold.md` ajouté ;
- ADR non nécessaire : le changement applique les frontières d'ADR-010 sans modifier le contrat d'architecture.

## Validations

- `cd cli && uv run --frozen pytest -q` : **173 passed, 1 skipped** ;
- tests ciblés scaffold/recette/E2E : **52 passed** ;
- `make quality` : **2171 passed, 5 skipped**, couverture **91.19 %**, Ruff/Bandit/radon/mypy OK ;
- `make precommit` : OK ;
- `make docs` : build MkDocs strict OK ;
- `uv lock --check` racine et CLI : OK ;
- smoke consommateur : génération liée et transverse, Ruff et compilation Python OK ;
- les huit liens Arclith/Pydantic intégrés répondent en HTTP 200.

## Risques restants

Le contenu des fichiers générés évolue intentionnellement. Les scripts doivent utiliser `--entity`, `--new-entity` ou `--no-entity` pour éviter tout prompt ; le replay des recettes antérieures sans mode reste transverse et non interactif.
