### PR TITLE
ci: moderniser et épingler les actions GitHub

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
+          save-cache: false
 
       - name: Install CLI dependencies
         working-directory: cli

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -22,9 +22,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -43,10 +43,10 @@ jobs:
         run: uv run --frozen --group docs mkdocs build --strict
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          enable-cache: true
+          save-cache: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -19,8 +19,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -30,8 +30,8 @@ jobs:
     name: Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -41,8 +41,8 @@ jobs:
     name: Complexity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -64,8 +64,8 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -77,7 +77,7 @@ jobs:
     if: always() && github.event_name == 'pull_request'
     needs: [lint, security, complexity, coverage, typecheck]
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const icon = r => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
+          save-cache: false
       - run: make lint
 
   security:
@@ -35,6 +36,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
+          save-cache: false
       - run: make security
 
   complexity:
@@ -46,6 +48,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
+          save-cache: false
       - run: make complexity
 
   typecheck:
@@ -58,6 +61,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
+          save-cache: false
       - run: make typecheck
 
   coverage:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
     name: Quality Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
@@ -38,11 +38,11 @@ jobs:
         run: uv build --out-dir dist/arclith .
       - name: Build arclith-cli
         run: uv build --out-dir dist/arclith-cli cli
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: arclith-dist
           path: dist/arclith/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: arclith-cli-dist
           path: dist/arclith-cli/
@@ -57,11 +57,13 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: arclith-dist
           path: dist/arclith/
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          enable-cache: false
       - name: Publish arclith
         run: uv publish --check-url https://pypi.org/simple/ dist/arclith/*
 
@@ -75,10 +77,12 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: arclith-cli-dist
           path: dist/arclith-cli/
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+        with:
+          enable-cache: false
       - name: Publish arclith-cli
         run: uv publish --check-url https://pypi.org/simple/ dist/arclith-cli/*


### PR DESCRIPTION
## Contexte

Le workflow de publication `v0.27.0` a réussi, mais GitHub a signalé deux dettes de maintenance : des actions encore exécutées sur Node.js 20 et une tentative de cache `setup-uv` dans les jobs PyPI qui ne checkoutent aucun lock.

L'audit des quatre workflows a trouvé d'autres actions first-party encore basées sur Node.js 20. Cette PR les traite ensemble afin que l'avertissement ne réapparaisse pas sur les contrôles de PR ou le déploiement Pages.

## Changements

- met à niveau toutes les actions concernées vers leur dernière release stable Node.js 24 ;
- épingle les 29 usages d'actions à des SHA vérifiés, avec la version lisible en commentaire ;
- conserve le cache uv dans les jobs de qualité et de build qui checkoutent les locks ;
- désactive explicitement le cache uv dans les deux jobs Trusted Publisher, qui ne téléchargent que les distributions ;
- conserve les permissions minimales et les environnements OIDC PyPI existants.

Versions principales :

- `actions/checkout` 7.0.1 ;
- `astral-sh/setup-uv` 10.1.0 ;
- `actions/upload-artifact` 7.0.1 ;
- `actions/download-artifact` 8.0.1 ;
- `actions/setup-python` 7.0.0 ;
- `actions/github-script` 9.0.0 ;
- actions GitHub Pages compatibles Node.js 24.

## Validation

- releases et SHA vérifiés contre les dépôts officiels ;
- runtime `node24` vérifié dans les manifests des actions ;
- syntaxe des quatre workflows chargée avec PyYAML ;
- 29/29 usages d'actions épinglés à un SHA complet ;
- `actionlint v1.7.12` réussi ;
- hook de commit et de push : Ruff, mypy, Bandit et 2 259 tests framework réussis, 5 ignorés, couverture 91,19 %.

## Portée

Aucune modification du framework, de la CLI, des versions PyPI ou des permissions de publication.
