### PR TITLE
feat(cli): add CRUD application blueprint

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,7 +32,8 @@ arclith-cli init todo-list-service --dir ~/projects
 ```
 
 Cette commande ne crée aucune entité, aucun CRUD et aucun endpoint métier. Elle sert quand on veut
-construire le projet étape par étape avec `add-entity`, `add-usecase`, puis `add-adapter`.
+construire le projet étape par étape avec `add-entity`, `add-blueprint`, `add-usecase`, puis
+`add-adapter`.
 Elle ne crée pas non plus FastAPI ou FastMCP et n'installe aucun de leurs extras.
 
 #### Pourquoi `src/<package>/...` ?
@@ -67,13 +68,18 @@ est régénéré automatiquement pour un use case sans dépendance ou avec une d
 `Repository[Entity]`. Une composition plus riche reste explicite. Voir le
 [guide des bindings](https://karned-rekipe.github.io/arclith/deep-dives/use-case-bindings/).
 
+Pour initialiser plutôt les cinq opérations CRUD, utiliser
+`add-entity Todo --profile crud`. Ce blueprint crée le cœur applicatif et sa
+composition, mais aucun endpoint : la projection FastAPI, FastMCP, RabbitMQ ou
+LangGraph reste une décision distincte.
+
 ---
 
 ### `new` — Raccourci minimal compatible
 
-`new` exécute le même scaffold canonique que `init`, puis ajoute uniquement
-l'entité demandée. Aucun adapter, transport, runtime Docker ou feature n'est
-créé implicitement.
+`new` exécute le même scaffold canonique que `init`, puis ajoute l'entité
+demandée avec le profil `minimal` par défaut. Le profil `crud` reste explicite.
+Aucun adapter, transport ou runtime Docker n'est créé implicitement.
 
 ```bash
 # Mode interactif — l'outil pose les questions
@@ -83,12 +89,14 @@ arclith-cli new
 arclith-cli new Recipe my-recipe-service
 arclith-cli new RecipeStep meal-planner --port 8400
 arclith-cli new MealPlan meal-plan-service --dir ~/projects --port 8500
+arclith-cli new Todo todo-service --profile crud
 ```
 
 | Option | Défaut | Description |
 |--------|--------|-------------|
 | `--port` / `-p` | `8000` | Port à proposer lors du futur ajout explicite de FastAPI |
 | `--dir` / `-d` | `.` | Répertoire parent |
+| `--profile` | `minimal` | Profil applicatif initial (`minimal` ou `crud`) |
 
 Le projet généré utilise un layout `src/<package>/...` pour le code applicatif et un dossier
 `config/` structuré par adapter (voir section [Configuration](#configuration)). Utiliser ensuite
@@ -107,6 +115,7 @@ reste commenté, donc aucun import inutilisé n'est ajouté.
 ```bash
 cd my-recipe-service
 arclith-cli add-entity ShoppingItem
+arclith-cli add-entity Todo --profile crud
 ```
 
 Fichier généré :
@@ -115,9 +124,31 @@ Fichier généré :
 src/<package>/domain/models/shopping_item.py
 ```
 
-La commande ne génère aucun CRUD, aucun port repository, aucun adapter et aucun
-endpoint. Elle pose seulement le point d'ancrage du modèle métier ; le
-développeur complète ensuite les champs et invariants de l'entité.
+Sans `--profile`, le mode direct conserve le profil `minimal` et ne génère aucun
+CRUD, port repository, adapter ou endpoint. En interactif, la CLI demande de
+choisir `minimal` ou `crud`. Le profil `crud` initialise les ports inbound, use
+cases, erreurs, composition et tests du cycle `create/get/list/update/delete`,
+sans créer d'adapter.
+
+---
+
+### `blueprints` et `add-blueprint` — Initialiser un comportement applicatif
+
+Le catalogue des blueprints est distinct du catalogue des capabilities et des
+adapters :
+
+```bash
+arclith-cli blueprints
+arclith-cli blueprints --json
+arclith-cli add-blueprint crud --entity ShoppingItem --dry-run
+arclith-cli add-blueprint crud --entity ShoppingItem
+```
+
+La première application écrit `.arclith/features/shopping_item.yaml`. Un replay
+préserve les fichiers applicatifs déjà personnalisés et complète uniquement les
+fichiers manquants. Le CRUD est une possibilité parmi les futurs blueprints ;
+il n'est jamais inféré depuis un adapter. Voir le
+[contrat détaillé](https://karned-rekipe.github.io/arclith/blueprints/).
 
 ---
 
@@ -388,8 +419,9 @@ arclith = Arclith("config.yaml")
 
 ### `history` et `replay` — Relire et rejouer les décisions CLI
 
-`init`, `new`, `add-entity`, `add-usecase`, `add-intent-interpreter` et
-`add-adapter` ajoutent une étape à `arclith.recipe.yaml` uniquement après leur
+`init`, `new`, `add-entity`, `add-blueprint`, `add-usecase`,
+`add-intent-interpreter` et `add-adapter` ajoutent une étape à
+`arclith.recipe.yaml` uniquement après leur
 succès complet. La recette est un historique fonctionnel rejouable ; Git reste
 l'historique du code et `export-config` reste la configuration consolidée de
 déploiement.

--- a/cli/arclith_cli/application_blueprint_cli.py
+++ b/cli/arclith_cli/application_blueprint_cli.py
@@ -1,0 +1,234 @@
+import json
+import re
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+
+from arclith_cli.application_blueprints import (
+    APPLICATION_BLUEPRINT_CATALOG,
+    application_blueprint_catalog_as_dict,
+    application_blueprint_digest,
+    get_application_blueprint,
+)
+from arclith_cli.blueprint_generation import (
+    add_application_blueprint_cmd,
+    apply_application_blueprint,
+    plan_application_blueprint_for_entity,
+)
+from arclith_cli.command_recording import record_success
+from arclith_cli.core_scaffold import add_entity_cmd
+from arclith_cli.entity_scanner import EntityInfo
+from arclith_cli.project_paths import detect_project_paths
+from arclith_cli.recipe import snapshot_project_files
+from arclith_cli.rename import EntityNames
+
+console = Console()
+_ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+
+def add_entity_command(
+    entity: Annotated[
+        str | None,
+        typer.Argument(
+            help="Nom de l'entité métier au singulier. Exemple : Recipe, recipe_step, meal-plan",
+        ),
+    ] = None,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            help="Profil applicatif initial : minimal ou un blueprint tel que crud.",
+        ),
+    ] = None,
+    no_record: Annotated[
+        bool,
+        typer.Option("--no-record", hidden=True),
+    ] = False,
+) -> None:
+    """Créer une entité minimale, avec un blueprint applicatif explicite en option."""
+    interactive = entity is None
+    resolved_name = entity or prompt_entity()
+    try:
+        resolved_profile = resolve_entity_profile(profile, interactive=interactive)
+    except ValueError as exc:
+        console.print(f"[red]✗ Profil invalide :[/red] {exc}")
+        raise typer.Exit(1) from exc
+    project_dir = Path.cwd()
+    before = snapshot_project_files(project_dir) if not no_record else {}
+    blueprint_plan = None
+    if resolved_profile != "minimal":
+        try:
+            paths = detect_project_paths(project_dir)
+            names = EntityNames.from_input(resolved_name)
+            blueprint_plan = plan_application_blueprint_for_entity(
+                project_dir,
+                blueprint=get_application_blueprint(resolved_profile),
+                entity=EntityInfo(
+                    pascal=names.pascal,
+                    snake=names.snake,
+                    file_path=paths.domain_models / f"{names.snake}.py",
+                ),
+                feature_name=names.snake,
+            )
+        except (OSError, SyntaxError, ValueError) as exc:
+            console.print(f"[red]✗ Blueprint refusé :[/red] {exc}")
+            raise typer.Exit(1) from exc
+    add_entity_cmd(project_dir=project_dir, entity_name=resolved_name)
+    if blueprint_plan is not None:
+        try:
+            apply_application_blueprint(blueprint_plan)
+        except (OSError, ValueError) as exc:
+            console.print(f"[red]✗ Blueprint refusé :[/red] {exc}")
+            raise typer.Exit(1) from exc
+        console.print(
+            f"[bold green]✓ Blueprint {resolved_profile} appliqué à "
+            f"{blueprint_plan.entity.pascal}.[/bold green]"
+        )
+    if not no_record:
+        record_success(
+            project_dir,
+            command="add-entity",
+            args={
+                "entity": resolved_name,
+                "profile": resolved_profile,
+                **application_profile_recipe_metadata(resolved_profile),
+            },
+            before=before,
+        )
+
+
+def blueprints_command(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Afficher le catalogue au format JSON."),
+    ] = False,
+) -> None:
+    """Lister les blueprints applicatifs, distincts des adapters techniques."""
+    if as_json:
+        typer.echo(json.dumps(application_blueprint_catalog_as_dict(), indent=2))
+        return
+
+    table = Table(show_header=True, header_style="bold blue", box=None, padding=(0, 2))
+    table.add_column("Blueprint")
+    table.add_column("Version")
+    table.add_column("Opérations")
+    table.add_column("Description")
+    for blueprint_spec in APPLICATION_BLUEPRINT_CATALOG:
+        table.add_row(
+            blueprint_spec.name,
+            str(blueprint_spec.version),
+            ", ".join(blueprint_spec.operations),
+            blueprint_spec.description,
+        )
+    console.print(table)
+
+
+def add_blueprint_command(
+    blueprint: Annotated[
+        str,
+        typer.Argument(help="Blueprint applicatif à appliquer, par exemple crud."),
+    ],
+    entity: Annotated[
+        str,
+        typer.Option("--entity", "-e", help="Entité métier existante ciblée."),
+    ],
+    feature: Annotated[
+        str | None,
+        typer.Option(
+            "--feature",
+            help="Nom stable de la feature ; défaut : nom snake_case de l'entité.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Afficher le plan sans écrire de fichier."),
+    ] = False,
+    no_record: Annotated[
+        bool,
+        typer.Option("--no-record", hidden=True),
+    ] = False,
+) -> None:
+    """Appliquer un blueprint au cœur applicatif sans installer d'adapter."""
+    project_dir = Path.cwd()
+    before = (
+        snapshot_project_files(project_dir) if not no_record and not dry_run else {}
+    )
+    try:
+        result = add_application_blueprint_cmd(
+            project_dir=project_dir,
+            blueprint_name=blueprint,
+            entity_name=entity,
+            feature_name=feature,
+            dry_run=dry_run,
+        )
+    except (OSError, SyntaxError, ValueError) as exc:
+        console.print(f"[red]✗ Blueprint refusé :[/red] {exc}")
+        raise typer.Exit(1) from exc
+    if not no_record and not dry_run and result.changed:
+        record_success(
+            project_dir,
+            command="add-blueprint",
+            args={
+                "blueprint": result.blueprint.name,
+                "entity": result.entity.pascal,
+                "feature": result.feature,
+                "operations": list(result.blueprint.operations),
+                "blueprint_version": result.blueprint.version,
+                "template_digest": application_blueprint_digest(result.blueprint),
+            },
+            before=before,
+        )
+
+
+def prompt_entity() -> str:
+    console.print(
+        "\n[bold]Entité[/bold] — utilisez le [yellow]singulier[/yellow] "
+        "[dim](ex : Recipe, recipe_step, MealPlan)[/dim]"
+    )
+    while True:
+        value = Prompt.ask("  [bold green]Nom de l'entité[/bold green]").strip()
+        if not value:
+            console.print("  [red]Le nom ne peut pas être vide.[/red]")
+        elif not _ENTITY_RE.match(value):
+            console.print(
+                "  [red]Caractères invalides.[/red] "
+                "[dim]Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre.[/dim]"
+            )
+        else:
+            return value
+
+
+def resolve_entity_profile(value: str | None, *, interactive: bool) -> str:
+    if value is None and not interactive:
+        return "minimal"
+    if value is None:
+        labels = ["minimal", *(item.name for item in APPLICATION_BLUEPRINT_CATALOG)]
+        console.print("\n[bold]Profil applicatif initial[/bold]")
+        for index, label in enumerate(labels, start=1):
+            console.print(f"  [cyan]{index}[/cyan]. {label}")
+        selected = Prompt.ask(
+            "  [bold green]Choix[/bold green]",
+            choices=[str(index) for index in range(1, len(labels) + 1)],
+            default="1",
+        )
+        return labels[int(selected) - 1]
+    normalized = value.strip().lower()
+    if normalized == "minimal":
+        return normalized
+    return get_application_blueprint(normalized).name
+
+
+def application_profile_recipe_metadata(profile: str) -> dict[str, object]:
+    """Describe a non-minimal profile well enough to audit recipe drift."""
+    if profile == "minimal":
+        return {}
+    blueprint = get_application_blueprint(profile)
+    return {
+        "operations": list(blueprint.operations),
+        "blueprint_version": blueprint.version,
+        "template_digest": application_blueprint_digest(blueprint),
+    }

--- a/cli/arclith_cli/application_blueprint_cli.py
+++ b/cli/arclith_cli/application_blueprint_cli.py
@@ -17,14 +17,11 @@ from arclith_cli.application_blueprints import (
 from arclith_cli.blueprint_generation import (
     add_application_blueprint_cmd,
     apply_application_blueprint,
-    plan_application_blueprint_for_entity,
+    plan_application_profile_for_new_entity,
 )
 from arclith_cli.command_recording import record_success
 from arclith_cli.core_scaffold import add_entity_cmd
-from arclith_cli.entity_scanner import EntityInfo
-from arclith_cli.project_paths import detect_project_paths
 from arclith_cli.recipe import snapshot_project_files
-from arclith_cli.rename import EntityNames
 
 console = Console()
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -59,24 +56,15 @@ def add_entity_command(
         raise typer.Exit(1) from exc
     project_dir = Path.cwd()
     before = snapshot_project_files(project_dir) if not no_record else {}
-    blueprint_plan = None
-    if resolved_profile != "minimal":
-        try:
-            paths = detect_project_paths(project_dir)
-            names = EntityNames.from_input(resolved_name)
-            blueprint_plan = plan_application_blueprint_for_entity(
-                project_dir,
-                blueprint=get_application_blueprint(resolved_profile),
-                entity=EntityInfo(
-                    pascal=names.pascal,
-                    snake=names.snake,
-                    file_path=paths.domain_models / f"{names.snake}.py",
-                ),
-                feature_name=names.snake,
-            )
-        except (OSError, SyntaxError, ValueError) as exc:
-            console.print(f"[red]✗ Blueprint refusé :[/red] {exc}")
-            raise typer.Exit(1) from exc
+    try:
+        blueprint_plan = plan_application_profile_for_new_entity(
+            project_dir,
+            profile_name=resolved_profile,
+            entity_name=resolved_name,
+        )
+    except (OSError, SyntaxError, ValueError) as exc:
+        console.print(f"[red]✗ Blueprint refusé :[/red] {exc}")
+        raise typer.Exit(1) from exc
     add_entity_cmd(project_dir=project_dir, entity_name=resolved_name)
     if blueprint_plan is not None:
         try:

--- a/cli/arclith_cli/application_blueprint_recipe.py
+++ b/cli/arclith_cli/application_blueprint_recipe.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Any
+
+from arclith_cli.blueprint_generation import add_application_blueprint_cmd
+from arclith_cli.core_scaffold import add_entity_cmd
+
+
+def replay_application_blueprint_step(
+    command: str,
+    target_dir: Path,
+    args: dict[str, Any],
+) -> None:
+    """Replay entity and application-blueprint recipe operations."""
+    if command == "add-entity":
+        replay_add_entity_step(target_dir, args)
+        return
+    if command == "add-blueprint":
+        replay_add_blueprint_step(target_dir, args)
+        return
+    raise ValueError(f"Unsupported application blueprint recipe command: {command}")
+
+
+def replay_add_entity_step(target_dir: Path, args: dict[str, Any]) -> None:
+    """Replay entity creation, including an optional application profile."""
+    entity = str(args["entity"])
+    add_entity_cmd(project_dir=target_dir, entity_name=entity)
+    profile = str(args.get("profile", "minimal"))
+    if profile != "minimal":
+        add_application_blueprint_cmd(
+            project_dir=target_dir,
+            blueprint_name=profile,
+            entity_name=entity,
+            feature_name=None,
+            dry_run=False,
+        )
+
+
+def replay_add_blueprint_step(target_dir: Path, args: dict[str, Any]) -> None:
+    """Replay a standalone application-blueprint decision."""
+    feature = args.get("feature")
+    add_application_blueprint_cmd(
+        project_dir=target_dir,
+        blueprint_name=str(args["blueprint"]),
+        entity_name=str(args["entity"]),
+        feature_name=str(feature) if feature else None,
+        dry_run=False,
+    )

--- a/cli/arclith_cli/application_blueprint_recipe.py
+++ b/cli/arclith_cli/application_blueprint_recipe.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import Any
 
-from arclith_cli.blueprint_generation import add_application_blueprint_cmd
+from arclith_cli.blueprint_generation import (
+    add_application_blueprint_cmd,
+    apply_application_blueprint,
+    plan_application_profile_for_new_entity,
+)
 from arclith_cli.core_scaffold import add_entity_cmd
 
 
@@ -23,16 +27,15 @@ def replay_application_blueprint_step(
 def replay_add_entity_step(target_dir: Path, args: dict[str, Any]) -> None:
     """Replay entity creation, including an optional application profile."""
     entity = str(args["entity"])
-    add_entity_cmd(project_dir=target_dir, entity_name=entity)
     profile = str(args.get("profile", "minimal"))
-    if profile != "minimal":
-        add_application_blueprint_cmd(
-            project_dir=target_dir,
-            blueprint_name=profile,
-            entity_name=entity,
-            feature_name=None,
-            dry_run=False,
-        )
+    blueprint_plan = plan_application_profile_for_new_entity(
+        target_dir,
+        profile_name=profile,
+        entity_name=entity,
+    )
+    add_entity_cmd(project_dir=target_dir, entity_name=entity)
+    if blueprint_plan is not None:
+        apply_application_blueprint(blueprint_plan)
 
 
 def replay_add_blueprint_step(target_dir: Path, args: dict[str, Any]) -> None:

--- a/cli/arclith_cli/application_blueprints.py
+++ b/cli/arclith_cli/application_blueprints.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from arclith_cli.entity_scanner import EntityInfo
+    from arclith_cli.project_paths import ProjectPaths
+
+
+APPLICATION_BLUEPRINT_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ApplicationBlueprintSpec:
+    """Declarative contract for one reusable application-level blueprint."""
+
+    name: str
+    description: str
+    operations: tuple[str, ...]
+    version: int = APPLICATION_BLUEPRINT_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "operations": list(self.operations),
+        }
+
+
+CRUD_BLUEPRINT = ApplicationBlueprintSpec(
+    name="crud",
+    description="Cycle de vie CRUD explicite pour une entité métier.",
+    operations=("create", "get", "list", "update", "delete"),
+)
+
+APPLICATION_BLUEPRINT_CATALOG = (CRUD_BLUEPRINT,)
+
+
+def get_application_blueprint(name: str) -> ApplicationBlueprintSpec:
+    normalized = name.strip().lower()
+    blueprint = next(
+        (item for item in APPLICATION_BLUEPRINT_CATALOG if item.name == normalized),
+        None,
+    )
+    if blueprint is None:
+        supported = ", ".join(item.name for item in APPLICATION_BLUEPRINT_CATALOG)
+        raise ValueError(
+            f"Unknown application blueprint {name!r}; expected one of: {supported}"
+        )
+    return blueprint
+
+
+def application_blueprint_catalog_as_dict() -> list[dict[str, object]]:
+    return [item.to_dict() for item in APPLICATION_BLUEPRINT_CATALOG]
+
+
+def render_application_blueprint(
+    blueprint: ApplicationBlueprintSpec,
+    paths: ProjectPaths,
+    entity: EntityInfo,
+    feature: str,
+) -> dict[Path, str]:
+    """Render one catalogued application blueprint."""
+    if blueprint.name == "crud":
+        from arclith_cli.crud_blueprint import render_crud_blueprint
+
+        return render_crud_blueprint(paths, entity, feature)
+    raise ValueError(f"No renderer for application blueprint {blueprint.name!r}")
+
+
+def application_blueprint_digest(blueprint: ApplicationBlueprintSpec) -> str:
+    from arclith_cli.entity_scanner import EntityInfo
+    from arclith_cli.project_paths import ProjectPaths
+
+    root = Path("/application-blueprint")
+    package_root = root / "src" / "application_package"
+    paths = ProjectPaths(
+        root=root,
+        package_root=package_root,
+        package_name="application_package",
+    )
+    entity = EntityInfo(
+        pascal="Entity",
+        snake="entity",
+        file_path=package_root / "domain" / "models" / "entity.py",
+    )
+    rendered = render_application_blueprint(blueprint, paths, entity, "feature")
+    payload = json.dumps(
+        {
+            "blueprint": blueprint.to_dict(),
+            "files": {
+                path.relative_to(root).as_posix(): content
+                for path, content in sorted(rendered.items())
+            },
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()

--- a/cli/arclith_cli/blueprint_generation.py
+++ b/cli/arclith_cli/blueprint_generation.py
@@ -1,0 +1,216 @@
+import keyword
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from arclith_cli.application_blueprints import (
+    ApplicationBlueprintSpec,
+    get_application_blueprint,
+    render_application_blueprint,
+)
+from arclith_cli.entity_scanner import EntityInfo, scan_entities
+from arclith_cli.feature_manifest import (
+    FEATURE_MANIFEST_VERSION,
+    FeatureBlueprint,
+    FeatureEntity,
+    FeatureManifest,
+    load_feature_manifest,
+    render_feature_manifest,
+    save_feature_manifest,
+)
+from arclith_cli.project_paths import detect_project_paths
+from arclith_cli.rename import EntityNames
+
+console = Console()
+
+
+@dataclass(frozen=True)
+class ApplicationBlueprintPlan:
+    project_dir: Path
+    blueprint: ApplicationBlueprintSpec
+    entity: EntityInfo
+    feature: str
+    manifest: FeatureManifest
+    manifest_path: Path
+    files: dict[Path, str]
+    preserved: tuple[Path, ...]
+    originals: dict[Path, bytes | None]
+
+
+@dataclass(frozen=True)
+class ApplicationBlueprintResult:
+    blueprint: ApplicationBlueprintSpec
+    entity: EntityInfo
+    feature: str
+    manifest_path: Path
+    changed: tuple[Path, ...]
+    preserved: tuple[Path, ...]
+
+
+def plan_application_blueprint(
+    project_dir: Path,
+    *,
+    blueprint_name: str,
+    entity_name: str,
+    feature_name: str | None,
+) -> ApplicationBlueprintPlan:
+    entity = _require_entity(project_dir, entity_name)
+    return plan_application_blueprint_for_entity(
+        project_dir,
+        blueprint=get_application_blueprint(blueprint_name),
+        entity=entity,
+        feature_name=feature_name,
+    )
+
+
+def plan_application_blueprint_for_entity(
+    project_dir: Path,
+    *,
+    blueprint: ApplicationBlueprintSpec,
+    entity: EntityInfo,
+    feature_name: str | None,
+) -> ApplicationBlueprintPlan:
+    paths = detect_project_paths(project_dir)
+    feature = _feature_name(feature_name or entity.snake)
+    manifest = FeatureManifest(
+        version=FEATURE_MANIFEST_VERSION,
+        feature=feature,
+        entity=FeatureEntity(
+            name=entity.pascal,
+            module=paths.import_path("domain", "models", entity.file_path.stem),
+        ),
+        blueprint=FeatureBlueprint(name=blueprint.name, version=blueprint.version),
+        operations=blueprint.operations,
+    )
+    manifest_path = project_dir / ".arclith" / "features" / f"{feature}.yaml"
+    rendered = render_application_blueprint(blueprint, paths, entity, feature)
+    invalid_targets = sorted(
+        path for path in rendered if path.exists() and not path.is_file()
+    )
+    if invalid_targets:
+        relative = ", ".join(
+            str(path.relative_to(project_dir)) for path in invalid_targets
+        )
+        raise ValueError(f"Application blueprint target is not a file: {relative}")
+    installed = manifest_path.is_file()
+    if installed and load_feature_manifest(manifest_path) != manifest:
+        raise ValueError(
+            f"Feature {feature!r} already has a different canonical manifest"
+        )
+    if not installed:
+        collisions = sorted(
+            path for path in rendered if path.exists() and path.name != "__init__.py"
+        )
+        if collisions:
+            relative = ", ".join(
+                str(path.relative_to(project_dir)) for path in collisions
+            )
+            raise ValueError(
+                f"Application blueprint target already exists before first install: {relative}"
+            )
+
+    preserved = tuple(sorted(path for path in rendered if path.exists()))
+    files = {path: content for path, content in rendered.items() if not path.exists()}
+    if not installed:
+        files[manifest_path] = render_feature_manifest(manifest)
+    originals = {path: path.read_bytes() if path.is_file() else None for path in files}
+    return ApplicationBlueprintPlan(
+        project_dir=project_dir,
+        blueprint=blueprint,
+        entity=entity,
+        feature=feature,
+        manifest=manifest,
+        manifest_path=manifest_path,
+        files=files,
+        preserved=preserved,
+        originals=originals,
+    )
+
+
+def apply_application_blueprint(
+    plan: ApplicationBlueprintPlan,
+) -> tuple[Path, ...]:
+    for path, original in plan.originals.items():
+        current = path.read_bytes() if path.is_file() else None
+        if current != original or (path.exists() and not path.is_file()):
+            raise ValueError(
+                f"File changed after blueprint planning; rerun the command: {path}"
+            )
+    for path, content in plan.files.items():
+        if path == plan.manifest_path:
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    if plan.manifest_path in plan.files:
+        save_feature_manifest(plan.manifest, plan.manifest_path)
+    return tuple(plan.files)
+
+
+def add_application_blueprint_cmd(
+    *,
+    project_dir: Path,
+    blueprint_name: str,
+    entity_name: str,
+    feature_name: str | None,
+    dry_run: bool,
+) -> ApplicationBlueprintResult:
+    plan = plan_application_blueprint(
+        project_dir,
+        blueprint_name=blueprint_name,
+        entity_name=entity_name,
+        feature_name=feature_name,
+    )
+    for path in plan.files:
+        console.print(f"create [bold]{path.relative_to(project_dir)}[/bold]")
+    for path in plan.preserved:
+        console.print(f"preserve [dim]{path.relative_to(project_dir)}[/dim]")
+    changed = () if dry_run else apply_application_blueprint(plan)
+    if dry_run:
+        console.print("[cyan]Dry run: aucun fichier ni manifest modifié.[/cyan]")
+    else:
+        console.print(
+            f"[bold green]✓ Blueprint {plan.blueprint.name} appliqué à "
+            f"{plan.entity.pascal}.[/bold green]"
+        )
+    return ApplicationBlueprintResult(
+        blueprint=plan.blueprint,
+        entity=plan.entity,
+        feature=plan.feature,
+        manifest_path=plan.manifest_path,
+        changed=changed,
+        preserved=plan.preserved,
+    )
+
+
+def _require_entity(project_dir: Path, raw_name: str) -> EntityInfo:
+    normalized = EntityNames.from_input(raw_name.strip())
+    entities = scan_entities(project_dir)
+    entity = next(
+        (
+            item
+            for item in entities
+            if item.pascal == normalized.pascal or item.snake == normalized.snake
+        ),
+        None,
+    )
+    if entity is not None:
+        return entity
+    detected = ", ".join(item.pascal for item in entities) or "aucune"
+    console.print(
+        f"[red]✗[/red] Entité introuvable : [bold]{raw_name}[/bold]. "
+        f"Entités détectées : {detected}."
+    )
+    raise typer.Exit(1)
+
+
+def _feature_name(raw: str) -> str:
+    normalized = raw.strip().lower().replace("-", "_")
+    if (
+        not normalized.isidentifier()
+        or normalized.startswith("_")
+        or keyword.iskeyword(normalized)
+    ):
+        raise ValueError(f"Invalid public feature name: {raw!r}")
+    return normalized

--- a/cli/arclith_cli/blueprint_generation.py
+++ b/cli/arclith_cli/blueprint_generation.py
@@ -73,6 +73,11 @@ def plan_application_blueprint_for_entity(
     feature_name: str | None,
 ) -> ApplicationBlueprintPlan:
     paths = detect_project_paths(project_dir)
+    if keyword.iskeyword(entity.snake):
+        raise ValueError(
+            f"Entity {entity.pascal!r} normalizes to the reserved Python keyword "
+            f"{entity.snake!r}"
+        )
     feature = _feature_name(feature_name or entity.snake)
     manifest = FeatureManifest(
         version=FEATURE_MANIFEST_VERSION,
@@ -87,7 +92,9 @@ def plan_application_blueprint_for_entity(
     manifest_path = project_dir / ".arclith" / "features" / f"{feature}.yaml"
     rendered = render_application_blueprint(blueprint, paths, entity, feature)
     invalid_targets = sorted(
-        path for path in rendered if path.exists() and not path.is_file()
+        path
+        for path in (*rendered, manifest_path)
+        if path.exists() and not path.is_file()
     )
     if invalid_targets:
         relative = ", ".join(
@@ -126,6 +133,29 @@ def plan_application_blueprint_for_entity(
         files=files,
         preserved=preserved,
         originals=originals,
+    )
+
+
+def plan_application_profile_for_new_entity(
+    project_dir: Path,
+    *,
+    profile_name: str,
+    entity_name: str,
+) -> ApplicationBlueprintPlan | None:
+    """Preflight an optional application profile before creating its entity."""
+    if profile_name == "minimal":
+        return None
+    paths = detect_project_paths(project_dir)
+    names = EntityNames.from_input(entity_name.strip())
+    return plan_application_blueprint_for_entity(
+        project_dir,
+        blueprint=get_application_blueprint(profile_name),
+        entity=EntityInfo(
+            pascal=names.pascal,
+            snake=names.snake,
+            file_path=paths.domain_models / f"{names.snake}.py",
+        ),
+        feature_name=names.snake,
     )
 
 

--- a/cli/arclith_cli/command_recording.py
+++ b/cli/arclith_cli/command_recording.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Any, Mapping, Never
+
+import typer
+from rich.console import Console
+
+from arclith_cli.recipe import RecipeError, record_successful_step
+from arclith_cli.recipe_models import RecipeSecretRef
+
+console = Console()
+
+
+def record_success(
+    project_dir: Path,
+    *,
+    command: str,
+    args: Mapping[str, Any],
+    before: Mapping[str, str],
+    secret_fields: Mapping[str, str] | None = None,
+    secret_references: tuple[RecipeSecretRef, ...] = (),
+) -> None:
+    """Record one completed command and present recipe failures consistently."""
+    try:
+        record_successful_step(
+            project_dir,
+            command=command,
+            args=args,
+            before=before,
+            secret_fields=secret_fields,
+            secret_references=secret_references,
+        )
+    except (OSError, RecipeError) as exc:
+        _recipe_error(exc)
+
+
+def _recipe_error(exc: Exception) -> Never:
+    console.print(f"[red]✗ Recette CLI invalide :[/red] {exc}")
+    raise typer.Exit(1)

--- a/cli/arclith_cli/core_scaffold.py
+++ b/cli/arclith_cli/core_scaffold.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import keyword
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -279,12 +280,16 @@ def _assert_project_root(project_dir: Path, *, command: str) -> None:
 
 
 def _assert_valid_name(raw: str, *, label: str) -> None:
-    if _NAME_RE.match(raw.strip()):
+    normalized = raw.strip()
+    if _NAME_RE.match(normalized) and not keyword.iskeyword(
+        EntityNames.from_input(normalized).snake
+    ):
         return
 
     console.print(
         f"[red]✗[/red] Nom de {label} invalide : [bold]{raw}[/bold]. "
-        "Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre."
+        "Lettres, chiffres, _ et - uniquement, sans mot-clé Python réservé. "
+        "Doit commencer par une lettre."
     )
     raise typer.Exit(1)
 

--- a/cli/arclith_cli/crud_blueprint.py
+++ b/cli/arclith_cli/crud_blueprint.py
@@ -1,0 +1,550 @@
+from pathlib import Path
+from textwrap import dedent
+
+from arclith_cli.entity_scanner import EntityInfo
+from arclith_cli.project_paths import ProjectPaths
+
+
+def render_crud_blueprint(
+    paths: ProjectPaths,
+    entity: EntityInfo,
+    feature: str,
+) -> dict[Path, str]:
+    entity_module = paths.import_path("domain", "models", entity.file_path.stem)
+    errors_module = paths.import_path("domain", "errors", feature)
+    ports_prefix = paths.import_path("domain", "ports", "inbound")
+    use_cases_prefix = paths.import_path("application", "use_cases")
+    base = {
+        paths.package_root / "domain" / "errors" / f"{feature}.py": _errors(
+            entity.pascal
+        ),
+        paths.inbound_ports / f"create_{feature}.py": _create_port(
+            entity.pascal, entity_module
+        ),
+        paths.inbound_ports / f"get_{feature}.py": _get_port(
+            entity.pascal, entity_module
+        ),
+        paths.inbound_ports / f"list_{feature}.py": _list_port(
+            entity.pascal, entity_module
+        ),
+        paths.inbound_ports / f"update_{feature}.py": _update_port(
+            entity.pascal, entity_module
+        ),
+        paths.inbound_ports / f"delete_{feature}.py": _delete_port(entity.pascal),
+        paths.application_use_cases / f"create_{feature}.py": _create_use_case(
+            entity.pascal,
+            entity_module,
+            f"{ports_prefix}.create_{feature}",
+        ),
+        paths.application_use_cases / f"get_{feature}.py": _get_use_case(
+            entity.pascal,
+            entity_module,
+            f"{ports_prefix}.get_{feature}",
+            errors_module,
+        ),
+        paths.application_use_cases / f"list_{feature}.py": _list_use_case(
+            entity.pascal,
+            entity_module,
+            f"{ports_prefix}.list_{feature}",
+        ),
+        paths.application_use_cases / f"update_{feature}.py": _update_use_case(
+            entity.pascal,
+            entity_module,
+            f"{ports_prefix}.update_{feature}",
+            errors_module,
+        ),
+        paths.application_use_cases / f"delete_{feature}.py": _delete_use_case(
+            entity.pascal,
+            entity_module,
+            f"{ports_prefix}.delete_{feature}",
+            errors_module,
+        ),
+        paths.containers / f"{feature}.py": _container(
+            entity.pascal,
+            entity_module,
+            ports_prefix,
+            use_cases_prefix,
+            feature,
+        ),
+        paths.root / "tests" / "application" / f"test_{feature}_crud.py": _test(
+            paths.package_name or "", entity.pascal, feature
+        ),
+        paths.root / "docs" / "blueprints" / f"{feature}-crud.md": _documentation(
+            entity.pascal, feature
+        ),
+    }
+    return _with_package_initializers(paths, base)
+
+
+def _with_package_initializers(
+    paths: ProjectPaths,
+    files: dict[Path, str],
+) -> dict[Path, str]:
+    result = dict(files)
+    for path in tuple(files):
+        for parent in path.parents:
+            if parent in {paths.root, paths.package_root.parent}:
+                break
+            if parent.is_relative_to(paths.package_root) or parent.is_relative_to(
+                paths.root / "tests"
+            ):
+                result.setdefault(parent / "__init__.py", "")
+    return result
+
+
+def _errors(entity: str) -> str:
+    return dedent(
+        f'''\
+        class {entity}NotFoundError(LookupError):
+            """Raised when the requested {entity} does not exist or was deleted."""
+
+
+        class {entity}VersionConflictError(RuntimeError):
+            """Raised when an update targets a stale optimistic-lock version."""
+        '''
+    )
+
+
+def _create_port(entity: str, entity_module: str) -> str:
+    return dedent(
+        f'''\
+        from abc import ABC, abstractmethod
+
+        from pydantic import BaseModel
+
+        from {entity_module} import {entity}
+
+
+        class Create{entity}Command(BaseModel):
+            """Validated creation fields; add the entity's writable business fields."""
+
+            pass
+
+
+        class Create{entity}Result(BaseModel):
+            item: {entity}
+
+
+        class Create{entity}Port(ABC):
+            @abstractmethod
+            async def execute(
+                self, command: Create{entity}Command
+            ) -> Create{entity}Result:
+                raise NotImplementedError
+        '''
+    )
+
+
+def _get_port(entity: str, entity_module: str) -> str:
+    return dedent(
+        f"""\
+        from abc import ABC, abstractmethod
+        from uuid import UUID
+
+        from pydantic import BaseModel
+
+        from {entity_module} import {entity}
+
+
+        class Get{entity}Query(BaseModel):
+            uuid: UUID
+
+
+        class Get{entity}Result(BaseModel):
+            item: {entity}
+
+
+        class Get{entity}Port(ABC):
+            @abstractmethod
+            async def execute(self, query: Get{entity}Query) -> Get{entity}Result:
+                raise NotImplementedError
+        """
+    )
+
+
+def _list_port(entity: str, entity_module: str) -> str:
+    return dedent(
+        f"""\
+        from abc import ABC, abstractmethod
+
+        from pydantic import BaseModel, Field
+
+        from {entity_module} import {entity}
+
+
+        class List{entity}Query(BaseModel):
+            offset: int = Field(default=0, ge=0)
+            limit: int = Field(default=100, ge=1, le=1000)
+
+
+        class List{entity}Result(BaseModel):
+            items: list[{entity}]
+            total: int
+            offset: int
+            limit: int
+
+
+        class List{entity}Port(ABC):
+            @abstractmethod
+            async def execute(self, query: List{entity}Query) -> List{entity}Result:
+                raise NotImplementedError
+        """
+    )
+
+
+def _update_port(entity: str, entity_module: str) -> str:
+    return dedent(
+        f'''\
+        from abc import ABC, abstractmethod
+        from uuid import UUID
+
+        from pydantic import BaseModel, Field
+
+        from {entity_module} import {entity}
+
+
+        class Update{entity}Command(BaseModel):
+            """Optimistic update; add the entity's writable business fields."""
+
+            uuid: UUID
+            version: int = Field(ge=1)
+
+
+        class Update{entity}Result(BaseModel):
+            item: {entity}
+
+
+        class Update{entity}Port(ABC):
+            @abstractmethod
+            async def execute(
+                self, command: Update{entity}Command
+            ) -> Update{entity}Result:
+                raise NotImplementedError
+        '''
+    )
+
+
+def _delete_port(entity: str) -> str:
+    return dedent(
+        f"""\
+        from abc import ABC, abstractmethod
+        from uuid import UUID
+
+        from pydantic import BaseModel
+
+
+        class Delete{entity}Command(BaseModel):
+            uuid: UUID
+            deleted_by: str | None = None
+
+
+        class Delete{entity}Result(BaseModel):
+            deleted: bool
+
+
+        class Delete{entity}Port(ABC):
+            @abstractmethod
+            async def execute(
+                self, command: Delete{entity}Command
+            ) -> Delete{entity}Result:
+                raise NotImplementedError
+        """
+    )
+
+
+def _create_use_case(entity: str, entity_module: str, port_module: str) -> str:
+    return dedent(
+        f"""\
+        from arclith.application.services.base_service import BaseService
+
+        from {entity_module} import {entity}
+        from {port_module} import (
+            Create{entity}Command,
+            Create{entity}Port,
+            Create{entity}Result,
+        )
+
+
+        class Create{entity}UseCase(Create{entity}Port):
+            def __init__(self, service: BaseService[{entity}]) -> None:
+                self._service = service
+
+            async def execute(
+                self, command: Create{entity}Command
+            ) -> Create{entity}Result:
+                entity = {entity}.model_validate(
+                    command.model_dump(exclude_unset=True), by_name=True
+                )
+                return Create{entity}Result(item=await self._service.create(entity))
+        """
+    )
+
+
+def _get_use_case(
+    entity: str,
+    entity_module: str,
+    port_module: str,
+    errors_module: str,
+) -> str:
+    return dedent(
+        f"""\
+        from arclith.application.services.base_service import BaseService
+
+        from {entity_module} import {entity}
+        from {errors_module} import {entity}NotFoundError
+        from {port_module} import Get{entity}Port, Get{entity}Query, Get{entity}Result
+
+
+        class Get{entity}UseCase(Get{entity}Port):
+            def __init__(self, service: BaseService[{entity}]) -> None:
+                self._service = service
+
+            async def execute(self, query: Get{entity}Query) -> Get{entity}Result:
+                item = await self._service.read(query.uuid)
+                if item is None:
+                    raise {entity}NotFoundError(str(query.uuid))
+                return Get{entity}Result(item=item)
+        """
+    )
+
+
+def _list_use_case(entity: str, entity_module: str, port_module: str) -> str:
+    return dedent(
+        f"""\
+        from arclith.application.services.base_service import BaseService
+
+        from {entity_module} import {entity}
+        from {port_module} import List{entity}Port, List{entity}Query, List{entity}Result
+
+
+        class List{entity}UseCase(List{entity}Port):
+            def __init__(self, service: BaseService[{entity}]) -> None:
+                self._service = service
+
+            async def execute(self, query: List{entity}Query) -> List{entity}Result:
+                items, total = await self._service.find_page(query.offset, query.limit)
+                return List{entity}Result(
+                    items=items,
+                    total=total,
+                    offset=query.offset,
+                    limit=query.limit,
+                )
+        """
+    )
+
+
+def _update_use_case(
+    entity: str,
+    entity_module: str,
+    port_module: str,
+    errors_module: str,
+) -> str:
+    return dedent(
+        f"""\
+        from arclith.application.services.base_service import BaseService
+
+        from {entity_module} import {entity}
+        from {errors_module} import (
+            {entity}NotFoundError,
+            {entity}VersionConflictError,
+        )
+        from {port_module} import (
+            Update{entity}Command,
+            Update{entity}Port,
+            Update{entity}Result,
+        )
+
+
+        class Update{entity}UseCase(Update{entity}Port):
+            def __init__(self, service: BaseService[{entity}]) -> None:
+                self._service = service
+
+            async def execute(
+                self, command: Update{entity}Command
+            ) -> Update{entity}Result:
+                current = await self._service.read(command.uuid)
+                if current is None:
+                    raise {entity}NotFoundError(str(command.uuid))
+                if current.version != command.version:
+                    raise {entity}VersionConflictError(
+                        f"expected version {{current.version}}, got {{command.version}}"
+                    )
+                changes = command.model_dump(
+                    exclude={{"uuid", "version"}}, exclude_unset=True
+                )
+                candidate = type(current).model_validate(
+                    {{
+                        **current.model_dump(),
+                        **changes,
+                        "version": command.version,
+                    }}
+                )
+                return Update{entity}Result(
+                    item=await self._service.update(candidate)
+                )
+        """
+    )
+
+
+def _delete_use_case(
+    entity: str,
+    entity_module: str,
+    port_module: str,
+    errors_module: str,
+) -> str:
+    return dedent(
+        f"""\
+        from arclith.application.services.base_service import BaseService
+
+        from {entity_module} import {entity}
+        from {errors_module} import {entity}NotFoundError
+        from {port_module} import (
+            Delete{entity}Command,
+            Delete{entity}Port,
+            Delete{entity}Result,
+        )
+
+
+        class Delete{entity}UseCase(Delete{entity}Port):
+            def __init__(self, service: BaseService[{entity}]) -> None:
+                self._service = service
+
+            async def execute(
+                self, command: Delete{entity}Command
+            ) -> Delete{entity}Result:
+                if await self._service.read(command.uuid) is None:
+                    raise {entity}NotFoundError(str(command.uuid))
+                await self._service.delete(command.uuid, command.deleted_by)
+                return Delete{entity}Result(deleted=True)
+        """
+    )
+
+
+def _container(
+    entity: str,
+    entity_module: str,
+    ports_prefix: str,
+    use_cases_prefix: str,
+    feature: str,
+) -> str:
+    return dedent(
+        f'''\
+        from dataclasses import dataclass
+
+        from arclith import Arclith
+        from arclith.application.services.base_service import BaseService
+
+        from {use_cases_prefix}.create_{feature} import Create{entity}UseCase
+        from {use_cases_prefix}.delete_{feature} import Delete{entity}UseCase
+        from {use_cases_prefix}.get_{feature} import Get{entity}UseCase
+        from {use_cases_prefix}.list_{feature} import List{entity}UseCase
+        from {use_cases_prefix}.update_{feature} import Update{entity}UseCase
+        from {entity_module} import {entity}
+        from {ports_prefix}.create_{feature} import Create{entity}Port
+        from {ports_prefix}.delete_{feature} import Delete{entity}Port
+        from {ports_prefix}.get_{feature} import Get{entity}Port
+        from {ports_prefix}.list_{feature} import List{entity}Port
+        from {ports_prefix}.update_{feature} import Update{entity}Port
+
+
+        @dataclass(frozen=True)
+        class {entity}UseCases:
+            create: Create{entity}Port
+            get: Get{entity}Port
+            list: List{entity}Port
+            update: Update{entity}Port
+            delete: Delete{entity}Port
+
+
+        def build_{feature}_use_cases(arclith: Arclith) -> {entity}UseCases:
+            """Compose one shared CRUD service without selecting a concrete adapter."""
+            service = BaseService[{entity}](
+                arclith.repository({entity}),
+                arclith.logger,
+                arclith.config.soft_delete.retention_days,
+            )
+            return {entity}UseCases(
+                create=Create{entity}UseCase(service),
+                get=Get{entity}UseCase(service),
+                list=List{entity}UseCase(service),
+                update=Update{entity}UseCase(service),
+                delete=Delete{entity}UseCase(service),
+            )
+        '''
+    )
+
+
+def _test(package: str, entity: str, feature: str) -> str:
+    prefix = f"{package}." if package else ""
+    return dedent(
+        f"""\
+        import pytest
+
+        from arclith import Arclith
+
+        from {prefix}domain.errors.{feature} import {entity}NotFoundError
+        from {prefix}domain.ports.inbound.create_{feature} import (
+            Create{entity}Command,
+        )
+        from {prefix}domain.ports.inbound.delete_{feature} import (
+            Delete{entity}Command,
+        )
+        from {prefix}domain.ports.inbound.get_{feature} import Get{entity}Query
+        from {prefix}domain.ports.inbound.list_{feature} import List{entity}Query
+        from {prefix}domain.ports.inbound.update_{feature} import (
+            Update{entity}Command,
+        )
+        from {prefix}infrastructure.containers.{feature} import (
+            build_{feature}_use_cases,
+        )
+
+
+        @pytest.mark.asyncio
+        async def test_{feature}_crud_uses_the_configured_repository() -> None:
+            use_cases = build_{feature}_use_cases(Arclith("config"))
+
+            created = await use_cases.create.execute(Create{entity}Command())
+            found = await use_cases.get.execute(
+                Get{entity}Query(uuid=created.item.uuid)
+            )
+            page = await use_cases.list.execute(List{entity}Query())
+            updated = await use_cases.update.execute(
+                Update{entity}Command(
+                    uuid=created.item.uuid,
+                    version=created.item.version,
+                )
+            )
+            deleted = await use_cases.delete.execute(
+                Delete{entity}Command(uuid=created.item.uuid)
+            )
+
+            assert found.item == created.item
+            assert page.items == [created.item]
+            assert page.total == 1
+            assert updated.item.version == 2
+            assert deleted.deleted is True
+            with pytest.raises({entity}NotFoundError):
+                await use_cases.get.execute(Get{entity}Query(uuid=created.item.uuid))
+        """
+    )
+
+
+def _documentation(entity: str, feature: str) -> str:
+    return dedent(
+        f"""\
+        # Blueprint CRUD `{feature}`
+
+        Cette feature applique le blueprint CRUD version 1 à l'entité `{entity}`.
+
+        Opérations déclarées : `create`, `get`, `list`, `update`, `delete`.
+
+        Les ports inbound et les use cases sont détenus par ce projet. Complétez les
+        champs métier de `Create{entity}Command` et `Update{entity}Command` avant de
+        publier un contrat de transport. Le container compose les primitives CRUD
+        Arclith avec le repository choisi par la configuration ; il ne sélectionne
+        aucun adapter concret.
+
+        Les projections FastAPI, FastMCP, RabbitMQ ou LangGraph sont des décisions
+        séparées. N'exposez que les opérations compatibles avec le transport visé.
+        """
+    )

--- a/cli/arclith_cli/feature_manifest.py
+++ b/cli/arclith_cli/feature_manifest.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import keyword
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+FEATURE_MANIFEST_VERSION = 1
+
+
+@dataclass(frozen=True)
+class FeatureEntity:
+    name: str
+    module: str
+
+    @classmethod
+    def from_dict(cls, raw: object) -> FeatureEntity:
+        data = _mapping(raw, "feature.entity")
+        _exact_keys(data, {"name", "module"}, "feature.entity")
+        return cls(
+            name=_string(data["name"], "feature.entity.name"),
+            module=_string(data["module"], "feature.entity.module"),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "module": self.module}
+
+
+@dataclass(frozen=True)
+class FeatureBlueprint:
+    name: str
+    version: int
+
+    @classmethod
+    def from_dict(cls, raw: object) -> FeatureBlueprint:
+        data = _mapping(raw, "feature.blueprint")
+        _exact_keys(data, {"name", "version"}, "feature.blueprint")
+        version = data["version"]
+        if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+            raise ValueError("feature.blueprint.version must be a positive integer")
+        return cls(
+            name=_string(data["name"], "feature.blueprint.name"),
+            version=version,
+        )
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {"name": self.name, "version": self.version}
+
+
+@dataclass(frozen=True)
+class FeatureManifest:
+    version: int
+    feature: str
+    entity: FeatureEntity
+    blueprint: FeatureBlueprint
+    operations: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, raw: object) -> FeatureManifest:
+        data = _mapping(raw, "feature manifest")
+        _exact_keys(
+            data,
+            {"version", "feature", "entity", "blueprint", "operations"},
+            "feature manifest",
+        )
+        version = data["version"]
+        if version != FEATURE_MANIFEST_VERSION:
+            raise ValueError(
+                f"Unsupported feature manifest version {version!r}; "
+                f"expected {FEATURE_MANIFEST_VERSION}"
+            )
+        raw_operations = data["operations"]
+        if not isinstance(raw_operations, list) or not raw_operations:
+            raise ValueError("feature.operations must be a non-empty list")
+        operations = tuple(
+            _string(operation, "feature.operations[]") for operation in raw_operations
+        )
+        if len(operations) != len(set(operations)):
+            raise ValueError("feature.operations must not contain duplicates")
+        return cls(
+            version=version,
+            feature=_identifier(data["feature"], "feature.feature"),
+            entity=FeatureEntity.from_dict(data["entity"]),
+            blueprint=FeatureBlueprint.from_dict(data["blueprint"]),
+            operations=operations,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "feature": self.feature,
+            "entity": self.entity.to_dict(),
+            "blueprint": self.blueprint.to_dict(),
+            "operations": list(self.operations),
+        }
+
+
+def load_feature_manifest(path: Path) -> FeatureManifest:
+    if not path.is_file():
+        raise ValueError(f"Feature manifest not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return FeatureManifest.from_dict(raw)
+
+
+def render_feature_manifest(manifest: FeatureManifest) -> str:
+    validated = FeatureManifest.from_dict(manifest.to_dict())
+    return yaml.safe_dump(
+        validated.to_dict(),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+    )
+
+
+def save_feature_manifest(manifest: FeatureManifest, path: Path) -> None:
+    rendered = render_feature_manifest(manifest)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(rendered)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.chmod(0o644)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _mapping(raw: object, label: str) -> dict[str, Any]:
+    if not isinstance(raw, dict) or not all(isinstance(key, str) for key in raw):
+        raise ValueError(f"{label} must be a mapping with string keys")
+    return raw
+
+
+def _exact_keys(data: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(data) != expected:
+        raise ValueError(f"{label} must contain exactly: {', '.join(sorted(expected))}")
+
+
+def _string(raw: object, label: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return raw
+
+
+def _identifier(raw: object, label: str) -> str:
+    value = _string(raw, label)
+    if not value.isidentifier() or value.startswith("_") or keyword.iskeyword(value):
+        raise ValueError(f"{label} must be a public Python identifier")
+    return value

--- a/cli/arclith_cli/feature_manifest.py
+++ b/cli/arclith_cli/feature_manifest.py
@@ -69,6 +69,8 @@ class FeatureManifest:
             "feature manifest",
         )
         version = data["version"]
+        if isinstance(version, bool) or not isinstance(version, int):
+            raise ValueError("feature.version must be an integer")
         if version != FEATURE_MANIFEST_VERSION:
             raise ValueError(
                 f"Unsupported feature manifest version {version!r}; "
@@ -103,7 +105,10 @@ class FeatureManifest:
 def load_feature_manifest(path: Path) -> FeatureManifest:
     if not path.is_file():
         raise ValueError(f"Feature manifest not found: {path}")
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in feature manifest {path}: {exc}") from exc
     return FeatureManifest.from_dict(raw)
 
 

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -164,7 +164,8 @@ Le parcours fonctionne immédiatement avec les seuls champs techniques de
 `Entity`. Ajoutez ensuite les champs métier dans le modèle et la commande ; les
 fichiers indiquent où placer validations et règles métier. `expose-usecase`
 régénère la composition typée. Aucun transport ni adapter optionnel n'est créé
-par `init`.
+par `init`. Pour initialiser le cycle applicatif classique sans adapter, utilisez
+`arclith-cli add-entity Todo --profile crud`.
 """,
         encoding="utf-8",
     )
@@ -179,9 +180,10 @@ This `src/<package>` namespace is required by Python packaging and must not be f
 
 - MUST create technologies with `arclith-cli add-adapter` and public bindings with `expose-usecase`.
 - MUST keep code inside a path declared by `ARCHITECTURE.md` and the installed adapter blueprint.
-- MUST NOT create alternate roots, global `utils.py`/`helpers.py`, or infer a feature from an entity.
+- MUST NOT create alternate roots, global `utils.py`/`helpers.py`, or infer a transport feature from an entity.
 - If no declared location fits, update the official blueprint and architecture decision before adding code.
 - Each `.arclith/blueprints/*.yaml` file is a closed, machine-readable list of expected paths.
+- Each `.arclith/features/*.yaml` file declares an application blueprint and its operations, never a transport.
 
 - Domain imports no adapter or infrastructure module.
 - Application depends on domain models and inbound/outbound ports.
@@ -195,7 +197,7 @@ This `src/<package>` namespace is required by Python packaging and must not be f
 - Test mapping, application contracts and runtime registration with fake ports before delivery.
 - LangGraph state is serializable and versioned; test checkpoint resume when persisted keys change.
 
-Start with `arclith-cli add-entity`, `add-usecase` and `add-adapter`.
+Start with `arclith-cli add-entity`, optionally `add-blueprint`, then `add-usecase` and `add-adapter`.
 Use `uv run python -m pytest` to validate this service.
 """,
         encoding="utf-8",
@@ -234,6 +236,10 @@ An adapter directory exists only after `add-adapter`. Its root README and every
 role README define the allowed responsibilities. The corresponding
 `.arclith/blueprints/<capability>-<adapter>.yaml` records the closed list of
 expected paths. A feature directory exists only after `expose-usecase`.
+
+An application blueprint exists only after `add-entity --profile <name>` or
+`add-blueprint`. Its `.arclith/features/<feature>.yaml` manifest declares the
+application operations but never creates an adapter or transport binding.
 
 FastAPI uses exactly `register.py -> routers/v1/router.py -> <feature>/router.py
 -> routes/<operation>.py`. FastMCP uses `register.py -> features/<feature>/

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Annotated, Any, Mapping, Never
+from typing import Annotated
 
 import typer
 from rich.console import Console
@@ -13,17 +13,23 @@ from rich.table import Table
 from . import __version__
 from .add_adapter import add_adapter_cmd
 from .adapter_blueprints import blueprint_digest, get_adapter_blueprint
+from .application_blueprint_cli import (
+    add_blueprint_command,
+    add_entity_command,
+    application_profile_recipe_metadata,
+    blueprints_command,
+    prompt_entity,
+    resolve_entity_profile,
+)
 from .binding_cli import expose_usecase_command
 from .capabilities import CAPABILITY_CATALOG, capability_catalog_as_dict
-from .core_scaffold import add_entity_cmd, add_intent_interpreter_cmd, add_usecase_cmd
+from .command_recording import record_success as _record_success
+from .core_scaffold import add_intent_interpreter_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .init_project import init_project_cmd
 from .new_project import new_project_cmd as _new_project_cmd
 from .recipe import (
-    RecipeError,
-    RecipeSecretRef,
     adapter_secret_metadata,
-    record_successful_step,
     snapshot_project_files,
 )
 from .recipe_cli import history_command, replay_command
@@ -41,6 +47,9 @@ console = Console()
 app.command(name="history")(history_command)
 app.command(name="replay")(replay_command)
 app.command(name="expose-usecase")(expose_usecase_command)
+app.command(name="add-entity")(add_entity_command)
+app.command(name="blueprints")(blueprints_command)
+app.command(name="add-blueprint")(add_blueprint_command)
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -110,6 +119,13 @@ def new(
             help="Port REST suggéré pour un futur add-adapter api/fastapi",
         ),
     ] = 8000,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            help="Profil applicatif initial : minimal ou un blueprint tel que crud.",
+        ),
+    ] = None,
     repo_ref: Annotated[
         str,
         typer.Option(
@@ -134,7 +150,13 @@ def new(
     ] = False,
 ) -> None:
     """Raccourci canonique pour init puis add-entity, sans adapter implicite."""
-    entity = entity or _prompt_entity()
+    interactive = entity is None
+    entity = entity or prompt_entity()
+    try:
+        resolved_profile = resolve_entity_profile(profile, interactive=interactive)
+    except ValueError as exc:
+        console.print(f"[red]✗ Profil invalide :[/red] {exc}")
+        raise typer.Exit(1) from exc
     project_name = project_name or _prompt_project()
     target_dir = _new_project_cmd(
         entity=entity,
@@ -143,6 +165,7 @@ def new(
         port=port,
         repo_ref=repo_ref,
         template_dir=template_dir,
+        profile=resolved_profile,
     )
     if not no_record:
         _record_success(
@@ -154,6 +177,8 @@ def new(
                 "directory": ".",
                 "port": port,
                 "repo_ref": repo_ref,
+                "profile": resolved_profile,
+                **application_profile_recipe_metadata(resolved_profile),
             },
             before={},
         )
@@ -307,33 +332,6 @@ def add_adapter(
         )
 
 
-@app.command(name="add-entity")
-def add_entity(
-    entity: Annotated[
-        str | None,
-        typer.Argument(
-            help="Nom de l'entité métier au singulier. Exemple : Recipe, recipe_step, meal-plan",
-        ),
-    ] = None,
-    no_record: Annotated[
-        bool,
-        typer.Option("--no-record", hidden=True),
-    ] = False,
-) -> None:
-    """Créer uniquement le fichier minimal d'une entité métier dans domain/models."""
-    resolved_name = entity or _prompt_entity()
-    project_dir = Path.cwd()
-    before = snapshot_project_files(project_dir) if not no_record else {}
-    add_entity_cmd(project_dir=project_dir, entity_name=resolved_name)
-    if not no_record:
-        _record_success(
-            project_dir,
-            command="add-entity",
-            args={"entity": resolved_name},
-            before=before,
-        )
-
-
 @app.command(name="add-usecase")
 def add_usecase(
     usecase: Annotated[
@@ -471,24 +469,6 @@ def export_config(
 # ── Prompts interactifs ───────────────────────────────────────────────────────
 
 
-def _prompt_entity() -> str:
-    console.print(
-        "\n[bold]Entité[/bold] — utilisez le [yellow]singulier[/yellow] "
-        "[dim](ex : Recipe, recipe_step, MealPlan)[/dim]"
-    )
-    while True:
-        value = Prompt.ask("  [bold green]Nom de l'entité[/bold green]").strip()
-        if not value:
-            console.print("  [red]Le nom ne peut pas être vide.[/red]")
-        elif not _ENTITY_RE.match(value):
-            console.print(
-                "  [red]Caractères invalides.[/red] "
-                "[dim]Lettres, chiffres, _ et - uniquement. Doit commencer par une lettre.[/dim]"
-            )
-        else:
-            return value
-
-
 def _prompt_project() -> str:
     console.print(
         "\n[bold]Projet[/bold] [dim](ex : my-recipe-service, meal-planner)[/dim]"
@@ -541,33 +521,6 @@ def _prompt_intent_interpreter() -> str:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
-
-
-def _record_success(
-    project_dir: Path,
-    *,
-    command: str,
-    args: Mapping[str, Any],
-    before: Mapping[str, str],
-    secret_fields: Mapping[str, str] | None = None,
-    secret_references: tuple[RecipeSecretRef, ...] = (),
-) -> None:
-    try:
-        record_successful_step(
-            project_dir,
-            command=command,
-            args=args,
-            before=before,
-            secret_fields=secret_fields,
-            secret_references=secret_references,
-        )
-    except (OSError, RecipeError) as exc:
-        _recipe_error(exc)
-
-
-def _recipe_error(exc: Exception) -> Never:
-    console.print(f"[red]✗ Recette CLI invalide :[/red] {exc}")
-    raise typer.Exit(1)
 
 
 def _split_entity_option(value: str | None) -> list[str] | None:

--- a/cli/arclith_cli/new_project.py
+++ b/cli/arclith_cli/new_project.py
@@ -6,6 +6,8 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from arclith_cli.application_blueprints import get_application_blueprint
+from arclith_cli.blueprint_generation import add_application_blueprint_cmd
 from arclith_cli.core_scaffold import add_entity_cmd
 from arclith_cli.init_project import init_project_cmd
 from arclith_cli.rename import EntityNames
@@ -21,6 +23,7 @@ def new_project_cmd(
     port: int,
     repo_ref: str,
     template_dir: Path | None,
+    profile: str = "minimal",
     target_path: Path | None = None,
 ) -> Path:
     """Create the canonical minimal project and its first entity.
@@ -30,6 +33,8 @@ def new_project_cmd(
     and runtime files remain explicit ``add-adapter`` decisions.
     """
     _validate_suggested_api_port(port)
+    if profile != "minimal":
+        get_application_blueprint(profile)
     _ = repo_ref, template_dir  # Retained for replay compatibility with old recipes.
     entity_names = EntityNames.from_input(entity)
 
@@ -39,12 +44,26 @@ def new_project_cmd(
         target_path=target_path,
     )
     add_entity_cmd(project_dir=target_dir, entity_name=entity)
+    if profile != "minimal":
+        add_application_blueprint_cmd(
+            project_dir=target_dir,
+            blueprint_name=profile,
+            entity_name=entity,
+            feature_name=None,
+            dry_run=False,
+        )
+
+    application_next = (
+        f"[bold cyan]arclith-cli add-usecase Create{entity_names.pascal} "
+        f"--entity {entity_names.pascal}[/bold cyan]"
+        if profile == "minimal"
+        else "[bold cyan]Compléter les commandes et invariants du CRUD généré[/bold cyan]"
+    )
 
     console.print(
         Panel(
             "Aucun adapter n'a été ajouté automatiquement.\n\n"
-            "[bold cyan]arclith-cli add-usecase Create"
-            f"{entity_names.pascal} --entity {entity_names.pascal}[/bold cyan]\n"
+            f"{application_next}\n"
             "[bold cyan]arclith-cli add-adapter[/bold cyan]"
             "  [dim]# choisir explicitement repository, API, MCP, bus…[/dim]\n"
             "[bold cyan]arclith-cli add-adapter --capability api --adapter fastapi "

--- a/cli/arclith_cli/recipe.py
+++ b/cli/arclith_cli/recipe.py
@@ -33,6 +33,7 @@ _SUPPORTED_COMMANDS = {
     "init",
     "new",
     "add-adapter",
+    "add-blueprint",
     "add-entity",
     "add-usecase",
     "add-intent-interpreter",
@@ -255,27 +256,6 @@ def validate_replay_steps(
         )
 
 
-def step_summary(step: RecipeStep) -> str:
-    """Return a compact, secret-free human summary for history and dry-run."""
-    args = step.args
-    if step.command in {"init", "new"}:
-        return str(args.get("project_name") or "project")
-    if step.command == "add-adapter":
-        capability = args.get("capability", "repository")
-        adapter = args.get("adapter", "?")
-        entities = args.get("entities") or []
-        suffix = f" ({', '.join(map(str, entities))})" if entities else ""
-        return f"{capability}/{adapter}{suffix}"
-    if step.command == "add-usecase":
-        usecase = str(args.get("usecase") or "usecase")
-        entity = args.get("entity") or args.get("new_entity")
-        return f"{usecase} ({entity})" if entity else f"{usecase} (transverse)"
-    for key in ("entity", "usecase", "intent"):
-        if key in args:
-            return str(args[key])
-    return ""
-
-
 def required_replay_env(steps: tuple[RecipeStep, ...]) -> tuple[str, ...]:
     """List environment variables needed to hydrate redacted replay arguments."""
     return tuple(
@@ -315,6 +295,7 @@ def _execute_step(
             port=int(args.get("port", 8000)),
             repo_ref=str(args.get("repo_ref", "main")),
             template_dir=None,
+            profile=str(args.get("profile", "minimal")),
             target_path=target_dir,
         )
         return
@@ -322,10 +303,12 @@ def _execute_step(
         raise RecipeError(
             f"Replay target does not exist before step {step.id}: {target_dir}"
         )
-    if step.command == "add-entity":
-        from arclith_cli.core_scaffold import add_entity_cmd
+    if step.command in {"add-entity", "add-blueprint"}:
+        from arclith_cli.application_blueprint_recipe import (
+            replay_application_blueprint_step,
+        )
 
-        add_entity_cmd(project_dir=target_dir, entity_name=str(args["entity"]))
+        replay_application_blueprint_step(step.command, target_dir, args)
         return
     if step.command == "add-usecase":
         from arclith_cli.core_scaffold import add_usecase_cmd

--- a/cli/arclith_cli/recipe_cli.py
+++ b/cli/arclith_cli/recipe_cli.py
@@ -15,8 +15,8 @@ from arclith_cli.recipe import (
     replay_recipe,
     required_replay_env,
     select_recipe_steps,
-    step_summary,
 )
+from arclith_cli.recipe_reporting import step_summary
 
 console = Console()
 

--- a/cli/arclith_cli/recipe_reporting.py
+++ b/cli/arclith_cli/recipe_reporting.py
@@ -1,0 +1,24 @@
+from arclith_cli.recipe_models import RecipeStep
+
+
+def step_summary(step: RecipeStep) -> str:
+    """Return a compact, secret-free human summary for history and dry-run."""
+    args = step.args
+    if step.command in {"init", "new"}:
+        return str(args.get("project_name") or "project")
+    if step.command == "add-adapter":
+        capability = args.get("capability", "repository")
+        adapter = args.get("adapter", "?")
+        entities = args.get("entities") or []
+        suffix = f" ({', '.join(map(str, entities))})" if entities else ""
+        return f"{capability}/{adapter}{suffix}"
+    if step.command == "add-usecase":
+        usecase = str(args.get("usecase") or "usecase")
+        entity = args.get("entity") or args.get("new_entity")
+        return f"{usecase} ({entity})" if entity else f"{usecase} (transverse)"
+    if step.command == "add-blueprint":
+        return f"{args.get('blueprint', '?')} ({args.get('entity', '?')})"
+    for key in ("entity", "usecase", "intent"):
+        if key in args:
+            return str(args[key])
+    return ""

--- a/cli/tests/test_application_blueprints.py
+++ b/cli/tests/test_application_blueprints.py
@@ -1,0 +1,514 @@
+import asyncio
+import importlib
+import json
+import re
+import sys
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+import typer
+import yaml
+from typer.testing import CliRunner
+
+from arclith_cli.application_blueprints import (
+    application_blueprint_catalog_as_dict,
+    get_application_blueprint,
+)
+from arclith_cli.blueprint_generation import (
+    add_application_blueprint_cmd,
+    apply_application_blueprint,
+    plan_application_blueprint,
+)
+from arclith_cli.core_scaffold import add_entity_cmd
+from arclith_cli.feature_manifest import load_feature_manifest
+from arclith_cli.init_project import init_project_cmd
+from arclith_cli.main import app
+from arclith_cli.recipe import load_recipe, replay_recipe
+
+runner = CliRunner()
+T = TypeVar("T")
+
+
+def _project(tmp_path: Path, name: str = "blueprint-service") -> Path:
+    project = init_project_cmd(project_name=name, directory=tmp_path)
+    add_entity_cmd(project_dir=project, entity_name="Todo")
+    return project
+
+
+def _invoke(
+    monkeypatch: pytest.MonkeyPatch,
+    project: Path,
+    arguments: list[str],
+    *,
+    input_text: str | None = None,
+):
+    monkeypatch.chdir(project)
+    return runner.invoke(app, arguments, input=input_text)
+
+
+def test_crud_is_an_application_blueprint_not_an_adapter_capability() -> None:
+    crud = get_application_blueprint("crud")
+
+    assert crud.name == "crud"
+    assert crud.operations == ("create", "get", "list", "update", "delete")
+    assert application_blueprint_catalog_as_dict() == [
+        {
+            "name": "crud",
+            "version": 1,
+            "description": "Cycle de vie CRUD explicite pour une entité métier.",
+            "operations": ["create", "get", "list", "update", "delete"],
+        }
+    ]
+
+
+def test_crud_blueprint_generates_canonical_feature_layers(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+
+    result = add_application_blueprint_cmd(
+        project_dir=project,
+        blueprint_name="crud",
+        entity_name="Todo",
+        feature_name="todo",
+        dry_run=False,
+    )
+
+    package = project / "src/blueprint_service"
+    manifest_path = project / ".arclith/features/todo.yaml"
+    manifest = load_feature_manifest(manifest_path)
+    assert result.manifest_path == manifest_path
+    assert manifest.feature == "todo"
+    assert manifest.entity.name == "Todo"
+    assert manifest.entity.module == "blueprint_service.domain.models.todo"
+    assert manifest.blueprint.name == "crud"
+    assert manifest.operations == ("create", "get", "list", "update", "delete")
+
+    assert (package / "domain/errors/todo.py").is_file()
+    for operation in manifest.operations:
+        assert (package / f"domain/ports/inbound/{operation}_todo.py").is_file()
+        assert (package / f"application/use_cases/{operation}_todo.py").is_file()
+    assert (package / "infrastructure/containers/todo.py").is_file()
+    assert (project / "tests/application/test_todo_crud.py").is_file()
+    assert (project / "docs/blueprints/todo-crud.md").is_file()
+    assert not (package / "adapters/inbound/fastapi").exists()
+    assert not (package / "adapters/inbound/fastmcp").exists()
+
+
+def test_crud_blueprint_replays_without_overwriting_developer_files(
+    tmp_path: Path,
+) -> None:
+    project = _project(tmp_path)
+    first = plan_application_blueprint(
+        project,
+        blueprint_name="crud",
+        entity_name="Todo",
+        feature_name="todo",
+    )
+    apply_application_blueprint(first)
+    create_use_case = (
+        project / "src/blueprint_service/application/use_cases/create_todo.py"
+    )
+    create_use_case.write_text(
+        create_use_case.read_text(encoding="utf-8") + "\n# developer rule\n",
+        encoding="utf-8",
+    )
+
+    replay = plan_application_blueprint(
+        project,
+        blueprint_name="crud",
+        entity_name="Todo",
+        feature_name="todo",
+    )
+    changed = apply_application_blueprint(replay)
+
+    assert changed == ()
+    assert create_use_case.read_text(encoding="utf-8").endswith("# developer rule\n")
+    assert create_use_case in replay.preserved
+
+
+def test_crud_blueprint_rejects_a_changed_canonical_manifest(
+    tmp_path: Path,
+) -> None:
+    project = _project(tmp_path)
+    add_application_blueprint_cmd(
+        project_dir=project,
+        blueprint_name="crud",
+        entity_name="Todo",
+        feature_name="todo",
+        dry_run=False,
+    )
+    manifest_path = project / ".arclith/features/todo.yaml"
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    raw["operations"] = ["create", "get"]
+    manifest_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="different canonical manifest"):
+        plan_application_blueprint(
+            project,
+            blueprint_name="crud",
+            entity_name="Todo",
+            feature_name="todo",
+        )
+
+
+@pytest.mark.parametrize(
+    ("feature", "message"),
+    [
+        ("todo-item", "public Python identifier"),
+        ("class", "public Python identifier"),
+    ],
+)
+def test_feature_manifest_rejects_an_invalid_feature_identifier(
+    tmp_path: Path,
+    feature: str,
+    message: str,
+) -> None:
+    manifest_path = tmp_path / "feature.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "feature": feature,
+                "entity": {"name": "Todo", "module": "demo.domain.models.todo"},
+                "blueprint": {"name": "crud", "version": 1},
+                "operations": ["create"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_feature_manifest(manifest_path)
+
+
+def test_crud_blueprint_dry_run_has_no_filesystem_or_recipe_side_effect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _project(tmp_path)
+    before = {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    }
+
+    result = _invoke(
+        monkeypatch,
+        project,
+        ["add-blueprint", "crud", "--entity", "Todo", "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    } == before
+    assert not (project / "arclith.recipe.yaml").exists()
+    assert not (project / ".arclith/features/todo.yaml").exists()
+
+
+def test_crud_blueprint_rejects_a_first_install_collision_without_writes(
+    tmp_path: Path,
+) -> None:
+    project = _project(tmp_path)
+    conflict = project / "src/blueprint_service/application/use_cases/create_todo.py"
+    conflict.write_text("# existing\n", encoding="utf-8")
+    before = {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(ValueError, match="already exists"):
+        plan_application_blueprint(
+            project,
+            blueprint_name="crud",
+            entity_name="Todo",
+            feature_name="todo",
+        )
+
+    assert {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    } == before
+    assert not (project / ".arclith/features/todo.yaml").exists()
+
+
+def test_crud_blueprint_executes_the_framework_crud_primitives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _project(tmp_path, "runtime-blueprint-service")
+    add_application_blueprint_cmd(
+        project_dir=project,
+        blueprint_name="crud",
+        entity_name="Todo",
+        feature_name="todo",
+        dry_run=False,
+    )
+    monkeypatch.syspath_prepend(str(project / "src"))
+    container = importlib.import_module(
+        "runtime_blueprint_service.infrastructure.containers.todo"
+    )
+    contracts = {
+        operation: importlib.import_module(
+            f"runtime_blueprint_service.domain.ports.inbound.{operation}_todo"
+        )
+        for operation in ("create", "get", "list", "update", "delete")
+    }
+    from arclith import Arclith
+
+    use_cases = container.build_todo_use_cases(Arclith(project / "config"))
+    created = _run(
+        use_cases.create.execute(contracts["create"].CreateTodoCommand())
+    ).item
+    assert created.version == 1
+
+    found = _run(
+        use_cases.get.execute(contracts["get"].GetTodoQuery(uuid=created.uuid))
+    )
+    assert found.item == created
+
+    page = _run(use_cases.list.execute(contracts["list"].ListTodoQuery()))
+    assert page.items == [created]
+    assert page.total == 1
+
+    updated = _run(
+        use_cases.update.execute(
+            contracts["update"].UpdateTodoCommand(
+                uuid=created.uuid,
+                version=created.version,
+            )
+        )
+    ).item
+    assert updated.version == 2
+
+    with pytest.raises(
+        importlib.import_module(
+            "runtime_blueprint_service.domain.errors.todo"
+        ).TodoVersionConflictError
+    ):
+        _run(
+            use_cases.update.execute(
+                contracts["update"].UpdateTodoCommand(
+                    uuid=created.uuid,
+                    version=created.version,
+                )
+            )
+        )
+
+    deleted = _run(
+        use_cases.delete.execute(
+            contracts["delete"].DeleteTodoCommand(uuid=created.uuid)
+        )
+    )
+    assert deleted.deleted is True
+    with pytest.raises(
+        importlib.import_module(
+            "runtime_blueprint_service.domain.errors.todo"
+        ).TodoNotFoundError
+    ):
+        _run(use_cases.get.execute(contracts["get"].GetTodoQuery(uuid=created.uuid)))
+
+    for module in tuple(sys.modules):
+        if module == "runtime_blueprint_service" or module.startswith(
+            "runtime_blueprint_service."
+        ):
+            sys.modules.pop(module)
+
+
+def _run(awaitable: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(awaitable)
+
+
+def test_blueprints_command_and_add_blueprint_are_recipe_aware(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _project(tmp_path)
+
+    catalogue = _invoke(monkeypatch, project, ["blueprints", "--json"])
+    assert catalogue.exit_code == 0, catalogue.output
+    assert json.loads(catalogue.output)[0]["name"] == "crud"
+
+    generated = _invoke(
+        monkeypatch,
+        project,
+        ["add-blueprint", "crud", "--entity", "Todo", "--feature", "todo"],
+    )
+    assert generated.exit_code == 0, generated.output
+    recipe = load_recipe(project / "arclith.recipe.yaml")
+    assert recipe.steps[-1].command == "add-blueprint"
+    assert recipe.steps[-1].args["blueprint"] == "crud"
+    assert recipe.steps[-1].args["entity"] == "Todo"
+    assert recipe.steps[-1].args["feature"] == "todo"
+    assert recipe.steps[-1].args["operations"] == [
+        "create",
+        "get",
+        "list",
+        "update",
+        "delete",
+    ]
+
+    replay_target = tmp_path / "blueprint-replay"
+    init_project_cmd(
+        project_name="blueprint-service",
+        target_path=replay_target,
+    )
+    add_entity_cmd(project_dir=replay_target, entity_name="Todo")
+    replay_recipe(recipe, (recipe.steps[-1],), target_dir=replay_target, strict=True)
+    assert (replay_target / ".arclith/features/todo.yaml").is_file()
+
+
+def test_add_entity_crud_profile_is_replayable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = runner.invoke(
+        app,
+        ["init", "profile-service", "--dir", str(tmp_path)],
+    )
+    assert created.exit_code == 0, created.output
+    project = tmp_path / "profile-service"
+
+    result = _invoke(
+        monkeypatch,
+        project,
+        ["add-entity", "Todo", "--profile", "crud"],
+    )
+    assert result.exit_code == 0, result.output
+    recipe = load_recipe(project / "arclith.recipe.yaml")
+    assert recipe.steps[-1].command == "add-entity"
+    assert recipe.steps[-1].args["entity"] == "Todo"
+    assert recipe.steps[-1].args["profile"] == "crud"
+    assert recipe.steps[-1].args["blueprint_version"] == 1
+    assert recipe.steps[-1].args["operations"] == [
+        "create",
+        "get",
+        "list",
+        "update",
+        "delete",
+    ]
+    assert re.fullmatch(
+        r"sha256:[a-f0-9]{64}", recipe.steps[-1].args["template_digest"]
+    )
+
+    replay_target = tmp_path / "profile-replay"
+    replay_recipe(recipe, recipe.steps, target_dir=replay_target, strict=True)
+    manifest = yaml.safe_load(
+        (replay_target / ".arclith/features/todo.yaml").read_text(encoding="utf-8")
+    )
+    assert manifest["blueprint"]["name"] == "crud"
+    assert manifest["operations"] == ["create", "get", "list", "update", "delete"]
+
+
+def test_new_accepts_and_replays_the_crud_profile(tmp_path: Path) -> None:
+    created = runner.invoke(
+        app,
+        [
+            "new",
+            "Todo",
+            "new-crud-service",
+            "--dir",
+            str(tmp_path),
+            "--profile",
+            "crud",
+        ],
+    )
+    assert created.exit_code == 0, created.output
+    project = tmp_path / "new-crud-service"
+    recipe = load_recipe(project / "arclith.recipe.yaml")
+    assert recipe.steps[0].args["profile"] == "crud"
+    assert recipe.steps[0].args["blueprint_version"] == 1
+    assert re.fullmatch(r"sha256:[a-f0-9]{64}", recipe.steps[0].args["template_digest"])
+    assert (project / ".arclith/features/todo.yaml").is_file()
+
+    replay_target = tmp_path / "new-crud-replay"
+    replay_recipe(recipe, recipe.steps, target_dir=replay_target, strict=True)
+    assert (replay_target / ".arclith/features/todo.yaml").is_file()
+
+
+def test_add_entity_interactive_profile_choice_is_explicit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = init_project_cmd(project_name="interactive-service", directory=tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project,
+        ["add-entity"],
+        input_text="Todo\n2\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Profil applicatif initial" in result.output
+    assert (project / ".arclith/features/todo.yaml").is_file()
+
+
+def test_add_entity_direct_mode_keeps_the_minimal_profile_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = init_project_cmd(project_name="minimal-service", directory=tmp_path)
+
+    result = _invoke(monkeypatch, project, ["add-entity", "Todo"])
+
+    assert result.exit_code == 0, result.output
+    assert not (project / ".arclith/features/todo.yaml").exists()
+    assert load_recipe(project / "arclith.recipe.yaml").steps[-1].args == {
+        "entity": "Todo",
+        "profile": "minimal",
+    }
+
+
+def test_unknown_blueprint_and_profile_fail_without_partial_entity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = init_project_cmd(project_name="invalid-service", directory=tmp_path)
+
+    with pytest.raises(ValueError, match="Unknown application blueprint"):
+        get_application_blueprint("unknown")
+
+    result = _invoke(
+        monkeypatch,
+        project,
+        ["add-entity", "Todo", "--profile", "unknown"],
+    )
+    assert result.exit_code == 1
+    assert not (project / "src/invalid_service/domain/models/todo.py").exists()
+    assert not (project / ".arclith/features/todo.yaml").exists()
+
+    new_result = runner.invoke(
+        app,
+        [
+            "new",
+            "Todo",
+            "invalid-new-service",
+            "--dir",
+            str(tmp_path),
+            "--profile",
+            "unknown",
+        ],
+    )
+    assert new_result.exit_code == 1
+    assert not (tmp_path / "invalid-new-service").exists()
+
+
+def test_add_blueprint_requires_an_existing_entity(tmp_path: Path) -> None:
+    project = init_project_cmd(project_name="empty-service", directory=tmp_path)
+
+    with pytest.raises(typer.Exit):
+        add_application_blueprint_cmd(
+            project_dir=project,
+            blueprint_name="crud",
+            entity_name="Todo",
+            feature_name="todo",
+            dry_run=False,
+        )

--- a/cli/tests/test_application_blueprints.py
+++ b/cli/tests/test_application_blueprints.py
@@ -16,6 +16,7 @@ from arclith_cli.application_blueprints import (
     application_blueprint_catalog_as_dict,
     get_application_blueprint,
 )
+from arclith_cli.application_blueprint_recipe import replay_add_entity_step
 from arclith_cli.blueprint_generation import (
     add_application_blueprint_cmd,
     apply_application_blueprint,
@@ -183,6 +184,36 @@ def test_feature_manifest_rejects_an_invalid_feature_identifier(
         load_feature_manifest(manifest_path)
 
 
+def test_feature_manifest_rejects_a_boolean_schema_version(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "feature.yaml"
+    manifest_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": True,
+                "feature": "todo",
+                "entity": {"name": "Todo", "module": "demo.domain.models.todo"},
+                "blueprint": {"name": "crud", "version": 1},
+                "operations": ["create"],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="feature.version must be an integer"):
+        load_feature_manifest(manifest_path)
+
+
+def test_feature_manifest_reports_malformed_yaml_as_a_validation_error(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "feature.yaml"
+    manifest_path.write_text("version: [unterminated\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid YAML in feature manifest"):
+        load_feature_manifest(manifest_path)
+
+
 def test_crud_blueprint_dry_run_has_no_filesystem_or_recipe_side_effect(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -237,6 +268,36 @@ def test_crud_blueprint_rejects_a_first_install_collision_without_writes(
         if path.is_file()
     } == before
     assert not (project / ".arclith/features/todo.yaml").exists()
+
+
+def test_crud_blueprint_rejects_a_manifest_directory_without_writes(
+    tmp_path: Path,
+) -> None:
+    project = _project(tmp_path)
+    manifest_path = project / ".arclith/features/todo.yaml"
+    manifest_path.mkdir(parents=True)
+    before = {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    }
+
+    with pytest.raises(ValueError, match="target is not a file"):
+        plan_application_blueprint(
+            project,
+            blueprint_name="crud",
+            entity_name="Todo",
+            feature_name="todo",
+        )
+
+    assert {
+        path.relative_to(project): path.read_bytes()
+        for path in project.rglob("*")
+        if path.is_file()
+    } == before
+    assert not (
+        project / "src/blueprint_service/application/use_cases/create_todo.py"
+    ).exists()
 
 
 def test_crud_blueprint_executes_the_framework_crud_primitives(
@@ -499,6 +560,61 @@ def test_unknown_blueprint_and_profile_fail_without_partial_entity(
     )
     assert new_result.exit_code == 1
     assert not (tmp_path / "invalid-new-service").exists()
+
+
+@pytest.mark.parametrize("profile", ["minimal", "crud"])
+def test_add_entity_rejects_python_keyword_names_before_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+) -> None:
+    project = init_project_cmd(project_name="keyword-service", directory=tmp_path)
+
+    result = _invoke(
+        monkeypatch,
+        project,
+        ["add-entity", "Class", "--profile", profile],
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "mot-clé Python réservé" in result.output
+        or "reserved Python keyword" in result.output
+    )
+    assert not (project / "src/keyword_service/domain/models/class.py").exists()
+    assert not (project / ".arclith/features/class.yaml").exists()
+
+
+def test_crud_profile_recipe_preflights_collisions_before_entity_creation(
+    tmp_path: Path,
+) -> None:
+    project = init_project_cmd(project_name="recipe-service", directory=tmp_path)
+    collision = project / "src/recipe_service/application/use_cases/create_todo.py"
+    collision.parent.mkdir(parents=True, exist_ok=True)
+    collision.write_text("# developer-owned\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="already exists"):
+        replay_add_entity_step(
+            project,
+            {"entity": "Todo", "profile": "crud"},
+        )
+
+    assert not (project / "src/recipe_service/domain/models/todo.py").exists()
+    assert collision.read_text(encoding="utf-8") == "# developer-owned\n"
+
+
+def test_crud_profile_recipe_validates_profile_before_entity_creation(
+    tmp_path: Path,
+) -> None:
+    project = init_project_cmd(project_name="recipe-service", directory=tmp_path)
+
+    with pytest.raises(ValueError, match="Unknown application blueprint"):
+        replay_add_entity_step(
+            project,
+            {"entity": "Todo", "profile": "unknown"},
+        )
+
+    assert not (project / "src/recipe_service/domain/models/todo.py").exists()
 
 
 def test_add_blueprint_requires_an_existing_entity(tmp_path: Path) -> None:

--- a/cli/tests/test_recipe.py
+++ b/cli/tests/test_recipe.py
@@ -96,6 +96,7 @@ def test_new_creates_recipe(
         "directory": ".",
         "port": 8000,
         "repo_ref": "main",
+        "profile": "minimal",
     }
 
 
@@ -342,7 +343,7 @@ def test_non_strict_dry_run_marks_unsupported_steps_as_ignored(
     unknown.update(
         {
             "id": "0002",
-            "command": "add-blueprint",
+            "command": "add-policy",
             "args": {"token": REDACTED},
             "secrets": [
                 {
@@ -370,7 +371,7 @@ def test_non_strict_dry_run_marks_unsupported_steps_as_ignored(
     )
 
     assert result.exit_code == 0, result.output
-    assert "add-blueprint" in result.output
+    assert "add-policy" in result.output
     assert "ignorer (non supportée)" in result.output
     assert "1 étape(s) à exécuter, 1 ignorée(s)" in result.output
     assert "IGNORED_BLUEPRINT_TOKEN" not in result.output
@@ -384,7 +385,7 @@ def test_strict_dry_run_rejects_unknown_command_without_writing(
     recipe_path = project_dir / RECIPE_FILENAME
     raw = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
     unknown = dict(raw["steps"][0])
-    unknown.update({"id": "0002", "command": "add-blueprint"})
+    unknown.update({"id": "0002", "command": "add-policy"})
     raw["steps"].append(unknown)
     recipe_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
     target = tmp_path / "strict-target"

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -1,0 +1,103 @@
+# Blueprints Applicatifs
+
+Un blueprint applicatif accélère un cas d'usage récurrent sans le confondre avec
+une technologie. Il génère une structure initiale cohérente dans le domaine,
+l'application, la composition et les tests. Le projet reste propriétaire de ces
+fichiers et doit y ajouter ses règles métier.
+
+Le CRUD est le premier blueprint fourni par Arclith. Ce n'est ni le modèle
+universel d'une entité, ni une capability, ni un adapter. D'autres familles
+pourront être ajoutées indépendamment, par exemple un workflow, une recherche,
+un import, un traitement événementiel, une conversation ou un pipeline RAG.
+
+## Trois Niveaux Distincts
+
+| Niveau | Question | Exemples | Commande |
+|---|---|---|---|
+| Blueprint applicatif | Quel comportement récurrent initialiser ? | CRUD | `add-blueprint` |
+| Capability | De quelle capacité technique le service a-t-il besoin ? | API, MCP, repository, agent | `capabilities` |
+| Adapter | Avec quelle technologie implémenter la capability ? | FastAPI, FastMCP, MongoDB, PostgreSQL | `add-adapter` |
+
+Une feature peut donc appliquer un blueprint CRUD tout en restant sans transport
+et en utilisant le repository mémoire par défaut. FastAPI, FastMCP et un store
+persistant sont des décisions explicites ultérieures.
+
+## Découvrir Le Catalogue
+
+```bash
+arclith-cli blueprints
+arclith-cli blueprints --json
+```
+
+La sortie JSON est stable et exploitable par un agent ou une CI. Chaque entrée
+publie son nom, sa version et les opérations qu'elle initialise.
+
+## Appliquer Un Blueprint
+
+Lors de la création interactive d'une entité, la CLI propose un profil initial :
+
+```text
+Profil applicatif initial
+  1. minimal
+  2. crud
+```
+
+Le profil `minimal`, sélectionné par défaut, conserve le comportement historique :
+seul le modèle est créé. Pour un script, un agent ou une CI, rendre la décision
+explicite :
+
+```bash
+arclith-cli add-entity Todo --profile minimal
+arclith-cli add-entity Todo --profile crud
+arclith-cli new Todo todo-service --profile crud
+```
+
+Un blueprint peut aussi être appliqué après la création de l'entité :
+
+```bash
+arclith-cli add-blueprint crud --entity Todo
+arclith-cli add-blueprint crud --entity Todo --feature todo --dry-run
+```
+
+`--feature` accepte un nom Python public en `snake_case`. Par défaut, il reprend
+le nom normalisé de l'entité.
+
+## Manifeste Et Propriété Des Fichiers
+
+La première application écrit un manifeste canonique versionné :
+
+```yaml
+version: 1
+feature: todo
+entity:
+  name: Todo
+  module: todo_service.domain.models.todo
+blueprint:
+  name: crud
+  version: 1
+operations:
+  - create
+  - get
+  - list
+  - update
+  - delete
+```
+
+Il est enregistré dans `.arclith/features/<feature>.yaml`. Ce manifeste permet
+à une future projection de transport de savoir quelles opérations existent,
+sans déduire un comportement depuis le nom d'un fichier ou d'un adapter.
+
+Les règles de génération sont strictes :
+
+- avant la première installation, une collision avec un fichier applicatif
+  existant arrête toute la génération ;
+- après installation, un replay complète uniquement les fichiers manquants et
+  préserve tous les fichiers existants ;
+- un manifeste modifié ou incompatible doit être résolu explicitement ;
+- `--dry-run` n'écrit ni fichier, ni manifeste, ni étape de recette ;
+- aucune route, aucun tool MCP et aucun adapter de persistence ne sont créés
+  implicitement.
+
+Consulter le [blueprint CRUD](blueprints/crud.md) pour son contrat détaillé et
+les [blueprints des adapters](deep-dives/adapter-blueprints.md) pour la structure
+des implémentations techniques.

--- a/docs/blueprints/crud.md
+++ b/docs/blueprints/crud.md
@@ -1,0 +1,106 @@
+# Blueprint CRUD
+
+Le blueprint `crud` initialise le cycle de vie applicatif classique d'une
+entité : `create`, `get`, `list`, `update` et `delete`. Il compose les primitives
+déjà fournies par Arclith, mais laisse les champs, invariants, autorisations et
+politiques métier au projet généré.
+
+## Créer La Feature
+
+En une commande avec l'entité :
+
+```bash
+arclith-cli add-entity Todo --profile crud
+```
+
+Ou sur une entité existante :
+
+```bash
+arclith-cli add-blueprint crud --entity Todo --feature todo
+```
+
+Prévisualiser avant d'écrire :
+
+```bash
+arclith-cli add-blueprint crud --entity Todo --dry-run
+```
+
+## Fichiers Créés
+
+Pour le package `todo_service`, la feature `todo` produit :
+
+```text
+.arclith/features/todo.yaml
+src/todo_service/
+├── domain/
+│   ├── errors/todo.py
+│   └── ports/inbound/
+│       ├── create_todo.py
+│       ├── get_todo.py
+│       ├── list_todo.py
+│       ├── update_todo.py
+│       └── delete_todo.py
+├── application/use_cases/
+│   ├── create_todo.py
+│   ├── get_todo.py
+│   ├── list_todo.py
+│   ├── update_todo.py
+│   └── delete_todo.py
+└── infrastructure/containers/todo.py
+tests/application/test_todo_crud.py
+docs/blueprints/todo-crud.md
+```
+
+Le document créé dans le projet est local à la feature. Il rappelle les points
+à personnaliser avant d'exposer un contrat public.
+
+## Contrat Des Opérations
+
+| Opération | Entrée | Résultat | Comportement initial |
+|---|---|---|---|
+| `create` | `CreateTodoCommand` | `CreateTodoResult` | construit l'entité puis utilise `BaseService.create` |
+| `get` | `GetTodoQuery` | `GetTodoResult` | retourne l'entité active ou lève `TodoNotFoundError` |
+| `list` | `ListTodoQuery` | `ListTodoResult` | pagination par `offset` et `limit`, avec `total` |
+| `update` | `UpdateTodoCommand` | `UpdateTodoResult` | vérifie la version attendue puis délègue l'incrément |
+| `delete` | `DeleteTodoCommand` | `DeleteTodoResult` | applique la politique de soft delete configurée |
+
+`duplicate` et `purge` existent dans les primitives génériques d'Arclith mais
+ne font pas partie du CRUD. Ils doivent être ajoutés comme cas d'usage explicites
+si le métier en a besoin.
+
+## Personnalisation Obligatoire
+
+Les commandes de création et de mise à jour sont volontairement valides avec
+les seuls champs techniques d'`Entity`. Après avoir ajouté les champs métier au
+modèle, reporter uniquement les champs modifiables dans `CreateTodoCommand` et
+`UpdateTodoCommand`, puis placer les invariants dans le domaine.
+
+Les erreurs `TodoNotFoundError` et `TodoVersionConflictError` sont des erreurs
+applicatives. Une future projection FastAPI pourra les traduire en `404` et
+`409`; une projection MCP pourra produire son propre résultat d'erreur. Cette
+traduction n'appartient pas aux use cases.
+
+Le contrôle de version généré évite une mise à jour manifestement obsolète dans
+le processus courant. Le port `Repository[T]` générique ne garantit pas à lui
+seul un compare-and-swap atomique entre plusieurs processus. Si le métier exige
+cette garantie, définir un port outbound spécialisé et l'implémenter avec une
+transaction adaptée à MongoDB ou PostgreSQL.
+
+## Choisir Les Adapters Ensuite
+
+La feature est immédiatement testable avec le repository mémoire configuré par
+défaut. Les choix techniques restent séparés :
+
+```bash
+# Persistance durable, si nécessaire
+arclith-cli add-adapter --capability repository --adapter mongodb --yes
+
+# Transport, si nécessaire
+arclith-cli add-adapter --capability api --adapter fastapi --yes
+arclith-cli add-adapter --capability mcp --adapter fastmcp --yes
+```
+
+Cette première version ne projette pas encore automatiquement les cinq opérations
+vers un transport. Le manifeste `.arclith/features/todo.yaml` constitue le
+contrat d'entrée prévu pour cette évolution, sans coupler le blueprint à un
+adapter particulier.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -5,6 +5,11 @@ Une capability est une brique activable par `arclith-cli add-adapter`.
 Chaque installation crée son [blueprint complet](deep-dives/adapter-blueprints.md) :
 packages, fichiers de rôle et documentation développeur/IA sont présents dès le départ.
 
+Une capability et son adapter répondent à un besoin technique. Ils restent
+distincts des [blueprints applicatifs](blueprints.md), qui initialisent un
+comportement récurrent comme le CRUD sans choisir FastAPI, FastMCP, MongoDB ou
+PostgreSQL.
+
 La section Capabilities est le niveau deep dive de la documentation. Elle
 détaille les contrats, les adapters, les contraintes de production et les
 validations. Le format attendu est décrit dans
@@ -50,7 +55,7 @@ arclith-cli capabilities --json
 
 | Besoin | Lire |
 |---|---|
-| Concevoir le cœur métier | [Scaffold CLI guidé](deep-dives/cli-scaffold.md), puis [formation Todo](tutorials/todo-list/02-create-entity.md) |
+| Concevoir le cœur métier | [Scaffold CLI guidé](deep-dives/cli-scaffold.md), [blueprints applicatifs](blueprints.md), puis [formation Todo](tutorials/todo-list/02-create-entity.md) |
 | API minimale | [Quickstart API](quickstarts/api.md), [formation API](tutorials/todo-list/04-api.md), puis [api/fastapi](capabilities/api.md) |
 | MCP minimal | [Quickstart MCP](quickstarts/mcp.md), [formation MCP](tutorials/todo-list/05-mcp.md), puis [mcp/fastmcp](capabilities/mcp.md) |
 | Bus RabbitMQ | [Quickstart Bus](quickstarts/bus.md), puis [command-bus/rabbitmq](capabilities/command-bus.md) |

--- a/docs/cli-recipe.md
+++ b/docs/cli-recipe.md
@@ -29,6 +29,7 @@ La version 1 enregistre :
 
 - `init` et `new` ;
 - `add-entity` ;
+- `add-blueprint` ;
 - `add-usecase` ;
 - `add-intent-interpreter` ;
 - `add-adapter`.
@@ -73,6 +74,7 @@ steps:
     status: success
     args:
       entity: Todo
+      profile: minimal
     result:
       generated_files:
         - path: src/todo_service/domain/models/todo.py
@@ -137,10 +139,11 @@ Retirer `--dry-run` pour reconstruire le projet :
 arclith-cli replay arclith.recipe.yaml --dir ../todo-service-rebuilt
 ```
 
-Le replay appelle directement `init_project_cmd`, `add_entity_cmd`,
-`add_usecase_cmd`, `add_intent_interpreter_cmd` et `add_adapter_cmd`. Il ne
+Le replay appelle directement les opérations Python de `init`, `add-entity`,
+`add-blueprint`, `add-usecase`, `add-intent-interpreter` et `add-adapter`. Il ne
 construit pas une ligne de commande shell, ce qui évite les différences de
-quoting et garde les erreurs testables.
+quoting et garde les erreurs testables. Les anciennes étapes `add-entity` qui
+n'ont pas de `profile` restent compatibles et rejouent le profil `minimal`.
 
 Les étapes rejouées ne sont pas enregistrées une seconde fois. Pour une cible
 nouvelle, la recette sélectionnée est copiée une seule fois après le succès du

--- a/docs/deep-dives/cli-scaffold.md
+++ b/docs/deep-dives/cli-scaffold.md
@@ -11,11 +11,13 @@ inventer le métier. Les fichiers générés sont de courts repères modifiables
 - ils renvoient vers des exemples complets au lieu de les recopier dans chaque
   projet.
 
-Le cœur métier et les adapters ont des commandes distinctes. `init` ne crée aucun
-adapter. `add-adapter` crée le [blueprint complet](adapter-blueprints.md) de la seule
-capability choisie, avec ses dossiers, fichiers de rôle et exemples inertes. Les
-bindings métier viennent après le port inbound, le use case et l'installation du
-transport cible.
+Le cœur applicatif et les adapters ont des commandes distinctes. `init` ne crée
+aucun adapter. `add-entity --profile crud` ou `add-blueprint crud` applique un
+[blueprint applicatif](../blueprints.md) sans choisir de technologie.
+`add-adapter` crée ensuite le [blueprint technique](adapter-blueprints.md) de la
+seule capability choisie, avec ses dossiers, fichiers de rôle et exemples
+inertes. Les bindings métier viennent après le port inbound, le use case et
+l'installation du transport cible.
 
 ## Commandes
 
@@ -24,6 +26,18 @@ Créer une entité guidée :
 ```bash
 arclith-cli add-entity Todo
 ```
+
+En interactif, choisir le profil `minimal` par défaut ou `crud`. En mode direct :
+
+```bash
+arclith-cli add-entity Todo --profile minimal
+arclith-cli add-entity Todo --profile crud
+arclith-cli add-blueprint crud --entity Todo
+```
+
+Le profil CRUD génère les cinq ports et use cases applicatifs, leur composition,
+leurs tests et `.arclith/features/todo.yaml`. Il ne crée aucun adapter. Lire le
+[contrat du blueprint CRUD](../blueprints/crud.md).
 
 Créer un use case lié à une entité détectée :
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,7 +39,10 @@ arclith-cli expose-usecase create-todo --via fastapi --feature todos \
 
 `init` n'installe aucun transport. La commande `add-adapter` ci-dessus ajoute le
 blueprint et l'extra FastAPI à la demande ; utiliser `mcp/fastmcp` de la même
-manière uniquement si le service expose aussi MCP.
+manière uniquement si le service expose aussi MCP. Le profil CRUD initialise
+les ports et use cases applicatifs mais ne les projette pas encore
+automatiquement vers FastAPI ou FastMCP ; consulter le
+[blueprint CRUD](blueprints/crud.md) avant de définir ces contrats publics.
 
 Chaque commande mutante réussie enrichit `arclith.recipe.yaml`. Ce fichier
 versionné conserve les décisions de scaffolding sans remplacer Git et sans
@@ -56,6 +59,8 @@ uv tool install --force "git+https://github.com/karned-rekipe/arclith.git@feat/h
 
 Pour compatibilité, `new` reste disponible. Il équivaut à `init` suivi de
 `add-entity`; il ne télécharge plus un projet complet et n'ajoute aucun adapter.
+Le mode interactif demande le profil applicatif après l'entité ; le mode direct
+peut utiliser `--profile crud`, sinon il reste `minimal`.
 
 ```bash
 mkdir -p ~/Perso/projets/demo
@@ -108,13 +113,23 @@ arclith-cli add-usecase RunMaintenance --no-entity
 arclith-cli add-intent-interpreter ShoppingIntent
 ```
 
+Pour le cycle de vie CRUD classique, sans adapter automatique :
+
+```bash
+arclith-cli add-entity ShoppingItem --profile crud
+# ou, si l'entité existe déjà
+arclith-cli add-blueprint crud --entity ShoppingItem
+```
+
 `add-entity` ajoute un squelette guidé sans import inutilisé. `add-usecase`
 propose les entités détectées en interactif ; en mode direct, `--entity`,
 `--new-entity` et `--no-entity` rendent le choix explicite et sont mutuellement
 exclusifs. Les fichiers générés montrent le pattern
 `Command/Query -> UseCase -> Entity/Result`, mais les champs, invariants et
 appels aux ports restent du code métier à écrire dans le projet. Lire le
-[deep dive scaffold CLI](deep-dives/cli-scaffold.md) pour les exemples complets.
+[deep dive scaffold CLI](deep-dives/cli-scaffold.md) pour les exemples complets,
+ou la [vue d'ensemble des blueprints applicatifs](blueprints.md) pour comprendre
+la séparation entre comportement, capability et adapter.
 
 L'adapter actif est déclaré dans:
 

--- a/docs/tutorials/todo-list/02-create-entity.md
+++ b/docs/tutorials/todo-list/02-create-entity.md
@@ -15,7 +15,18 @@ Répondre au prompt:
 ```text
 Entité — utilisez le singulier (ex : Recipe, recipe_step, MealPlan)
   Nom de l'entité: Todo
+
+Profil applicatif initial
+  1. minimal
+  2. crud
+  Choix [1]: 1
 ```
+
+Ce chapitre construit chaque cas d'usage manuellement afin d'expliquer
+l'architecture ; il conserve donc le profil `minimal`. Pour initialiser le cycle
+complet en une fois, choisir `crud` ou utiliser
+`arclith-cli add-entity Todo --profile crud`. Le
+[blueprint CRUD](../../blueprints/crud.md) reste sans adapter implicite.
 
 La CLI crée:
 

--- a/docs/tutorials/todo-list/assets/02-create-entity.svg
+++ b/docs/tutorials/todo-list/assets/02-create-entity.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="300" viewBox="0 0 1120 300" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="430" viewBox="0 0 1120 430" role="img" aria-labelledby="title desc">
   <title id="title">Capture terminal - arclith-cli add-entity</title>
   <desc id="desc">Création interactive de l'entité Todo.</desc>
-  <rect width="1120" height="300" rx="8" fill="#1f2933"/>
+  <rect width="1120" height="430" rx="8" fill="#1f2933"/>
   <rect y="0" width="1120" height="36" rx="8" fill="#111827"/>
   <circle cx="22" cy="18" r="6" fill="#f87171"/>
   <circle cx="44" cy="18" r="6" fill="#fbbf24"/>
@@ -9,5 +9,9 @@
   <text x="24" y="72" fill="#d1d5db" font-family="Menlo, Consolas, monospace" font-size="18">$ arclith-cli add-entity</text>
   <text x="24" y="118" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Entite - utilisez le singulier (ex : Recipe, recipe_step, MealPlan)</text>
   <text x="24" y="154" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Nom de l'entite: Todo</text>
-  <text x="24" y="210" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Entite Todo creee : src/todo_list_service/domain/models/todo.py</text>
+  <text x="24" y="205" fill="#f9fafb" font-family="Menlo, Consolas, monospace" font-size="18">Profil applicatif initial</text>
+  <text x="48" y="241" fill="#67e8f9" font-family="Menlo, Consolas, monospace" font-size="18">1. minimal</text>
+  <text x="48" y="277" fill="#67e8f9" font-family="Menlo, Consolas, monospace" font-size="18">2. crud</text>
+  <text x="24" y="313" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">Choix [1]: 1</text>
+  <text x="24" y="377" fill="#a7f3d0" font-family="Menlo, Consolas, monospace" font-size="18">✓ Entite Todo creee : src/todo_list_service/domain/models/todo.py</text>
 </svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,9 @@ nav:
       - Le chemin hexagonal: foundations/hexagonal-flow.md
       - Modes runtime: foundations/runtime-modes.md
       - Recettes CLI: cli-recipe.md
+  - Blueprints:
+      - Vue d'ensemble: blueprints.md
+      - CRUD: blueprints/crud.md
   - Formation:
       - Parcours: learning/training-path.md
       - Quickstarts essentiels: learning/quickstarts.md


### PR DESCRIPTION
## Pourquoi

Le CRUD est un cas applicatif fréquent, mais ce n'est ni le comportement universel d'une entité, ni une capability, ni un adapter. Cette PR introduit donc la notion générique de **blueprint applicatif** et livre CRUD comme première implémentation, sans coupler le cœur métier à FastAPI, FastMCP ou à une base de données.

Cette livraison constitue la première implémentation concrète du chantier #155.

## Ce que livre cette PR

- ajoute le catalogue `arclith-cli blueprints` et sa sortie `--json` ;
- ajoute `arclith-cli add-blueprint crud --entity <Entity>` avec `--feature` et `--dry-run` ;
- propose `minimal` ou `crud` lors de la création interactive d'une entité ;
- ajoute `--profile minimal|crud` à `add-entity` et `new` pour les scripts, agents et CI ;
- génère les ports inbound et use cases `create`, `get`, `list`, `update`, `delete`, les erreurs applicatives, le container de composition, un test complet et une documentation locale ;
- écrit le manifeste strict et versionné `.arclith/features/<feature>.yaml` ;
- enregistre la version, les opérations et l'empreinte réelle des templates dans `arclith.recipe.yaml` ;
- rend `add-blueprint` et les profils rejouables, tout en conservant la compatibilité des anciennes recettes `add-entity` sans profil ;
- refuse les collisions lors d'une première installation, puis préserve le code développeur lors des replays ;
- documente explicitement la séparation blueprint applicatif / capability / adapter.

## Architecture retenue

```text
Entity
  -> Application blueprint (CRUD aujourd'hui)
     -> ports + use cases + composition + tests
        -> adapter(s) choisi(s) séparément
           -> FastAPI, FastMCP, RabbitMQ, MongoDB, PostgreSQL, ...
```

Le blueprint compose les primitives CRUD existantes d'Arclith via `BaseService[T]`. Il ne génère aucune route, aucun tool MCP et aucun adapter de persistence. Les erreurs `NotFound` et `VersionConflict` restent applicatives afin que chaque transport choisisse sa représentation publique.

`duplicate` et `purge` ne sont pas inclus : ce sont des comportements explicites, pas des opérations CRUD.

## Validation

- `uv run --project cli ruff format --check cli/arclith_cli cli/tests`
- `uv run --project cli ruff check cli/arclith_cli cli/tests`
- `.venv/bin/python -m mypy cli/arclith_cli`
- `uv run --project cli pytest -q cli/tests` : **294 passed**
- `make precommit` : Ruff, mypy et Bandit réussis
- `make coverage` : **2235 passed, 5 skipped, 91.19%**
- `make docs` : build MkDocs strict réussi
- `uv build cli` : sdist et wheel réussis
- projet frais généré : Ruff réussi, compilation réussie et **3 tests projet réussis**, dont le cycle CRUD complet

## Hors périmètre de cette itération

La projection automatique du manifeste vers FastAPI, FastMCP, RabbitMQ ou un autre transport n'est pas incluse. Elle formera l'itération suivante : elle devra consommer `.arclith/features/<feature>.yaml` après installation explicite du transport et générer uniquement les bindings demandés.

Le contrôle de version généré détecte une version obsolète dans le flux applicatif, mais le port `Repository[T]` générique ne promet pas un compare-and-swap atomique multi-processus. Un besoin métier de cette nature doit rester un port spécialisé avec une implémentation transactionnelle adaptée au store.
