### PR TITLE
feat(cli): ajouter un guide projet interactif persistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Guide projet persistant** — `arclith-cli` ouvre dans un vrai terminal un
+  menu contextuel pour créer un socle minimal, une API CRUD ou ciblée, un
+  serveur MCP, un agent LangGraph ou un worker RabbitMQ, puis continuer à faire
+  évoluer le projet sans relancer la CLI.
+- **Plans auditables et génération atomique** — chaque parcours affiche ses
+  commandes équivalentes avant confirmation ; les créations et rejeux complets
+  passent par un staging nettoyé en cas d'échec et refusent toute cible existante.
+- **État et diagnostic** — `status`, `status --json` et `doctor` inspectent les
+  entités, cas d'usage, features, adapters et métadonnées réellement présents.
+
+### Changed
+
+- **Compatibilité non interactive préservée** — sans TTY, dans une CI ou avec
+  `TERM=dumb`, la commande racine continue d'afficher l'aide avec succès ; les
+  commandes directes restent disponibles et le guide ne crée aucun adapter
+  implicitement.
+
 ---
 
 ## [0.27.0] — 2026-09-11

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Framework Python 3.13 pour construire des microservices hexagonaux avec domaine,
 adapters, FastAPI, FastMCP, bus, canaux conversationnels, agents, configuration, observabilité et
 runtime Docker.
 
+Pour construire un projet pas à pas dans une session guidée, lancez
+`uvx --from arclith-cli arclith-cli` sans argument. Les commandes directes
+restent disponibles pour les scripts et la CI.
+
 ```bash
 uvx --from arclith-cli arclith-cli init my-service --dir .
 cd my-service

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,9 +11,42 @@ implicite.
 uv tool install "git+https://github.com/karned-rekipe/arclith.git#subdirectory=cli"
 ```
 
-## Commandes
+## Guide interactif
 
-Exécuter `arclith-cli` sans argument affiche cette liste de commandes et termine sans erreur.
+Exécuter `arclith-cli` sans argument dans un vrai terminal ouvre une session
+persistante. Le guide propose un résultat (socle minimal, API CRUD, API sur
+mesure, serveur MCP, agent LangGraph ou worker RabbitMQ), collecte uniquement
+les décisions nécessaires, affiche le plan et les commandes équivalentes, puis
+demande confirmation avant d'écrire :
+
+```bash
+arclith-cli
+# ou explicitement
+arclith-cli guide
+```
+
+Après la création, le menu reste ouvert sur le projet afin d'ajouter une entité,
+un cas d'usage, un adapter ou une exposition sans relancer la CLI. Une création
+ou un replay complet utilise un staging atomique : la cible finale n'apparaît
+qu'après la réussite de toutes les étapes et une cible existante n'est jamais
+écrasée.
+
+Dans un pipe, un script, une CI ou avec `TERM=dumb`, l'appel sans argument reste
+non interactif : il affiche l'aide et termine avec succès. Toutes les commandes
+directes restent stables et sont montrées dans le plan du guide.
+
+Le projet courant peut aussi être inspecté sans ouvrir le menu :
+
+```bash
+arclith-cli status
+arclith-cli status --json
+arclith-cli doctor
+```
+
+La documentation complète est disponible dans le
+[guide interactif](https://karned-rekipe.github.io/arclith/cli-guide/).
+
+## Commandes
 
 ### `init` — Initialiser un projet minimal
 

--- a/cli/arclith_cli/guide.py
+++ b/cli/arclith_cli/guide.py
@@ -4,8 +4,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TextIO
 
-from click.exceptions import Exit
 from rich.console import Console
+import typer
 
 from arclith_cli.capabilities import CAPABILITY_CATALOG, get_capability
 from arclith_cli.capability_models import AdapterSpec, ParameterSpec
@@ -84,14 +84,14 @@ def run_interactive_guide(
         except GuideCancelled:
             renderer.warning("Guide fermé. Aucun choix en attente n'a été appliqué.")
             return
-        except (GuidePlanError, OSError, SyntaxError, ValueError, Exit) as exc:
+        except (GuidePlanError, OSError, SyntaxError, ValueError, typer.Exit) as exc:
             message = _guide_error_message(exc)
             if message is not None:
                 renderer.error(message)
 
 
 def _guide_error_message(exc: Exception) -> str | None:
-    if isinstance(exc, Exit):
+    if isinstance(exc, typer.Exit):
         if exc.exit_code == 0:
             return None
         return "L'étape Arclith a été refusée ; le guide reste ouvert."

--- a/cli/arclith_cli/guide.py
+++ b/cli/arclith_cli/guide.py
@@ -1,0 +1,572 @@
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TextIO
+
+from click.exceptions import Exit
+from rich.console import Console
+
+from arclith_cli.capabilities import CAPABILITY_CATALOG, get_capability
+from arclith_cli.capability_models import AdapterSpec, ParameterSpec
+from arclith_cli.guide_creation import ask_new_project_plan
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import (
+    GuideCancelled,
+    GuideChoice,
+    GuidePlanError,
+    GuideStep,
+    ProjectOverview,
+    ProjectPlan,
+)
+from arclith_cli.guide_planner import (
+    plan_add_adapter,
+    plan_add_entity,
+    plan_add_usecase,
+    plan_existing_steps,
+    plan_expose_feature,
+    plan_expose_usecase,
+)
+from arclith_cli.guide_prompts import GuidePrompt, QuestionaryGuidePrompt
+from arclith_cli.guide_rendering import GuideRenderer
+from arclith_cli.guide_replay import replay_recipe_from_prompt, show_history
+from arclith_cli.guide_status import find_project_root, inspect_project
+from arclith_cli.recipe import RECIPE_FILENAME
+
+_TRANSPORT_ADAPTERS = {
+    "api/fastapi": "fastapi",
+    "mcp/fastmcp": "fastmcp",
+    "agent/langgraph": "langgraph",
+    "command-bus/rabbitmq": "rabbitmq",
+}
+
+
+def should_launch_guide(
+    stdin: TextIO = sys.stdin,
+    stdout: TextIO = sys.stdout,
+    environ: Mapping[str, str] = os.environ,
+) -> bool:
+    """Keep scripts stable while making the no-argument TTY experience guided."""
+    return (
+        stdin.isatty() and stdout.isatty() and environ.get("TERM", "").lower() != "dumb"
+    )
+
+
+def run_interactive_guide(
+    *,
+    start_dir: Path | None = None,
+    prompt: GuidePrompt | None = None,
+    console: Console | None = None,
+) -> None:
+    """Run the persistent project guide until the user explicitly leaves it."""
+    resolved_console = console or Console()
+    renderer = GuideRenderer(resolved_console)
+    resolved_prompt = prompt or QuestionaryGuidePrompt()
+    current_dir = (start_dir or Path.cwd()).resolve()
+    project_dir = find_project_root(current_dir)
+    renderer.welcome()
+    while True:
+        try:
+            if project_dir is None:
+                project_dir, keep_running = _outside_project_menu(
+                    resolved_prompt,
+                    renderer,
+                    current_dir,
+                )
+            else:
+                project_dir, keep_running = _project_menu(
+                    resolved_prompt,
+                    renderer,
+                    project_dir,
+                )
+            if not keep_running:
+                return
+        except GuideCancelled:
+            renderer.warning("Guide fermé. Aucun choix en attente n'a été appliqué.")
+            return
+        except (GuidePlanError, OSError, SyntaxError, ValueError, Exit) as exc:
+            message = _guide_error_message(exc)
+            if message is not None:
+                renderer.error(message)
+
+
+def _guide_error_message(exc: Exception) -> str | None:
+    if isinstance(exc, Exit):
+        if exc.exit_code == 0:
+            return None
+        return "L'étape Arclith a été refusée ; le guide reste ouvert."
+    return str(exc)
+
+
+def _outside_project_menu(
+    prompt: GuidePrompt,
+    renderer: GuideRenderer,
+    current_dir: Path,
+) -> tuple[Path | None, bool]:
+    action = prompt.select(
+        "Que voulez-vous faire ?",
+        (
+            _choice(
+                "Créer un projet complet",
+                "create",
+                "Choisir un résultat, vérifier le plan, puis générer.",
+            ),
+            _choice(
+                "Rejouer une recette",
+                "replay",
+                f"Reconstruire un projet depuis {RECIPE_FILENAME}.",
+            ),
+            _choice(
+                "Explorer les capacités",
+                "capabilities",
+                "Voir les technologies disponibles sans rien installer.",
+            ),
+            _choice(
+                "Voir les commandes avancées",
+                "advanced",
+                "Continuer à utiliser chaque commande directement.",
+            ),
+            _choice("Quitter", "quit", "Rendre la main au terminal."),
+        ),
+    )
+    if action == "quit":
+        return None, False
+    if action == "capabilities":
+        renderer.capabilities()
+        return None, True
+    if action == "advanced":
+        renderer.advanced_commands()
+        return None, True
+    if action == "replay":
+        return replay_recipe_from_prompt(prompt, renderer, current_dir), True
+    plan = ask_new_project_plan(prompt, current_dir)
+    renderer.plan(plan)
+    if not prompt.confirm("Appliquer ce plan ?", default=True):
+        renderer.warning("Plan annulé ; aucun fichier n'a été créé.")
+        return None, True
+    result = execute_project_plan(plan, on_step=renderer.progress)
+    renderer.success(f"Projet complet créé dans {result.root}")
+    renderer.warning(f"Pour votre shell : cd {result.root}")
+    return result.root, True
+
+
+def _project_menu(
+    prompt: GuidePrompt,
+    renderer: GuideRenderer,
+    project_dir: Path,
+) -> tuple[Path | None, bool]:
+    overview = inspect_project(project_dir)
+    renderer.overview(overview)
+    action = prompt.select(
+        "Prochaine étape",
+        (
+            _choice("Ajouter une entité", "entity", "Profil minimal ou CRUD."),
+            _choice(
+                "Ajouter un cas d'usage",
+                "usecase",
+                "Port inbound et implémentation applicative.",
+            ),
+            _choice(
+                "Ajouter un adapter",
+                "adapter",
+                "Catalogue complet, profils et paramètres.",
+            ),
+            _choice(
+                "Exposer un cas d'usage",
+                "expose-usecase",
+                "FastAPI, FastMCP, LangGraph ou RabbitMQ.",
+                disabled=(
+                    None if overview.usecases else "ajoutez d'abord un cas d'usage"
+                ),
+            ),
+            _choice(
+                "Exposer une feature CRUD",
+                "expose-feature",
+                "Projeter toutes les opérations vers FastAPI.",
+                disabled=(
+                    None
+                    if overview.features and overview.has_adapter("api", "fastapi")
+                    else "feature CRUD et adapter FastAPI requis"
+                ),
+            ),
+            _choice("Vérifier le projet", "doctor", "Relire l'état et les manifestes."),
+            _choice(
+                "Voir l'historique", "history", "Afficher la recette reproductible."
+            ),
+            _choice(
+                "Menu projets",
+                "back",
+                "Créer ailleurs, rejouer une recette ou explorer le catalogue.",
+            ),
+            _choice("Quitter", "quit", "Rendre la main au terminal."),
+        ),
+    )
+    if action == "quit":
+        return project_dir, False
+    if action == "back":
+        return None, True
+    if action == "doctor":
+        if overview.issues:
+            renderer.warning("Le diagnostic a trouvé les points listés ci-dessus.")
+        else:
+            renderer.success("Structure, manifestes et recette sont lisibles.")
+        return project_dir, True
+    if action == "history":
+        show_history(renderer, project_dir)
+        return project_dir, True
+
+    plan = _ask_existing_plan(prompt, overview, action)
+    renderer.plan(plan)
+    if not prompt.confirm("Appliquer cette étape ?", default=True):
+        renderer.warning("Étape annulée ; aucun changement demandé.")
+        return project_dir, True
+    execute_project_plan(plan, on_step=renderer.progress)
+    renderer.success("Étape appliquée et ajoutée à la recette.")
+    return project_dir, True
+
+
+def _ask_existing_plan(
+    prompt: GuidePrompt,
+    overview: ProjectOverview,
+    action: str,
+) -> ProjectPlan:
+    if action == "entity":
+        entity = _required_text(prompt, "Nom de l'entité", default="Todo")
+        profile = prompt.select(
+            "Profil applicatif initial",
+            (
+                _choice("Minimal", "minimal", "Entité seule."),
+                _choice("CRUD", "crud", "Ports et cas d'usage CRUD complets."),
+            ),
+        )
+        step = plan_add_entity(entity, profile)
+    elif action == "usecase":
+        step = _ask_usecase_step(prompt, overview.entities)
+    elif action == "adapter":
+        step = _ask_adapter_step(prompt, overview.root)
+    elif action == "expose-usecase":
+        step = _ask_binding_step(prompt, overview)
+    elif action == "expose-feature":
+        feature = prompt.select(
+            "Feature à exposer",
+            tuple(
+                _choice(item.name, item.name, f"{item.entity} — {item.blueprint}")
+                for item in overview.features
+            ),
+        )
+        path = _required_text(
+            prompt,
+            "Chemin HTTP",
+            default=f"/v1/{feature.replace('_', '-')}",
+        )
+        step = plan_expose_feature(feature, path)
+    else:
+        raise GuidePlanError(f"Action du guide non supportée : {action}")
+    return plan_existing_steps(overview.root, (step,))
+
+
+def _ask_usecase_step(
+    prompt: GuidePrompt,
+    entities: tuple[str, ...],
+) -> GuideStep:
+    usecase = _required_text(prompt, "Nom du cas d'usage", default="CreateTodo")
+    options = tuple(
+        _choice(entity, f"entity:{entity}", "Lier à cette entité existante.")
+        for entity in entities
+    ) + (
+        _choice("Créer une nouvelle entité", "new", "Créer puis lier l'entité."),
+        _choice("Cas transverse", "none", "Aucun repository métier."),
+    )
+    mode = prompt.select("Entité métier", options)
+    if mode.startswith("entity:"):
+        return plan_add_usecase(
+            usecase,
+            entity=mode.removeprefix("entity:"),
+            new_entity=None,
+            no_entity=False,
+        )
+    if mode == "new":
+        return plan_add_usecase(
+            usecase,
+            entity=None,
+            new_entity=_required_text(prompt, "Nouvelle entité", default="Todo"),
+            no_entity=False,
+        )
+    return plan_add_usecase(
+        usecase,
+        entity=None,
+        new_entity=None,
+        no_entity=True,
+    )
+
+
+def _ask_adapter_step(prompt: GuidePrompt, project_dir: Path) -> GuideStep:
+    capability_name = prompt.select(
+        "Capacité à installer",
+        tuple(
+            _choice(item.name, item.name, item.description)
+            for item in CAPABILITY_CATALOG
+        ),
+    )
+    capability = get_capability(capability_name)
+    if capability is None:
+        raise GuidePlanError(f"Capacité inconnue : {capability_name}")
+    adapter_name = prompt.select(
+        "Technologie",
+        tuple(
+            _choice(adapter.name, adapter.name, adapter.description)
+            for adapter in capability.adapters
+        ),
+    )
+    adapter = capability.get_adapter(adapter_name)
+    if adapter is None:
+        raise GuidePlanError(f"Adapter inconnu : {adapter_name}")
+    profile: str | None = None
+    if adapter.profiles:
+        selected = prompt.select(
+            "Profil de configuration",
+            (_choice("Valeurs par défaut", "", "Paramètres catalogue."),)
+            + tuple(
+                _choice(item.name, item.name, "Profil prédéfini.")
+                for item in adapter.profiles
+            ),
+        )
+        profile = selected or None
+    customize = prompt.confirm("Personnaliser les paramètres ?", default=False)
+    params, secret_params = _ask_adapter_params(
+        prompt,
+        adapter,
+        project_dir,
+        profile=profile,
+        customize=customize,
+    )
+    return plan_add_adapter(
+        capability.name,
+        adapter.name,
+        params=params,
+        profile=profile,
+        secret_params=secret_params,
+    )
+
+
+def _ask_adapter_params(
+    prompt: GuidePrompt,
+    adapter: AdapterSpec,
+    project_dir: Path,
+    *,
+    profile: str | None,
+    customize: bool,
+) -> tuple[dict[str, str], frozenset[str]]:
+    profile_values: Mapping[str, str | bool] = {}
+    if profile is not None:
+        selected_profile = adapter.get_profile(profile)
+        if selected_profile is not None:
+            profile_values = selected_profile.values()
+    params: dict[str, str] = {}
+    secret_params: set[str] = set()
+    for parameter in adapter.parameters:
+        covered = parameter.name in profile_values
+        must_ask = (
+            parameter.required
+            and not covered
+            and not _parameter_default(parameter, project_dir)
+        )
+        if not customize and not must_ask:
+            continue
+        params[parameter.name] = _ask_parameter(prompt, parameter, project_dir)
+        if parameter.secret:
+            secret_params.add(parameter.name)
+    return params, frozenset(secret_params)
+
+
+def _ask_parameter(
+    prompt: GuidePrompt,
+    parameter: ParameterSpec,
+    project_dir: Path,
+) -> str:
+    default = _parameter_default(parameter, project_dir)
+    if parameter.kind == "boolean":
+        return _ask_boolean_parameter(prompt, parameter, default)
+    value = _ask_string_parameter(prompt, parameter, default)
+    if parameter.required and not value:
+        raise GuidePlanError(f"Paramètre requis manquant : {parameter.name}")
+    return value
+
+
+def _ask_boolean_parameter(
+    prompt: GuidePrompt,
+    parameter: ParameterSpec,
+    default: str,
+) -> str:
+    normalized = default.lower()
+    enabled = prompt.confirm(
+        parameter.prompt,
+        default=normalized in {"1", "true", "yes", "on"},
+    )
+    return "true" if enabled else "false"
+
+
+def _ask_string_parameter(
+    prompt: GuidePrompt,
+    parameter: ParameterSpec,
+    default: str,
+) -> str:
+    if parameter.choices and parameter.csv_choices:
+        defaults = set(default.split(","))
+        selected = prompt.checkbox(
+            parameter.prompt,
+            tuple(
+                GuideChoice(
+                    title=value,
+                    value=value,
+                    description="",
+                    checked=value in defaults,
+                )
+                for value in parameter.choices
+            ),
+        )
+        return ",".join(selected)
+    if parameter.choices:
+        return prompt.select(
+            parameter.prompt,
+            tuple(
+                GuideChoice(
+                    title=value,
+                    value=value,
+                    description="",
+                    checked=value == default,
+                )
+                for value in parameter.choices
+            ),
+        )
+    return prompt.text(
+        parameter.prompt,
+        default="" if parameter.secret else default,
+        secret=parameter.secret,
+    )
+
+
+def _ask_binding_step(
+    prompt: GuidePrompt,
+    overview: ProjectOverview,
+) -> GuideStep:
+    usecase = prompt.select(
+        "Cas d'usage à exposer",
+        tuple(
+            _choice(item, item, "Port inbound existant.") for item in overview.usecases
+        ),
+    )
+    transports = tuple(
+        _choice(adapter, via, f"Adapter installé : {adapter}")
+        for adapter, via in _TRANSPORT_ADAPTERS.items()
+        if adapter in overview.adapters
+    )
+    if not transports:
+        raise GuidePlanError(
+            "Installez d'abord FastAPI, FastMCP, LangGraph ou RabbitMQ."
+        )
+    via = prompt.select("Transport", transports)
+    default_feature = _feature_from_usecase(usecase)
+    feature = _required_text(
+        prompt, "Nom stable de la feature", default=default_feature
+    )
+    public_name = prompt.text("Nom public (vide = nom du cas d'usage)") or None
+    http_path: str | None = None
+    method: str | None = None
+    status_code = 200
+    command_type: str | None = None
+    if via == "fastapi":
+        http_path = _required_text(
+            prompt,
+            "Chemin HTTP",
+            default=f"/v1/{feature.replace('_', '-')}",
+        )
+        method = prompt.select(
+            "Méthode HTTP",
+            tuple(
+                _choice(value, value, "")
+                for value in ("POST", "GET", "PUT", "PATCH", "DELETE")
+            ),
+        )
+        status_code = _ask_status_code(
+            prompt,
+            default=201 if method == "POST" else 200,
+        )
+    elif via == "rabbitmq":
+        command_type = _required_text(
+            prompt,
+            "Type de commande versionné",
+            default=f"{feature}.{usecase}.v1",
+        )
+    return plan_expose_usecase(
+        usecase,
+        via=via,
+        feature=feature,
+        public_name=public_name,
+        http_path=http_path,
+        method=method,
+        status_code=status_code,
+        command_type=command_type,
+    )
+
+
+def _ask_port(prompt: GuidePrompt, label: str, *, default: int) -> int:
+    raw = _required_text(prompt, label, default=str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise GuidePlanError(f"{label} doit être un entier.") from exc
+    if not 1 <= value <= 65535:
+        raise GuidePlanError(f"{label} doit être compris entre 1 et 65535.")
+    return value
+
+
+def _ask_status_code(prompt: GuidePrompt, *, default: int) -> int:
+    raw = _required_text(prompt, "Statut HTTP", default=str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise GuidePlanError("Le statut HTTP doit être un entier.") from exc
+    return value
+
+
+def _required_text(prompt: GuidePrompt, message: str, *, default: str = "") -> str:
+    value = prompt.text(message, default=default)
+    if not value:
+        raise GuidePlanError(f"{message} ne peut pas être vide.")
+    return value
+
+
+def _parameter_default(parameter: ParameterSpec, project_dir: Path) -> str:
+    if parameter.default_from_project_name:
+        return project_dir.name
+    if isinstance(parameter.default, bool):
+        return "true" if parameter.default else "false"
+    return parameter.default or ""
+
+
+def _feature_from_usecase(usecase: str) -> str:
+    for prefix in ("create_", "get_", "list_", "update_", "delete_"):
+        if usecase.startswith(prefix) and len(usecase) > len(prefix):
+            return usecase.removeprefix(prefix)
+    return usecase
+
+
+def _choice(
+    title: str,
+    value: str,
+    description: str,
+    *,
+    disabled: str | None = None,
+) -> GuideChoice:
+    return GuideChoice(
+        title=title,
+        value=value,
+        description=description,
+        disabled=disabled,
+    )
+
+
+def guide_command() -> None:
+    """Lancer le guide persistant pour créer ou faire évoluer un projet."""
+    run_interactive_guide()

--- a/cli/arclith_cli/guide_creation.py
+++ b/cli/arclith_cli/guide_creation.py
@@ -1,0 +1,198 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from arclith_cli.guide_models import (
+    GuideChoice,
+    GuidePlanError,
+    NewProjectAnswers,
+    ProjectIntent,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.guide_prompts import GuidePrompt
+from arclith_cli.rename import EntityNames
+
+
+@dataclass(frozen=True)
+class _IntentAnswers:
+    entity: str | None
+    usecase: str | None = None
+    repository: RepositoryChoice | None = None
+    transport_port: int | None = None
+    public_path: str | None = None
+
+
+def ask_new_project_plan(
+    prompt: GuidePrompt,
+    current_dir: Path,
+) -> ProjectPlan:
+    """Collect the smallest answer set needed for one complete project intent."""
+    intent = ProjectIntent(
+        prompt.select(
+            "Quel résultat voulez-vous obtenir ?",
+            (
+                _choice(
+                    "Socle minimal",
+                    ProjectIntent.MINIMAL.value,
+                    "Projet hexagonal vide, avec entité optionnelle.",
+                ),
+                _choice(
+                    "API REST CRUD",
+                    ProjectIntent.API_CRUD.value,
+                    "Entité, CRUD, repository, FastAPI et routes REST.",
+                ),
+                _choice(
+                    "API REST sur mesure",
+                    ProjectIntent.API_CUSTOM.value,
+                    "Un cas d'usage explicitement exposé par FastAPI.",
+                ),
+                _choice(
+                    "Serveur MCP",
+                    ProjectIntent.MCP.value,
+                    "Un outil FastMCP relié à un cas d'usage.",
+                ),
+                _choice(
+                    "Agent LangGraph",
+                    ProjectIntent.AGENT.value,
+                    "Un graphe typé relié à un cas d'usage.",
+                ),
+                _choice(
+                    "Worker RabbitMQ",
+                    ProjectIntent.WORKER.value,
+                    "Un consumer versionné relié à un cas d'usage.",
+                ),
+            ),
+        )
+    )
+    parent_dir = Path(
+        _required_text(prompt, "Répertoire parent", default=str(current_dir))
+    ).expanduser()
+    project_name = _required_text(prompt, "Nom du projet", default="my-service")
+    answers = _ask_intent_answers(prompt, intent)
+    return plan_new_project(
+        NewProjectAnswers(
+            parent_dir=parent_dir,
+            project_name=project_name,
+            intent=intent,
+            entity=answers.entity,
+            usecase=answers.usecase,
+            repository=answers.repository,
+            transport_port=answers.transport_port,
+            public_path=answers.public_path,
+        )
+    )
+
+
+def _ask_intent_answers(
+    prompt: GuidePrompt,
+    intent: ProjectIntent,
+) -> _IntentAnswers:
+    if intent == ProjectIntent.MINIMAL:
+        entity = (
+            _required_text(prompt, "Nom de l'entité", default="Todo")
+            if prompt.confirm("Créer une première entité ?", default=True)
+            else None
+        )
+        return _partial_answers(entity=entity)
+
+    entity = _required_text(prompt, "Nom de l'entité", default="Todo")
+    repository = _ask_repository(prompt)
+    usecase = None
+    if intent != ProjectIntent.API_CRUD:
+        entity_names = EntityNames.from_input(entity)
+        usecase = _required_text(
+            prompt,
+            "Nom du cas d'usage",
+            default=f"Create{entity_names.pascal}",
+        )
+    port, public_path = _ask_transport_details(prompt, intent, entity)
+    return _partial_answers(
+        entity=entity,
+        usecase=usecase,
+        repository=repository,
+        transport_port=port,
+        public_path=public_path,
+    )
+
+
+def _ask_repository(prompt: GuidePrompt) -> RepositoryChoice:
+    return RepositoryChoice(
+        prompt.select(
+            "Quel repository installer explicitement ?",
+            (
+                _choice(
+                    "Mémoire",
+                    RepositoryChoice.MEMORY.value,
+                    "Simple pour démarrer et tester, non persistant.",
+                ),
+                _choice(
+                    "MongoDB",
+                    RepositoryChoice.MONGODB.value,
+                    "Persistance documentaire asynchrone.",
+                ),
+                _choice(
+                    "PostgreSQL JSONB",
+                    RepositoryChoice.POSTGRESQL.value,
+                    "Persistance relationnelle flexible.",
+                ),
+            ),
+        )
+    )
+
+
+def _ask_transport_details(
+    prompt: GuidePrompt,
+    intent: ProjectIntent,
+    entity: str,
+) -> tuple[int | None, str | None]:
+    if intent in {ProjectIntent.API_CRUD, ProjectIntent.API_CUSTOM}:
+        port = _ask_port(prompt, "Port HTTP", default=8000)
+        path = _required_text(
+            prompt,
+            "Chemin HTTP",
+            default=f"/v1/{EntityNames.from_input(entity).snake.replace('_', '-')}",
+        )
+        return port, path
+    if intent == ProjectIntent.MCP:
+        return _ask_port(prompt, "Port MCP", default=8001), None
+    return None, None
+
+
+def _partial_answers(
+    *,
+    entity: str | None,
+    usecase: str | None = None,
+    repository: RepositoryChoice | None = None,
+    transport_port: int | None = None,
+    public_path: str | None = None,
+) -> _IntentAnswers:
+    return _IntentAnswers(
+        entity=entity,
+        usecase=usecase,
+        repository=repository,
+        transport_port=transport_port,
+        public_path=public_path,
+    )
+
+
+def _ask_port(prompt: GuidePrompt, label: str, *, default: int) -> int:
+    raw = _required_text(prompt, label, default=str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise GuidePlanError(f"{label} doit être un entier.") from exc
+    if not 1 <= value <= 65535:
+        raise GuidePlanError(f"{label} doit être compris entre 1 et 65535.")
+    return value
+
+
+def _required_text(prompt: GuidePrompt, message: str, *, default: str = "") -> str:
+    value = prompt.text(message, default=default)
+    if not value:
+        raise GuidePlanError(f"{message} ne peut pas être vide.")
+    return value
+
+
+def _choice(title: str, value: str, description: str) -> GuideChoice:
+    return GuideChoice(title=title, value=value, description=description)

--- a/cli/arclith_cli/guide_executor.py
+++ b/cli/arclith_cli/guide_executor.py
@@ -1,0 +1,259 @@
+from collections.abc import Callable
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Mapping
+
+from arclith_cli.add_adapter import add_adapter_cmd
+from arclith_cli.adapter_blueprints import blueprint_digest, get_adapter_blueprint
+from arclith_cli.application_blueprint_recipe import (
+    replay_application_blueprint_step,
+)
+from arclith_cli.core_scaffold import add_usecase_cmd
+from arclith_cli.feature_projection import (
+    FEATURE_PROJECTION_VERSION,
+    apply_feature_projection,
+    feature_projection_digest,
+    plan_feature_projection,
+)
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    GuideStep,
+    ProjectExecutionResult,
+    ProjectPlan,
+)
+from arclith_cli.init_project import init_project_cmd
+from arclith_cli.recipe import (
+    adapter_secret_metadata,
+    record_successful_step,
+    replay_recipe,
+    snapshot_project_files,
+)
+from arclith_cli.recipe_models import Recipe, RecipeSecretRef
+from arclith_cli.usecase_binding import apply_binding, plan_binding
+
+StepProgress = Callable[[int, int, GuideStep], None]
+
+
+@dataclass(frozen=True)
+class _ExecutedStep:
+    args: Mapping[str, Any]
+    secret_fields: Mapping[str, str]
+    secret_references: tuple[RecipeSecretRef, ...]
+
+
+def execute_project_plan(
+    plan: ProjectPlan,
+    *,
+    on_step: StepProgress | None = None,
+) -> ProjectExecutionResult:
+    """Execute a confirmed guide plan and record every successful decision."""
+    if plan.creates_project:
+        return _execute_new_project_plan(plan, on_step=on_step)
+    if not plan.target_dir.is_dir():
+        raise GuidePlanError(f"Le projet n'existe pas : {plan.target_dir}")
+    return _execute_steps(plan, plan.target_dir.resolve(), on_step=on_step)
+
+
+def replay_recipe_atomically(
+    recipe: Recipe,
+    *,
+    target_dir: Path,
+) -> tuple[str, ...]:
+    """Replay a complete recipe without exposing a partially created target."""
+    target = target_dir.resolve()
+    if target.exists():
+        raise GuidePlanError(f"Le répertoire cible existe déjà : {target}")
+    if not target.parent.is_dir():
+        raise GuidePlanError(f"Le répertoire parent n'existe pas : {target.parent}")
+    prefix = f".{target.name}.arclith-replay-"
+    with TemporaryDirectory(prefix=prefix, dir=target.parent) as temporary:
+        staged_dir = Path(temporary) / target.name
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            executed = replay_recipe(
+                recipe,
+                recipe.steps,
+                target_dir=staged_dir,
+                strict=True,
+            )
+        staged_dir.replace(target)
+    return executed
+
+
+def _execute_new_project_plan(
+    plan: ProjectPlan,
+    *,
+    on_step: StepProgress | None,
+) -> ProjectExecutionResult:
+    target_dir = plan.target_dir.resolve()
+    parent_dir = target_dir.parent
+    if not parent_dir.is_dir():
+        raise GuidePlanError(f"Le répertoire parent n'existe pas : {parent_dir}")
+    if target_dir.exists():
+        raise GuidePlanError(f"Le répertoire cible existe déjà : {target_dir}")
+    if not plan.steps or plan.steps[0].command != "init":
+        raise GuidePlanError("Un nouveau projet doit commencer par l'étape init.")
+
+    prefix = f".{target_dir.name}.arclith-"
+    with TemporaryDirectory(prefix=prefix, dir=parent_dir) as temporary:
+        staged_dir = Path(temporary) / target_dir.name
+        staged_plan = ProjectPlan(
+            target_dir=staged_dir,
+            intent=plan.intent,
+            steps=plan.steps,
+            creates_project=True,
+        )
+        result = _execute_steps(staged_plan, staged_dir, on_step=on_step)
+        staged_dir.replace(target_dir)
+    return ProjectExecutionResult(
+        root=target_dir,
+        executed_commands=result.executed_commands,
+    )
+
+
+def _execute_steps(
+    plan: ProjectPlan,
+    project_dir: Path,
+    *,
+    on_step: StepProgress | None,
+) -> ProjectExecutionResult:
+    executed: list[str] = []
+    total = len(plan.steps)
+    for index, step in enumerate(plan.steps, start=1):
+        if on_step is not None:
+            on_step(index, total, step)
+        before = snapshot_project_files(project_dir)
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            metadata = _execute_step(step, project_dir)
+        record_successful_step(
+            project_dir,
+            command=step.command,
+            args=metadata.args,
+            before=before,
+            secret_fields=metadata.secret_fields,
+            secret_references=metadata.secret_references,
+        )
+        executed.append(step.command)
+    return ProjectExecutionResult(
+        root=project_dir,
+        executed_commands=tuple(executed),
+    )
+
+
+def _execute_step(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    if step.command == "init":
+        return _execute_init(step, project_dir)
+    if not project_dir.is_dir():
+        raise GuidePlanError(
+            f"Le projet n'existe pas avant l'étape {step.command} : {project_dir}"
+        )
+    executor = _PROJECT_STEP_EXECUTORS.get(step.command)
+    if executor is None:
+        raise GuidePlanError(f"Commande du guide non supportée : {step.command}")
+    return executor(step, project_dir)
+
+
+def _execute_init(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    init_project_cmd(
+        project_name=str(step.args.get("project_name") or project_dir.name),
+        directory=project_dir.parent,
+        target_path=project_dir,
+    )
+    return _metadata(step.args)
+
+
+def _execute_entity(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    replay_application_blueprint_step(step.command, project_dir, step.args)
+    return _metadata(step.args)
+
+
+def _execute_usecase(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    raw_entity = step.args.get("entity")
+    raw_new_entity = step.args.get("new_entity")
+    add_usecase_cmd(
+        project_dir=project_dir,
+        usecase_name=str(step.args["usecase"]),
+        entity_name=str(raw_entity) if raw_entity is not None else None,
+        new_entity_name=str(raw_new_entity) if raw_new_entity is not None else None,
+    )
+    return _metadata(step.args)
+
+
+def _execute_binding(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    binding = plan_binding(project_dir, **step.args)
+    apply_binding(binding)
+    return _metadata(step.args)
+
+
+def _execute_feature(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    projection = plan_feature_projection(
+        project_dir,
+        feature_name=str(step.args["feature"]),
+        via=str(step.args["via"]),
+        http_path=str(step.args["http_path"]),
+    )
+    apply_feature_projection(projection)
+    args = {
+        "feature": projection.feature.feature,
+        "via": projection.via,
+        "http_path": projection.http_path,
+        "blueprint": projection.feature.blueprint.name,
+        "blueprint_version": projection.feature.blueprint.version,
+        "operations": list(projection.feature.operations),
+        "projection_version": FEATURE_PROJECTION_VERSION,
+        "template_digest": feature_projection_digest(projection),
+    }
+    return _metadata(args)
+
+
+def _execute_adapter(step: GuideStep, project_dir: Path) -> _ExecutedStep:
+    raw_params = step.args.get("params") or {}
+    raw_entities = step.args.get("entities") or []
+    if not isinstance(raw_params, dict):
+        raise GuidePlanError("Les paramètres d'adapter doivent former un mapping.")
+    if not isinstance(raw_entities, list):
+        raise GuidePlanError("Les entités d'adapter doivent former une liste.")
+    result = add_adapter_cmd(
+        project_dir=project_dir,
+        capability_name=str(step.args["capability"]),
+        adapter=str(step.args["adapter"]),
+        entity_names=[str(item) for item in raw_entities] or None,
+        activate=bool(step.args.get("activate", True)),
+        adapter_params={str(key): str(value) for key, value in raw_params.items()},
+        profile=(
+            str(step.args["profile"]) if step.args.get("profile") is not None else None
+        ),
+        yes=True,
+    )
+    blueprint = get_adapter_blueprint(result.adapter)
+    secret_fields, secret_references = adapter_secret_metadata(result.adapter)
+    args = {
+        "capability": result.capability.name,
+        "adapter": result.adapter.name,
+        "entities": [entity.pascal for entity in result.entities],
+        "activate": result.activate,
+        "profile": result.profile,
+        "params": result.params,
+        "blueprint_version": blueprint.version,
+        "template_digest": blueprint_digest(blueprint),
+    }
+    return _ExecutedStep(
+        args=args,
+        secret_fields=secret_fields,
+        secret_references=secret_references,
+    )
+
+
+def _metadata(args: Mapping[str, Any]) -> _ExecutedStep:
+    return _ExecutedStep(args=args, secret_fields={}, secret_references=())
+
+
+_PROJECT_STEP_EXECUTORS = {
+    "add-entity": _execute_entity,
+    "add-usecase": _execute_usecase,
+    "add-adapter": _execute_adapter,
+    "expose-usecase": _execute_binding,
+    "expose-feature": _execute_feature,
+}

--- a/cli/arclith_cli/guide_models.py
+++ b/cli/arclith_cli/guide_models.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class GuidePlanError(ValueError):
+    """Raised when guided answers cannot form a safe project plan."""
+
+
+class GuideCancelled(Exception):
+    """Raised when the user leaves an interactive prompt."""
+
+
+class ProjectIntent(StrEnum):
+    MINIMAL = "minimal"
+    API_CRUD = "api-crud"
+    API_CUSTOM = "api-custom"
+    MCP = "mcp"
+    AGENT = "agent"
+    WORKER = "worker"
+
+
+class RepositoryChoice(StrEnum):
+    MEMORY = "memory"
+    MONGODB = "mongodb"
+    POSTGRESQL = "postgresql"
+
+
+@dataclass(frozen=True)
+class GuideChoice:
+    title: str
+    value: str
+    description: str
+    disabled: str | None = None
+    checked: bool = False
+
+
+@dataclass(frozen=True)
+class GuideStep:
+    title: str
+    command: str
+    args: dict[str, Any]
+    argv: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProjectPlan:
+    target_dir: Path
+    intent: ProjectIntent | None
+    steps: tuple[GuideStep, ...]
+    creates_project: bool
+
+
+@dataclass(frozen=True)
+class ProjectExecutionResult:
+    root: Path
+    executed_commands: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NewProjectAnswers:
+    parent_dir: Path
+    project_name: str
+    intent: ProjectIntent
+    entity: str | None
+    usecase: str | None
+    repository: RepositoryChoice | None
+    transport_port: int | None
+    public_path: str | None
+
+
+@dataclass(frozen=True)
+class ProjectFeature:
+    name: str
+    entity: str
+    blueprint: str
+
+
+@dataclass(frozen=True)
+class ProjectOverview:
+    root: Path
+    name: str
+    package: str
+    entities: tuple[str, ...]
+    usecases: tuple[str, ...]
+    features: tuple[ProjectFeature, ...]
+    adapters: tuple[str, ...]
+    issues: tuple[str, ...]
+
+    def has_adapter(self, capability: str, adapter: str) -> bool:
+        return f"{capability}/{adapter}" in self.adapters

--- a/cli/arclith_cli/guide_planner.py
+++ b/cli/arclith_cli/guide_planner.py
@@ -1,0 +1,458 @@
+import re
+import shlex
+from collections.abc import Mapping
+from pathlib import Path
+
+from arclith_cli.application_blueprint_cli import (
+    application_profile_recipe_metadata,
+)
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    GuideStep,
+    NewProjectAnswers,
+    ProjectIntent,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.rename import EntityNames
+
+_COMPONENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+_SUPPORTED_REPOSITORIES = frozenset(RepositoryChoice)
+
+
+def plan_new_project(answers: NewProjectAnswers) -> ProjectPlan:
+    """Build a complete, deterministic plan without touching the filesystem."""
+    _validate_answers(answers)
+    target_dir = answers.parent_dir / answers.project_name
+    steps = [_init_step(answers.project_name, answers.parent_dir)]
+    if answers.intent == ProjectIntent.MINIMAL:
+        if answers.entity is not None:
+            steps.append(_entity_step(answers.entity, profile="minimal"))
+        return ProjectPlan(
+            target_dir=target_dir,
+            intent=answers.intent,
+            steps=tuple(steps),
+            creates_project=True,
+        )
+
+    assert answers.entity is not None
+    assert answers.repository is not None
+    if answers.intent == ProjectIntent.API_CRUD:
+        assert answers.public_path is not None
+        assert answers.transport_port is not None
+        steps.extend(
+            (
+                _entity_step(answers.entity, profile="crud"),
+                _adapter_step("repository", answers.repository.value, params={}),
+                _adapter_step(
+                    "api",
+                    "fastapi",
+                    params={"port": str(answers.transport_port)},
+                ),
+                _feature_step(answers.entity, answers.public_path),
+            )
+        )
+    else:
+        assert answers.usecase is not None
+        steps.extend(
+            (
+                _entity_step(answers.entity, profile="minimal"),
+                _usecase_step(answers.usecase, answers.entity),
+                _adapter_step("repository", answers.repository.value, params={}),
+                _transport_step(answers),
+                _binding_step(answers),
+            )
+        )
+    return ProjectPlan(
+        target_dir=target_dir,
+        intent=answers.intent,
+        steps=tuple(steps),
+        creates_project=True,
+    )
+
+
+def plan_existing_steps(project_dir: Path, steps: tuple[GuideStep, ...]) -> ProjectPlan:
+    """Wrap validated mutations for an existing project."""
+    if not project_dir.is_dir():
+        raise GuidePlanError(f"Le projet n'existe pas : {project_dir}")
+    if not steps:
+        raise GuidePlanError("Le plan ne contient aucune étape.")
+    return ProjectPlan(
+        target_dir=project_dir,
+        intent=None,
+        steps=steps,
+        creates_project=False,
+    )
+
+
+def plan_add_entity(entity: str, profile: str) -> GuideStep:
+    _validate_component(entity, "entité")
+    if profile not in {"minimal", "crud"}:
+        raise GuidePlanError("Le profil doit être minimal ou crud.")
+    return _entity_step(entity, profile=profile)
+
+
+def plan_add_usecase(
+    usecase: str,
+    *,
+    entity: str | None,
+    new_entity: str | None,
+    no_entity: bool,
+) -> GuideStep:
+    _validate_component(usecase, "cas d'usage")
+    modes = sum(
+        value is not None and value is not False
+        for value in (entity, new_entity, no_entity)
+    )
+    if modes != 1:
+        raise GuidePlanError(
+            "Choisissez exactement une entité existante, une nouvelle entité ou un cas transverse."
+        )
+    if entity is not None:
+        _validate_component(entity, "entité")
+    if new_entity is not None:
+        _validate_component(new_entity, "nouvelle entité")
+    args = {
+        "usecase": usecase,
+        "entity": entity,
+        "new_entity": new_entity,
+        "no_entity": no_entity,
+    }
+    argv = ["add-usecase", usecase]
+    if entity is not None:
+        argv.extend(("--entity", entity))
+    elif new_entity is not None:
+        argv.extend(("--new-entity", new_entity))
+    else:
+        argv.append("--no-entity")
+    return _step(f"Ajouter le cas d'usage {usecase}", "add-usecase", args, argv)
+
+
+def plan_add_adapter(
+    capability: str,
+    adapter: str,
+    *,
+    params: dict[str, str],
+    profile: str | None,
+    secret_params: frozenset[str] = frozenset(),
+) -> GuideStep:
+    return _adapter_step(
+        capability,
+        adapter,
+        params=params,
+        profile=profile,
+        secret_params=secret_params,
+    )
+
+
+def plan_expose_usecase(
+    usecase: str,
+    *,
+    via: str,
+    feature: str,
+    public_name: str | None,
+    http_path: str | None,
+    method: str | None,
+    status_code: int,
+    command_type: str | None,
+) -> GuideStep:
+    _validate_component(usecase, "cas d'usage")
+    _validate_component(feature, "feature")
+    _validate_binding(via, http_path, method, status_code, command_type)
+    args = {
+        "usecase": usecase,
+        "via": via,
+        "feature": feature,
+        "public_name": public_name,
+        "http_path": http_path,
+        "method": method,
+        "status_code": status_code,
+        "command_type": command_type,
+    }
+    argv = ["expose-usecase", usecase, "--via", via, "--feature", feature]
+    if public_name is not None:
+        argv.extend(("--name", public_name))
+    if http_path is not None:
+        argv.extend(("--path", http_path))
+    if method is not None:
+        argv.extend(("--method", method))
+    if status_code != 200:
+        argv.extend(("--status-code", str(status_code)))
+    if command_type is not None:
+        argv.extend(("--command-type", command_type))
+    return _step(
+        f"Exposer {usecase} via {via}",
+        "expose-usecase",
+        args,
+        argv,
+    )
+
+
+def plan_expose_feature(feature: str, http_path: str) -> GuideStep:
+    _validate_component(feature, "feature")
+    _validate_http_path(http_path)
+    return _step(
+        f"Exposer la feature {feature} via FastAPI",
+        "expose-feature",
+        {"feature": feature, "via": "fastapi", "http_path": http_path},
+        ("expose-feature", feature, "--via", "fastapi", "--path", http_path),
+    )
+
+
+def shell_command(step: GuideStep) -> str:
+    return shlex.join(("arclith-cli", *step.argv))
+
+
+def _validate_answers(answers: NewProjectAnswers) -> None:
+    _validate_project_target(answers)
+    if answers.entity is not None:
+        _validate_component(answers.entity, "entité")
+    if answers.intent != ProjectIntent.MINIMAL:
+        _validate_complete_project_answers(answers)
+
+
+def _validate_project_target(answers: NewProjectAnswers) -> None:
+    if not answers.parent_dir.is_dir():
+        raise GuidePlanError(
+            f"Le répertoire parent n'existe pas : {answers.parent_dir}"
+        )
+    _validate_component(answers.project_name, "projet")
+    if (answers.parent_dir / answers.project_name).exists():
+        raise GuidePlanError(
+            f"Le répertoire cible existe déjà : {answers.parent_dir / answers.project_name}"
+        )
+
+
+def _validate_complete_project_answers(answers: NewProjectAnswers) -> None:
+    _validate_required_core_answers(answers)
+    if answers.intent in {ProjectIntent.API_CRUD, ProjectIntent.API_CUSTOM}:
+        _validate_http_answers(answers)
+    if answers.intent == ProjectIntent.MCP:
+        _validate_port(answers.transport_port, "MCP")
+
+
+def _validate_required_core_answers(answers: NewProjectAnswers) -> None:
+    if answers.entity is None:
+        raise GuidePlanError("Une entité est requise pour ce parcours.")
+    if answers.repository not in _SUPPORTED_REPOSITORIES:
+        raise GuidePlanError("Un repository explicite est requis pour ce parcours.")
+    if answers.intent != ProjectIntent.API_CRUD and answers.usecase is None:
+        raise GuidePlanError("Un cas d'usage est requis pour ce parcours.")
+    if answers.usecase is not None:
+        _validate_component(answers.usecase, "cas d'usage")
+
+
+def _validate_http_answers(answers: NewProjectAnswers) -> None:
+    _validate_port(answers.transport_port, "HTTP")
+    if answers.public_path is None:
+        raise GuidePlanError("Un chemin HTTP est requis pour ce parcours.")
+    _validate_http_path(answers.public_path)
+
+
+def _validate_port(value: int | None, label: str) -> None:
+    if value is None or not 1 <= value <= 65535:
+        raise GuidePlanError(f"Le port {label} doit être compris entre 1 et 65535.")
+
+
+def _validate_binding(
+    via: str,
+    http_path: str | None,
+    method: str | None,
+    status_code: int,
+    command_type: str | None,
+) -> None:
+    if via not in {"fastapi", "fastmcp", "langgraph", "rabbitmq"}:
+        raise GuidePlanError(f"Transport non supporté : {via}")
+    if via == "fastapi":
+        _validate_fastapi_binding(http_path, method)
+    if not 200 <= status_code <= 299 or status_code in {204, 205}:
+        raise GuidePlanError(
+            "Le statut doit être un code 2xx avec un corps de réponse."
+        )
+    if via == "rabbitmq" and not command_type:
+        raise GuidePlanError("Un type de commande versionné est requis pour RabbitMQ.")
+
+
+def _validate_fastapi_binding(
+    http_path: str | None,
+    method: str | None,
+) -> None:
+    if http_path is None:
+        raise GuidePlanError("Un chemin HTTP est requis pour FastAPI.")
+    _validate_http_path(http_path)
+    if method not in {"GET", "POST", "PUT", "PATCH", "DELETE"}:
+        raise GuidePlanError("Méthode HTTP invalide.")
+
+
+def _validate_component(value: str, label: str) -> None:
+    if not _COMPONENT_RE.fullmatch(value):
+        raise GuidePlanError(
+            f"Nom de {label} invalide : lettres, chiffres, _ et -, en commençant par une lettre."
+        )
+
+
+def _validate_http_path(value: str) -> None:
+    if not value.startswith("/v1/") or any(
+        character.isspace() or character in "?#\\" for character in value
+    ):
+        raise GuidePlanError(
+            "Le chemin HTTP doit être absolu, sous /v1/, sans espace, query ni fragment."
+        )
+
+
+def _init_step(project_name: str, parent_dir: Path) -> GuideStep:
+    return _step(
+        f"Initialiser {project_name}",
+        "init",
+        {"project_name": project_name, "directory": "."},
+        ("init", project_name, "--dir", str(parent_dir)),
+    )
+
+
+def _entity_step(entity: str, *, profile: str) -> GuideStep:
+    args = {
+        "entity": entity,
+        "profile": profile,
+        **application_profile_recipe_metadata(profile),
+    }
+    return _step(
+        f"Ajouter l'entité {entity} ({profile})",
+        "add-entity",
+        args,
+        ("add-entity", entity, "--profile", profile),
+    )
+
+
+def _usecase_step(usecase: str, entity: str) -> GuideStep:
+    return plan_add_usecase(
+        usecase,
+        entity=entity,
+        new_entity=None,
+        no_entity=False,
+    )
+
+
+def _adapter_step(
+    capability: str,
+    adapter: str,
+    *,
+    params: dict[str, str],
+    profile: str | None = None,
+    secret_params: frozenset[str] = frozenset(),
+) -> GuideStep:
+    args = {
+        "capability": capability,
+        "adapter": adapter,
+        "entities": [],
+        "activate": True,
+        "profile": profile,
+        "params": params,
+    }
+    argv = [
+        "add-adapter",
+        "--capability",
+        capability,
+        "--adapter",
+        adapter,
+    ]
+    if profile is not None:
+        argv.extend(("--profile", profile))
+    for name, value in sorted(params.items()):
+        displayed_value = "<redacted>" if name in secret_params else value
+        argv.extend(("--param", f"{name}={displayed_value}"))
+    argv.append("--yes")
+    return _step(
+        f"Ajouter {capability}/{adapter}",
+        "add-adapter",
+        args,
+        argv,
+    )
+
+
+def _feature_step(entity: str, http_path: str) -> GuideStep:
+    return plan_expose_feature(EntityNames.from_input(entity).snake, http_path)
+
+
+def _transport_step(answers: NewProjectAnswers) -> GuideStep:
+    if answers.intent == ProjectIntent.API_CUSTOM:
+        assert answers.transport_port is not None
+        return _adapter_step(
+            "api", "fastapi", params={"port": str(answers.transport_port)}
+        )
+    if answers.intent == ProjectIntent.MCP:
+        assert answers.transport_port is not None
+        return _adapter_step(
+            "mcp", "fastmcp", params={"port": str(answers.transport_port)}
+        )
+    if answers.intent == ProjectIntent.AGENT:
+        assert answers.entity is not None
+        return _adapter_step(
+            "agent",
+            "langgraph",
+            params={"graph_name": EntityNames.from_input(answers.entity).snake},
+        )
+    return _adapter_step("command-bus", "rabbitmq", params={})
+
+
+def _binding_step(answers: NewProjectAnswers) -> GuideStep:
+    assert answers.entity is not None
+    assert answers.usecase is not None
+    feature = EntityNames.from_input(answers.entity).snake
+    if answers.intent == ProjectIntent.API_CUSTOM:
+        assert answers.public_path is not None
+        return plan_expose_usecase(
+            answers.usecase,
+            via="fastapi",
+            feature=feature,
+            public_name=None,
+            http_path=answers.public_path,
+            method="POST",
+            status_code=201,
+            command_type=None,
+        )
+    if answers.intent == ProjectIntent.MCP:
+        return plan_expose_usecase(
+            answers.usecase,
+            via="fastmcp",
+            feature=feature,
+            public_name=None,
+            http_path=None,
+            method=None,
+            status_code=200,
+            command_type=None,
+        )
+    if answers.intent == ProjectIntent.AGENT:
+        return plan_expose_usecase(
+            answers.usecase,
+            via="langgraph",
+            feature=feature,
+            public_name=None,
+            http_path=None,
+            method=None,
+            status_code=200,
+            command_type=None,
+        )
+    return plan_expose_usecase(
+        answers.usecase,
+        via="rabbitmq",
+        feature=feature,
+        public_name=None,
+        http_path=None,
+        method=None,
+        status_code=200,
+        command_type=f"{feature}.{EntityNames.from_input(answers.usecase).snake}.v1",
+    )
+
+
+def _step(
+    title: str,
+    command: str,
+    args: Mapping[str, object],
+    argv: list[str] | tuple[str, ...],
+) -> GuideStep:
+    return GuideStep(
+        title=title,
+        command=command,
+        args=dict(args),
+        argv=tuple(argv),
+    )

--- a/cli/arclith_cli/guide_prompts.py
+++ b/cli/arclith_cli/guide_prompts.py
@@ -1,0 +1,92 @@
+from abc import ABC, abstractmethod
+
+import questionary
+from questionary import Choice
+
+from arclith_cli.guide_models import GuideCancelled, GuideChoice
+
+
+class GuidePrompt(ABC):
+    """UI boundary used by the guide controller and deterministic tests."""
+
+    @abstractmethod
+    def select(self, message: str, choices: tuple[GuideChoice, ...]) -> str:
+        """Select exactly one value."""
+
+    @abstractmethod
+    def text(self, message: str, *, default: str = "", secret: bool = False) -> str:
+        """Read one text value."""
+
+    @abstractmethod
+    def confirm(self, message: str, *, default: bool = True) -> bool:
+        """Confirm or reject one decision."""
+
+    @abstractmethod
+    def checkbox(
+        self,
+        message: str,
+        choices: tuple[GuideChoice, ...],
+    ) -> tuple[str, ...]:
+        """Select zero or more values."""
+
+
+class QuestionaryGuidePrompt(GuidePrompt):
+    """Questionary-backed arrow-key interface."""
+
+    def select(self, message: str, choices: tuple[GuideChoice, ...]) -> str:
+        default = next(
+            (choice.value for choice in choices if choice.checked),
+            None,
+        )
+        answer = questionary.select(
+            message,
+            choices=[_to_questionary_choice(choice) for choice in choices],
+            default=default,
+            use_shortcuts=True,
+            use_arrow_keys=True,
+        ).ask()
+        return _required_answer(answer)
+
+    def text(self, message: str, *, default: str = "", secret: bool = False) -> str:
+        question = (
+            questionary.password(message)
+            if secret
+            else questionary.text(message, default=default)
+        )
+        answer = question.ask()
+        return _required_answer(answer).strip()
+
+    def confirm(self, message: str, *, default: bool = True) -> bool:
+        answer = questionary.confirm(message, default=default).ask()
+        if answer is None:
+            raise GuideCancelled
+        return bool(answer)
+
+    def checkbox(
+        self,
+        message: str,
+        choices: tuple[GuideChoice, ...],
+    ) -> tuple[str, ...]:
+        answer = questionary.checkbox(
+            message,
+            choices=[_to_questionary_choice(choice) for choice in choices],
+        ).ask()
+        if answer is None:
+            raise GuideCancelled
+        return tuple(str(value) for value in answer)
+
+
+def _to_questionary_choice(choice: GuideChoice) -> Choice:
+    return Choice(
+        title=choice.title,
+        value=choice.value,
+        description=choice.description,
+        disabled=choice.disabled,
+        checked=choice.checked,
+    )
+
+
+def _required_answer(answer: object) -> str:
+    if answer is None:
+        raise GuideCancelled
+    return str(answer)

--- a/cli/arclith_cli/guide_rendering.py
+++ b/cli/arclith_cli/guide_rendering.py
@@ -1,0 +1,109 @@
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from arclith_cli.capabilities import CAPABILITY_CATALOG
+from arclith_cli.guide_models import GuideStep, ProjectOverview, ProjectPlan
+from arclith_cli.guide_planner import shell_command
+
+
+class GuideRenderer:
+    def __init__(self, console: Console) -> None:
+        self._console = console
+
+    def welcome(self) -> None:
+        self._console.print(
+            Panel.fit(
+                "Créez et faites évoluer un projet hexagonal, étape par étape.\n"
+                "[dim]Chaque écriture est précédée d'un plan explicite.[/dim]",
+                title="[bold blue]Arclith — guide projet[/bold blue]",
+                border_style="blue",
+            )
+        )
+
+    def plan(self, plan: ProjectPlan) -> None:
+        table = Table(show_header=True, header_style="bold blue", box=None)
+        table.add_column("#", justify="right")
+        table.add_column("Décision")
+        table.add_column("Commande équivalente", style="dim")
+        for index, step in enumerate(plan.steps, start=1):
+            table.add_row(str(index), step.title, shell_command(step))
+        self._console.print(
+            Panel(
+                table,
+                title=f"Plan — {plan.target_dir}",
+                border_style="cyan",
+            )
+        )
+
+    def overview(self, overview: ProjectOverview) -> None:
+        table = Table(show_header=False, box=None, padding=(0, 1))
+        table.add_column("Élément", style="bold")
+        table.add_column("État")
+        table.add_row("Projet", overview.name)
+        table.add_row("Package", overview.package)
+        table.add_row("Entités", _list_or_empty(overview.entities))
+        table.add_row("Cas d'usage", _list_or_empty(overview.usecases))
+        table.add_row(
+            "Features",
+            _list_or_empty(tuple(feature.name for feature in overview.features)),
+        )
+        table.add_row("Adapters", _list_or_empty(overview.adapters))
+        health = (
+            "[green]sain[/green]"
+            if not overview.issues
+            else f"[yellow]{len(overview.issues)} point(s) à vérifier[/yellow]"
+        )
+        table.add_row("Diagnostic", health)
+        self._console.print(
+            Panel(table, title=f"[bold]{overview.name}[/bold]", border_style="blue")
+        )
+        for issue in overview.issues:
+            self._console.print(f"  [yellow]•[/yellow] {issue}")
+
+    def capabilities(self) -> None:
+        table = Table(show_header=True, header_style="bold blue", box=None)
+        table.add_column("Capacité")
+        table.add_column("Couche")
+        table.add_column("Adapters")
+        table.add_column("Rôle")
+        for capability in CAPABILITY_CATALOG:
+            table.add_row(
+                capability.name,
+                capability.layer,
+                ", ".join(capability.adapter_names()),
+                capability.description,
+            )
+        self._console.print(Panel(table, title="Catalogue des capacités"))
+
+    def advanced_commands(self) -> None:
+        self._console.print(
+            Panel(
+                "[bold]Inspection[/bold]  capabilities, blueprints, history\n"
+                "[bold]Scaffold[/bold]    init, new, add-entity, add-usecase, "
+                "add-blueprint, add-adapter, add-intent-interpreter\n"
+                "[bold]Exposition[/bold]  expose-usecase, expose-feature\n"
+                "[bold]Configuration[/bold] export-config\n"
+                "[bold]Rejeu[/bold]       replay\n\n"
+                "[bold]Maintenance[/bold] version, update\n\n"
+                "Utilisez [cyan]arclith-cli <commande> --help[/cyan] pour les "
+                "options avancées.",
+                title="Commandes directes",
+            )
+        )
+
+    def success(self, message: str) -> None:
+        self._console.print(f"[bold green]✓ {message}[/bold green]")
+
+    def progress(self, index: int, total: int, step: GuideStep) -> None:
+        self._console.print(f"[cyan]{index}/{total}[/cyan] {step.title}…")
+
+    def warning(self, message: str) -> None:
+        self._console.print(f"[yellow]{message}[/yellow]")
+
+    def error(self, message: str) -> None:
+        self._console.print(f"[bold red]✗ {message}[/bold red]")
+
+
+def _list_or_empty(values: tuple[str, ...]) -> str:
+    return ", ".join(values) if values else "[dim]aucun[/dim]"

--- a/cli/arclith_cli/guide_replay.py
+++ b/cli/arclith_cli/guide_replay.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from arclith_cli.guide_executor import replay_recipe_atomically
+from arclith_cli.guide_models import GuidePlanError
+from arclith_cli.guide_prompts import GuidePrompt
+from arclith_cli.guide_rendering import GuideRenderer
+from arclith_cli.recipe import RECIPE_FILENAME, load_recipe
+
+
+def replay_recipe_from_prompt(
+    prompt: GuidePrompt,
+    renderer: GuideRenderer,
+    current_dir: Path,
+) -> Path | None:
+    """Collect and execute one strict, atomic full-recipe replay."""
+    recipe_path = Path(
+        _required_text(
+            prompt,
+            "Chemin de la recette",
+            default=str(current_dir / RECIPE_FILENAME),
+        )
+    ).expanduser()
+    recipe = load_recipe(recipe_path)
+    target = Path(
+        _required_text(
+            prompt,
+            "Nouveau répertoire cible",
+            default=str(current_dir / recipe.project.name),
+        )
+    ).expanduser()
+    renderer.warning(
+        f"Rejeu strict de {len(recipe.steps)} étape(s) vers {target.resolve()}"
+    )
+    if not prompt.confirm("Rejouer cette recette ?", default=True):
+        renderer.warning("Rejeu annulé ; aucun fichier n'a été créé.")
+        return None
+    executed = replay_recipe_atomically(recipe, target_dir=target)
+    renderer.success(
+        f"Recette rejouée ({len(executed)} étapes) dans {target.resolve()}"
+    )
+    return target.resolve()
+
+
+def show_history(renderer: GuideRenderer, project_dir: Path) -> None:
+    """Render the reproducible mutation timeline for the current project."""
+    recipe = load_recipe(project_dir / RECIPE_FILENAME)
+    if not recipe.steps:
+        renderer.warning("La recette ne contient encore aucune étape.")
+        return
+    renderer.warning("Recette reproductible :")
+    for step in recipe.steps:
+        renderer.warning(f"  {step.id}  {step.command}  {step.at}")
+
+
+def _required_text(prompt: GuidePrompt, message: str, *, default: str = "") -> str:
+    value = prompt.text(message, default=default)
+    if not value:
+        raise GuidePlanError(f"{message} ne peut pas être vide.")
+    return value

--- a/cli/arclith_cli/guide_status.py
+++ b/cli/arclith_cli/guide_status.py
@@ -1,0 +1,135 @@
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from arclith_cli.entity_scanner import scan_entities
+from arclith_cli.feature_manifest import load_feature_manifest
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    ProjectFeature,
+    ProjectOverview,
+)
+from arclith_cli.project_paths import detect_project_paths
+from arclith_cli.recipe import RECIPE_FILENAME, RecipeError, load_recipe
+
+
+def find_project_root(start: Path) -> Path | None:
+    """Find the nearest Arclith project without crossing the filesystem root."""
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if _is_arclith_project(candidate):
+            return candidate
+    return None
+
+
+def inspect_project(project_dir: Path) -> ProjectOverview:
+    """Describe the generated project from its current on-disk state."""
+    root = project_dir.resolve()
+    if not _is_arclith_project(root):
+        raise GuidePlanError(f"Projet Arclith introuvable : {root}")
+    paths = detect_project_paths(root)
+    issues: list[str] = []
+    name = _project_name(root, issues)
+    entities = tuple(entity.pascal for entity in scan_entities(root))
+    usecases = _scan_usecases(paths.inbound_ports)
+    features = _scan_features(root, issues)
+    adapters = _scan_adapters(root, issues)
+    recipe_path = root / RECIPE_FILENAME
+    if recipe_path.is_file():
+        try:
+            load_recipe(recipe_path)
+        except (OSError, RecipeError) as exc:
+            issues.append(f"Recette invalide : {exc}")
+    else:
+        issues.append(f"Recette absente : {RECIPE_FILENAME}")
+    return ProjectOverview(
+        root=root,
+        name=name,
+        package=paths.package_name or root.name,
+        entities=entities,
+        usecases=usecases,
+        features=features,
+        adapters=adapters,
+        issues=tuple(issues),
+    )
+
+
+def _is_arclith_project(candidate: Path) -> bool:
+    if not (candidate / "pyproject.toml").is_file():
+        return False
+    paths = detect_project_paths(candidate)
+    return (paths.package_root / "domain" / "models").is_dir()
+
+
+def _project_name(root: Path, issues: list[str]) -> str:
+    try:
+        raw = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        issues.append(f"pyproject.toml invalide : {exc}")
+        return root.name
+    project = raw.get("project")
+    if isinstance(project, dict):
+        name = project.get("name")
+        if isinstance(name, str) and name.strip():
+            return name
+    issues.append("Nom de projet absent de pyproject.toml.")
+    return root.name
+
+
+def _scan_usecases(inbound_ports: Path) -> tuple[str, ...]:
+    if not inbound_ports.is_dir():
+        return ()
+    return tuple(
+        path.stem
+        for path in sorted(inbound_ports.glob("*.py"))
+        if not path.name.startswith("_")
+    )
+
+
+def _scan_features(root: Path, issues: list[str]) -> tuple[ProjectFeature, ...]:
+    manifests_dir = root / ".arclith" / "features"
+    if not manifests_dir.is_dir():
+        return ()
+    features: list[ProjectFeature] = []
+    for path in sorted(manifests_dir.glob("*.yaml")):
+        try:
+            manifest = load_feature_manifest(path)
+        except (OSError, ValueError) as exc:
+            issues.append(f"Feature invalide ({path.name}) : {exc}")
+            continue
+        features.append(
+            ProjectFeature(
+                name=manifest.feature,
+                entity=manifest.entity.name,
+                blueprint=manifest.blueprint.name,
+            )
+        )
+    return tuple(features)
+
+
+def _scan_adapters(root: Path, issues: list[str]) -> tuple[str, ...]:
+    manifests_dir = root / ".arclith" / "blueprints"
+    if not manifests_dir.is_dir():
+        return ()
+    adapters: list[str] = []
+    for path in sorted(manifests_dir.glob("*.yaml")):
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+            capability = _manifest_string(raw, "capability")
+            adapter = _manifest_string(raw, "adapter")
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            issues.append(f"Adapter invalide ({path.name}) : {exc}")
+            continue
+        adapters.append(f"{capability}/{adapter}")
+    return tuple(adapters)
+
+
+def _manifest_string(raw: Any, key: str) -> str:
+    if not isinstance(raw, dict):
+        raise ValueError("le manifeste doit être un mapping")
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"champ {key!r} absent ou invalide")
+    return value

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -27,8 +27,10 @@ from .command_recording import record_success as _record_success
 from .core_scaffold import add_intent_interpreter_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .feature_projection_cli import expose_feature_command
+from .guide import guide_command, run_interactive_guide, should_launch_guide
 from .init_project import init_project_cmd
 from .new_project import new_project_cmd as _new_project_cmd
+from .project_status_cli import doctor_command, status_command
 from .recipe import (
     adapter_secret_metadata,
     snapshot_project_files,
@@ -52,6 +54,9 @@ app.command(name="expose-feature")(expose_feature_command)
 app.command(name="add-entity")(add_entity_command)
 app.command(name="blueprints")(blueprints_command)
 app.command(name="add-blueprint")(add_blueprint_command)
+app.command(name="guide")(guide_command)
+app.command(name="status")(status_command)
+app.command(name="doctor")(doctor_command)
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -59,9 +64,12 @@ _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 
 @app.callback()
 def main(ctx: typer.Context) -> None:
-    """Afficher l'aide quand aucune commande n'est fournie."""
+    """Lancer le guide dans un terminal, sinon afficher l'aide stable."""
     if ctx.invoked_subcommand is None:
-        typer.echo(ctx.get_help())
+        if should_launch_guide():
+            run_interactive_guide()
+        else:
+            typer.echo(ctx.get_help())
 
 
 @app.command()

--- a/cli/arclith_cli/project_status_cli.py
+++ b/cli/arclith_cli/project_status_cli.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from arclith_cli.guide_models import GuidePlanError, ProjectOverview
+from arclith_cli.guide_rendering import GuideRenderer
+from arclith_cli.guide_status import find_project_root, inspect_project
+
+console = Console()
+
+
+def status_command(
+    directory: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Racine du projet Arclith."),
+    ] = Path("."),
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Afficher un état machine-readable."),
+    ] = False,
+) -> None:
+    """Afficher l'état réel du projet courant."""
+    overview = _load_overview(directory)
+    if as_json:
+        typer.echo(
+            json.dumps(_overview_as_dict(overview), ensure_ascii=False, indent=2)
+        )
+        return
+    GuideRenderer(console).overview(overview)
+
+
+def doctor_command(
+    directory: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Racine du projet Arclith."),
+    ] = Path("."),
+) -> None:
+    """Vérifier la lisibilité de la structure, des manifestes et de la recette."""
+    overview = _load_overview(directory)
+    GuideRenderer(console).overview(overview)
+    if overview.issues:
+        raise typer.Exit(1)
+    console.print(
+        "[bold green]✓ Structure, manifestes et recette sont lisibles.[/bold green]"
+    )
+
+
+def _load_overview(directory: Path) -> ProjectOverview:
+    try:
+        root = find_project_root(directory)
+        if root is None:
+            raise GuidePlanError(f"Projet Arclith introuvable : {directory.resolve()}")
+        return inspect_project(root)
+    except (GuidePlanError, OSError, ValueError) as exc:
+        console.print(f"[bold red]✗ {exc}[/bold red]")
+        raise typer.Exit(1) from exc
+
+
+def _overview_as_dict(overview: ProjectOverview) -> dict[str, object]:
+    return {
+        "root": str(overview.root),
+        "name": overview.name,
+        "package": overview.package,
+        "entities": list(overview.entities),
+        "usecases": list(overview.usecases),
+        "features": [
+            {
+                "name": feature.name,
+                "entity": feature.entity,
+                "blueprint": feature.blueprint,
+            }
+            for feature in overview.features
+        ],
+        "adapters": list(overview.adapters),
+        "issues": list(overview.issues),
+    }

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "rich>=13.0.0",
     "httpx>=0.27.0",
     "arclith>=0.27.0",
+    "questionary>=2.1.1,<3.0.0",
 ]
 
 [tool.uv.sources]

--- a/cli/tests/test_guide.py
+++ b/cli/tests/test_guide.py
@@ -1,0 +1,101 @@
+from collections import deque
+from pathlib import Path
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from arclith_cli.guide import run_interactive_guide, should_launch_guide
+from arclith_cli.guide_models import GuideChoice
+from arclith_cli.guide_prompts import GuidePrompt
+from arclith_cli.main import app
+from arclith_cli.recipe import RECIPE_FILENAME, load_recipe
+
+runner = CliRunner()
+
+
+class _TTY:
+    def __init__(self, *, interactive: bool) -> None:
+        self._interactive = interactive
+
+    def isatty(self) -> bool:
+        return self._interactive
+
+
+class FakePrompt(GuidePrompt):
+    def __init__(
+        self,
+        *,
+        selections: tuple[str, ...],
+        texts: tuple[str, ...] = (),
+        confirmations: tuple[bool, ...] = (),
+        checked: tuple[tuple[str, ...], ...] = (),
+    ) -> None:
+        self.selections = deque(selections)
+        self.texts = deque(texts)
+        self.confirmations = deque(confirmations)
+        self.checked = deque(checked)
+
+    def select(self, message: str, choices: tuple[GuideChoice, ...]) -> str:
+        del message
+        answer = self.selections.popleft()
+        assert answer in {choice.value for choice in choices}
+        return answer
+
+    def text(self, message: str, *, default: str = "", secret: bool = False) -> str:
+        del message, default, secret
+        return self.texts.popleft()
+
+    def confirm(self, message: str, *, default: bool = True) -> bool:
+        del message, default
+        return self.confirmations.popleft()
+
+    def checkbox(
+        self,
+        message: str,
+        choices: tuple[GuideChoice, ...],
+    ) -> tuple[str, ...]:
+        del message, choices
+        return self.checked.popleft()
+
+
+def test_should_launch_guide_only_in_real_terminal() -> None:
+    tty = _TTY(interactive=True)
+    pipe = _TTY(interactive=False)
+
+    assert should_launch_guide(tty, tty, {"TERM": "xterm-256color"}) is True  # type: ignore[arg-type]
+    assert should_launch_guide(pipe, tty, {"TERM": "xterm-256color"}) is False  # type: ignore[arg-type]
+    assert should_launch_guide(tty, tty, {"TERM": "dumb"}) is False  # type: ignore[arg-type]
+
+
+def test_no_arguments_remain_script_safe_and_show_help() -> None:
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "guide" in result.output
+
+
+def test_guide_creates_minimal_project_then_stays_open_until_quit(
+    tmp_path: Path,
+) -> None:
+    prompt = FakePrompt(
+        selections=("create", "minimal", "entity", "crud", "quit"),
+        texts=(str(tmp_path), "guided-service", "Todo"),
+        confirmations=(False, True, True),
+    )
+    console = Console(record=True, width=120)
+
+    run_interactive_guide(start_dir=tmp_path, prompt=prompt, console=console)
+
+    project = tmp_path / "guided-service"
+    assert project.is_dir()
+    recipe = load_recipe(project / RECIPE_FILENAME)
+    assert [step.command for step in recipe.steps] == ["init", "add-entity"]
+    assert recipe.steps[-1].args["profile"] == "crud"
+    rendered = console.export_text()
+    assert "Projet complet créé" in rendered
+    assert "Pour votre shell : cd" in rendered
+    assert "guided-service" in rendered
+    assert not prompt.selections
+    assert not prompt.texts
+    assert not prompt.confirmations

--- a/cli/tests/test_guide_executor.py
+++ b/cli/tests/test_guide_executor.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+import pytest
+
+from arclith_cli.guide_executor import execute_project_plan, replay_recipe_atomically
+from arclith_cli.guide_models import (
+    GuideStep,
+    NewProjectAnswers,
+    ProjectIntent,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.recipe import RECIPE_FILENAME, load_recipe
+
+
+def _crud_plan(tmp_path: Path) -> ProjectPlan:
+    return plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name="catalog-service",
+            intent=ProjectIntent.API_CRUD,
+            entity="Product",
+            usecase=None,
+            repository=RepositoryChoice.MEMORY,
+            transport_port=8090,
+            public_path="/v1/products",
+        )
+    )
+
+
+def _custom_plan(tmp_path: Path, intent: ProjectIntent) -> ProjectPlan:
+    return plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name=f"{intent.value}-service",
+            intent=intent,
+            entity="Product",
+            usecase="CreateProduct",
+            repository=RepositoryChoice.MEMORY,
+            transport_port=(8001 if intent == ProjectIntent.MCP else 8000),
+            public_path=(
+                "/v1/products"
+                if intent in {ProjectIntent.API_CRUD, ProjectIntent.API_CUSTOM}
+                else None
+            ),
+        )
+    )
+
+
+def test_execute_crud_plan_creates_replayable_complete_project(tmp_path: Path) -> None:
+    plan = _crud_plan(tmp_path)
+
+    result = execute_project_plan(plan)
+
+    assert result.root == tmp_path / "catalog-service"
+    assert result.executed_commands == (
+        "init",
+        "add-entity",
+        "add-adapter",
+        "add-adapter",
+        "expose-feature",
+    )
+    recipe = load_recipe(result.root / RECIPE_FILENAME)
+    assert [step.command for step in recipe.steps] == list(result.executed_commands)
+    assert recipe.steps[2].args["blueprint_version"] == "2"
+    assert recipe.steps[-1].args["projection_version"] == 1
+    assert (result.root / ".arclith" / "features" / "product.yaml").is_file()
+    assert (
+        result.root
+        / "src"
+        / "catalog_service"
+        / "adapters"
+        / "inbound"
+        / "fastapi"
+        / "routers"
+        / "v1"
+        / "product"
+        / "routes"
+        / "create_product.py"
+    ).is_file()
+    assert not list(tmp_path.glob(".catalog-service.arclith-*"))
+
+
+def test_failed_new_project_plan_leaves_no_partial_target(
+    tmp_path: Path,
+) -> None:
+    plan = _crud_plan(tmp_path)
+    failing_step = GuideStep(
+        title="Échec contrôlé",
+        command="unsupported",
+        args={},
+        argv=("unsupported",),
+    )
+    broken = ProjectPlan(
+        target_dir=plan.target_dir,
+        intent=plan.intent,
+        steps=(*plan.steps[:1], failing_step),
+        creates_project=True,
+    )
+
+    with pytest.raises(ValueError, match="non supportée"):
+        execute_project_plan(broken)
+
+    assert not plan.target_dir.exists()
+    assert not list(tmp_path.glob(".catalog-service.arclith-*"))
+
+
+@pytest.mark.parametrize(
+    ("intent", "adapter_manifest", "binding_manifest"),
+    [
+        (ProjectIntent.API_CUSTOM, "api-fastapi.yaml", "fastapi.json"),
+        (ProjectIntent.MCP, "mcp-fastmcp.yaml", "fastmcp.json"),
+        (ProjectIntent.AGENT, "agent-langgraph.yaml", "langgraph.json"),
+        (
+            ProjectIntent.WORKER,
+            "command-bus-rabbitmq.yaml",
+            "rabbitmq.json",
+        ),
+    ],
+)
+def test_execute_each_custom_intent_builds_transport_binding(
+    tmp_path: Path,
+    intent: ProjectIntent,
+    adapter_manifest: str,
+    binding_manifest: str,
+) -> None:
+    result = execute_project_plan(_custom_plan(tmp_path, intent))
+
+    assert (result.root / ".arclith" / "blueprints" / adapter_manifest).is_file()
+    assert (result.root / ".arclith" / "bindings" / binding_manifest).is_file()
+    recipe = load_recipe(result.root / RECIPE_FILENAME)
+    assert [step.command for step in recipe.steps] == [
+        "init",
+        "add-entity",
+        "add-usecase",
+        "add-adapter",
+        "add-adapter",
+        "expose-usecase",
+    ]
+
+
+def test_recipe_replay_is_atomic_and_reconstructs_the_project(tmp_path: Path) -> None:
+    source = execute_project_plan(_crud_plan(tmp_path)).root
+    recipe = load_recipe(source / RECIPE_FILENAME)
+    target = tmp_path / "replayed-service"
+
+    executed = replay_recipe_atomically(recipe, target_dir=target)
+
+    assert executed == ("0001", "0002", "0003", "0004", "0005")
+    assert (target / ".arclith" / "features" / "product.yaml").is_file()
+    assert [step.command for step in load_recipe(target / RECIPE_FILENAME).steps] == [
+        step.command for step in recipe.steps
+    ]
+    assert not list(tmp_path.glob(".replayed-service.arclith-replay-*"))
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        RepositoryChoice.MEMORY,
+        RepositoryChoice.MONGODB,
+        RepositoryChoice.POSTGRESQL,
+    ],
+)
+def test_complete_crud_supports_each_guided_repository(
+    tmp_path: Path,
+    repository: RepositoryChoice,
+) -> None:
+    plan = plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name=f"{repository.value}-catalog",
+            intent=ProjectIntent.API_CRUD,
+            entity="Product",
+            usecase=None,
+            repository=repository,
+            transport_port=8000,
+            public_path="/v1/products",
+        )
+    )
+
+    result = execute_project_plan(plan)
+
+    manifest = (
+        result.root / ".arclith" / "blueprints" / f"repository-{repository.value}.yaml"
+    )
+    assert manifest.is_file()
+    recipe = load_recipe(result.root / RECIPE_FILENAME)
+    assert recipe.steps[2].args["adapter"] == repository.value

--- a/cli/tests/test_guide_planner.py
+++ b/cli/tests/test_guide_planner.py
@@ -1,0 +1,165 @@
+from pathlib import Path
+
+import pytest
+
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    NewProjectAnswers,
+    ProjectIntent,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import (
+    plan_add_adapter,
+    plan_add_usecase,
+    plan_new_project,
+    shell_command,
+)
+
+
+def _answers(
+    tmp_path: Path,
+    intent: ProjectIntent,
+    **overrides: object,
+) -> NewProjectAnswers:
+    values: dict[str, object] = {
+        "parent_dir": tmp_path,
+        "project_name": "catalog-service",
+        "intent": intent,
+        "entity": "Product",
+        "usecase": "CreateProduct",
+        "repository": RepositoryChoice.MEMORY,
+        "transport_port": 8000,
+        "public_path": "/v1/products",
+    }
+    values.update(overrides)
+    return NewProjectAnswers(**values)  # type: ignore[arg-type]
+
+
+def test_crud_api_plan_is_complete_and_has_no_side_effect(tmp_path: Path) -> None:
+    plan = plan_new_project(_answers(tmp_path, ProjectIntent.API_CRUD))
+
+    assert plan.target_dir == tmp_path / "catalog-service"
+    assert plan.creates_project is True
+    assert [step.command for step in plan.steps] == [
+        "init",
+        "add-entity",
+        "add-adapter",
+        "add-adapter",
+        "expose-feature",
+    ]
+    assert plan.steps[1].args["profile"] == "crud"
+    assert plan.steps[0].argv == (
+        "init",
+        "catalog-service",
+        "--dir",
+        str(tmp_path),
+    )
+    assert plan.steps[2].args["adapter"] == "memory"
+    assert plan.steps[3].args["params"] == {"port": "8000"}
+    assert plan.steps[4].args == {
+        "feature": "product",
+        "via": "fastapi",
+        "http_path": "/v1/products",
+    }
+    assert not plan.target_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("intent", "transport", "binding"),
+    [
+        (ProjectIntent.API_CUSTOM, ("api", "fastapi"), "fastapi"),
+        (ProjectIntent.MCP, ("mcp", "fastmcp"), "fastmcp"),
+        (ProjectIntent.AGENT, ("agent", "langgraph"), "langgraph"),
+        (ProjectIntent.WORKER, ("command-bus", "rabbitmq"), "rabbitmq"),
+    ],
+)
+def test_custom_intent_plans_explicit_transport_and_binding(
+    tmp_path: Path,
+    intent: ProjectIntent,
+    transport: tuple[str, str],
+    binding: str,
+) -> None:
+    plan = plan_new_project(_answers(tmp_path, intent))
+
+    assert [step.command for step in plan.steps] == [
+        "init",
+        "add-entity",
+        "add-usecase",
+        "add-adapter",
+        "add-adapter",
+        "expose-usecase",
+    ]
+    assert (
+        plan.steps[4].args["capability"],
+        plan.steps[4].args["adapter"],
+    ) == transport
+    assert plan.steps[5].args["via"] == binding
+    if intent == ProjectIntent.WORKER:
+        assert plan.steps[5].args["command_type"] == "product.create_product.v1"
+
+
+def test_minimal_plan_can_stop_after_initialization(tmp_path: Path) -> None:
+    plan = plan_new_project(
+        _answers(
+            tmp_path,
+            ProjectIntent.MINIMAL,
+            entity=None,
+            usecase=None,
+            repository=None,
+            transport_port=None,
+            public_path=None,
+        )
+    )
+
+    assert [step.command for step in plan.steps] == ["init"]
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"entity": None}, "Une entité est requise"),
+        ({"repository": None}, "repository explicite"),
+        ({"transport_port": 70_000}, "port HTTP"),
+        ({"public_path": "products"}, "sous /v1/"),
+        ({"project_name": "bad name"}, "Nom de projet invalide"),
+    ],
+)
+def test_invalid_answers_are_rejected_before_writes(
+    tmp_path: Path,
+    override: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(GuidePlanError, match=message):
+        plan_new_project(_answers(tmp_path, ProjectIntent.API_CRUD, **override))
+
+
+def test_existing_target_is_never_overwritten(tmp_path: Path) -> None:
+    (tmp_path / "catalog-service").mkdir()
+
+    with pytest.raises(GuidePlanError, match="existe déjà"):
+        plan_new_project(_answers(tmp_path, ProjectIntent.API_CRUD))
+
+
+def test_equivalent_command_is_shell_quoted() -> None:
+    step = plan_add_usecase(
+        "Search",
+        entity="Product",
+        new_entity=None,
+        no_entity=False,
+    )
+
+    assert shell_command(step) == "arclith-cli add-usecase Search --entity Product"
+
+
+def test_equivalent_adapter_command_never_exposes_secrets() -> None:
+    step = plan_add_adapter(
+        "llm",
+        "openai",
+        params={"api_key": "super-secret"},
+        profile=None,
+        secret_params=frozenset({"api_key"}),
+    )
+
+    rendered = shell_command(step)
+    assert "super-secret" not in rendered
+    assert "'api_key=<redacted>'" in rendered

--- a/cli/tests/test_guide_status.py
+++ b/cli/tests/test_guide_status.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import (
+    NewProjectAnswers,
+    ProjectIntent,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.guide_status import find_project_root, inspect_project
+
+
+def _project(tmp_path: Path) -> Path:
+    plan = plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name="catalog-service",
+            intent=ProjectIntent.API_CRUD,
+            entity="Product",
+            usecase=None,
+            repository=RepositoryChoice.MEMORY,
+            transport_port=8000,
+            public_path="/v1/products",
+        )
+    )
+    return execute_project_plan(plan).root
+
+
+def test_inspect_project_reports_current_generated_state(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+
+    overview = inspect_project(project)
+
+    assert overview.name == "catalog-service"
+    assert overview.package == "catalog_service"
+    assert overview.entities == ("Product",)
+    assert overview.usecases == (
+        "create_product",
+        "delete_product",
+        "get_product",
+        "list_product",
+        "update_product",
+    )
+    assert [(item.name, item.entity, item.blueprint) for item in overview.features] == [
+        ("product", "Product", "crud")
+    ]
+    assert overview.adapters == ("api/fastapi", "repository/memory")
+    assert overview.issues == ()
+    assert find_project_root(project / "src" / "catalog_service") == project
+
+
+def test_inspect_project_surfaces_invalid_metadata(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    (project / ".arclith" / "features" / "broken.yaml").write_text(
+        "not: a-feature\n",
+        encoding="utf-8",
+    )
+    (project / ".arclith" / "blueprints" / "broken.yaml").write_text(
+        "capability: api\n",
+        encoding="utf-8",
+    )
+
+    overview = inspect_project(project)
+
+    assert len(overview.issues) == 2
+    assert overview.issues[0].startswith("Feature invalide (broken.yaml)")
+    assert overview.issues[1].startswith("Adapter invalide (broken.yaml)")
+
+
+def test_find_project_root_returns_none_outside_project(tmp_path: Path) -> None:
+    assert find_project_root(tmp_path) is None
+
+
+def test_status_keeps_support_for_legacy_root_layout(tmp_path: Path) -> None:
+    (tmp_path / "domain" / "models").mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "legacy-service"\n',
+        encoding="utf-8",
+    )
+
+    overview = inspect_project(tmp_path)
+
+    assert overview.name == "legacy-service"
+    assert overview.package == tmp_path.name
+    assert overview.issues == ("Recette absente : arclith.recipe.yaml",)

--- a/cli/tests/test_project_status_cli.py
+++ b/cli/tests/test_project_status_cli.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import NewProjectAnswers, ProjectIntent
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.main import app
+from arclith_cli.recipe import RECIPE_FILENAME
+
+runner = CliRunner()
+
+
+def _project(tmp_path: Path) -> Path:
+    plan = plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name="status-service",
+            intent=ProjectIntent.MINIMAL,
+            entity="Todo",
+            usecase=None,
+            repository=None,
+            transport_port=None,
+            public_path=None,
+        )
+    )
+    return execute_project_plan(plan).root
+
+
+def test_status_json_is_stable_for_automation(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["status", "--dir", str(project / "src" / "status_service"), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["name"] == "status-service"
+    assert payload["entities"] == ["Todo"]
+    assert payload["issues"] == []
+
+
+def test_doctor_fails_when_recipe_is_missing(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    (project / RECIPE_FILENAME).unlink()
+
+    result = runner.invoke(app, ["doctor", "--dir", str(project)])
+
+    assert result.exit_code == 1
+    assert "Recette absente" in result.output
+
+
+def test_status_rejects_non_arclith_directory(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["status", "--dir", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Projet Arclith introuvable" in result.output

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -200,6 +200,7 @@ source = { editable = "." }
 dependencies = [
     { name = "arclith" },
     { name = "httpx" },
+    { name = "questionary" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -216,6 +217,7 @@ dev = [
 requires-dist = [
     { name = "arclith", editable = "../" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "questionary", specifier = ">=2.1.1,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.15.0" },
 ]
@@ -1670,6 +1672,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1994,6 +2008,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2598,6 +2624,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/57/ed58088fafdf4c55a0ad6bde846502567645424d7ebf325230b9237f4085/wcwidth-0.8.3.tar.gz", hash = "sha256:d128512515fbf4612e0ff21fd6380399210318b7b54a9af59dff8454cf9730eb", size = 1458450, upload-time = "2026-08-28T18:10:06.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0e/57f6bb3024a597b2e8ec4aee710ffe62ddc95af2e2bb1ee7a7abdc22c68c/wcwidth-0.8.3-py3-none-any.whl", hash = "sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4", size = 331669, upload-time = "2026-08-28T18:10:04.909Z" },
 ]
 
 [[package]]

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,0 +1,108 @@
+# Guide interactif Arclith CLI
+
+Le guide interactif transforme la CLI en session persistante : vous choisissez
+le résultat attendu, Arclith construit un plan complet, affiche les commandes
+équivalentes, puis attend une confirmation unique avant d'écrire.
+
+```bash
+arclith-cli
+```
+
+Dans un vrai terminal, cette commande ouvre le guide. Dans un pipe, un script,
+une CI ou un terminal déclaré `TERM=dumb`, elle conserve le comportement
+non-interactif historique et affiche l'aide avec un code de sortie `0`. Pour
+ouvrir explicitement le guide :
+
+```bash
+arclith-cli guide
+```
+
+## Créer par intention
+
+Le premier écran ne demande pas de connaître les commandes Arclith. Il propose
+six résultats :
+
+| Intention | Cœur généré | Décisions techniques explicites | Exposition |
+|---|---|---|---|
+| Socle minimal | projet vide, entité optionnelle | aucune | aucune |
+| API REST CRUD | entité et cinq cas d'usage CRUD | repository + FastAPI | cinq routes REST |
+| API REST sur mesure | entité et un cas d'usage | repository + FastAPI | une route typée |
+| Serveur MCP | entité et un cas d'usage | repository + FastMCP | un outil MCP |
+| Agent LangGraph | entité et un cas d'usage | repository + LangGraph | un nœud de graphe |
+| Worker RabbitMQ | entité et un cas d'usage | repository + RabbitMQ | une commande versionnée |
+
+Le repository n'est jamais déduit du transport. Pour chaque parcours complet,
+vous choisissez explicitement `memory`, `mongodb` ou `postgresql`. De même, un
+profil CRUD décrit le comportement applicatif ; il n'installe pas FastAPI tout
+seul.
+
+Avant génération, le récapitulatif présente chaque décision et sa commande
+directe équivalente. Exemple :
+
+```text
+1  Initialiser catalog-service       arclith-cli init catalog-service
+2  Ajouter l'entité Product (crud)   arclith-cli add-entity Product --profile crud
+3  Ajouter repository/memory         arclith-cli add-adapter ...
+4  Ajouter api/fastapi               arclith-cli add-adapter ...
+5  Exposer la feature product        arclith-cli expose-feature ...
+```
+
+Ces commandes restent utilisables indépendamment dans un script. Les paramètres
+secrets éventuellement saisis dans le parcours avancé sont masqués dans le plan
+et dans `arclith.recipe.yaml`.
+
+## Continuer dans le même menu
+
+Après la création, le guide reste ouvert sur le nouveau projet. Lancé depuis
+n'importe quel sous-répertoire d'un projet Arclith, il retrouve automatiquement
+la racine et affiche :
+
+- les entités détectées dans le domaine ;
+- les ports inbound existants ;
+- les features applicatives déclarées ;
+- les adapters réellement installés ;
+- les anomalies de manifeste ou de recette.
+
+Le menu permet ensuite d'ajouter une entité, un cas d'usage ou n'importe quel
+adapter du catalogue, puis d'exposer un cas d'usage via FastAPI, FastMCP,
+LangGraph ou RabbitMQ. Une action impossible reste désactivée tant que ses
+prérequis ne sont pas présents.
+
+La CLI ne peut pas changer le répertoire courant du shell parent. À la fin d'une
+création, elle affiche donc la commande `cd <projet>` à copier ; sa propre session
+utilise immédiatement le nouveau projet sans demander de relancer la CLI.
+
+## Écritures sûres et recette
+
+Le plan d'un nouveau projet est exécuté dans un répertoire temporaire situé sur
+le même système de fichiers. La cible finale n'apparaît qu'après la réussite de
+toutes les étapes. Une erreur ou une interruption nettoie le staging et ne laisse
+pas de projet partiel. Une cible existante n'est jamais remplacée.
+
+Chaque étape réussie alimente `arclith.recipe.yaml` avec les mêmes informations
+que sa commande directe : paramètres résolus, version et empreinte des
+blueprints, fichiers créés ou modifiés, et références de secrets sans leur
+valeur. Le menu « Rejouer une recette » reconstruit lui aussi une nouvelle cible
+par staging atomique et utilise le mode de compatibilité strict.
+
+## Inspection et automatisation
+
+Le tableau de bord est également disponible hors du guide :
+
+```bash
+arclith-cli status
+arclith-cli status --json
+arclith-cli doctor
+```
+
+`status` lit l'état courant du disque ; il ne suppose pas que la recette reflète
+encore exactement le projet. La sortie JSON est adaptée aux scripts. `doctor`
+retourne un code non nul si le projet est introuvable ou si un manifeste ou la
+recette est absent ou illisible.
+
+Pour retrouver toutes les options spécialisées, utilisez toujours :
+
+```bash
+arclith-cli --help
+arclith-cli <commande> --help
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,6 +23,20 @@ uv tool install arclith-cli
 arclith-cli version
 ```
 
+Pour le parcours recommandé dans un terminal, lancer simplement :
+
+```bash
+arclith-cli
+```
+
+Le guide persistant demande le résultat attendu, montre le plan complet avant
+toute écriture et continue dans le nouveau projet. Il couvre le socle minimal,
+l'API REST CRUD ou ciblée, FastMCP, LangGraph et RabbitMQ, sans rendre implicite
+le choix du repository ou du transport. Voir le
+[guide interactif Arclith CLI](cli-guide.md).
+
+Les commandes ci-dessous restent l'équivalent direct pour les scripts et la CI.
+
 Pour partir d'un projet vide de métier, utiliser `init`, puis ajouter explicitement les fichiers
 du cœur:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Le chemin hexagonal: foundations/hexagonal-flow.md
       - Modes runtime: foundations/runtime-modes.md
       - Recettes CLI: cli-recipe.md
+      - Guide interactif CLI: cli-guide.md
   - Blueprints:
       - Vue d'ensemble: blueprints.md
       - CRUD: blueprints/crud.md


### PR DESCRIPTION
## Pourquoi

La CLI fonctionnait comme une suite de commandes ponctuelles : après chaque scaffold, l'utilisateur devait connaître et relancer la commande suivante. Cette PR ajoute une session guidée persistante sans retirer les commandes directes ni rendre les choix techniques implicites.

## Ce qui change

- `arclith-cli` ouvre le guide dans un vrai TTY ; les pipes, scripts, CI et `TERM=dumb` conservent l'aide et un code de sortie 0.
- Six intentions complètes : socle minimal, API REST CRUD, API REST ciblée, FastMCP, LangGraph et RabbitMQ.
- Plan explicite et commandes équivalentes avant confirmation.
- Repository choisi séparément (`memory`, `mongodb`, `postgresql`) ; aucun adapter n'est déduit silencieusement.
- Création et replay complet par staging atomique, avec protection des cibles existantes.
- Tableau de bord persistant pour ajouter entités, cas d'usage, adapters et bindings.
- Parcours adapter avancé couvrant tout le catalogue, ses profils et paramètres ; secrets masqués dans le plan et la recette.
- Nouvelles commandes `status`, `status --json` et `doctor` fondées sur l'état réel du disque.
- Documentation dédiée et quickstart mis à jour.

## Architecture

Le contrôleur interactif dépend d'une interface de prompt testable. La collecte des réponses, la planification sans effets de bord, l'exécution, le rendu, l'inspection et le replay sont séparés. Les écritures réutilisent les générateurs Arclith existants et chaque étape enregistre les mêmes métadonnées de recette que la commande directe.

## Validation

- 386 tests CLI
- 2 299 tests framework réussis, 5 intégrations externes ignorées
- couverture globale 91,19 % (seuil 90 %)
- Ruff, mypy (CLI et framework), Bandit et complexité : OK
- MkDocs `--strict` : OK
- build wheel + sdist pour `arclith` et `arclith-cli` : OK
- smoke TTY réel : ouverture, création, persistance du menu et sortie
- projet REST CRUD consommateur : `uv sync`, 8 tests générés, FastAPI `POST /v1/products` = 201 et OpenAPI vérifié
