### PR TITLE
feat(cli): lancer les transports d’un projet généré

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   passent par un staging nettoyé en cas d'échec et refusent toute cible existante.
 - **État et diagnostic** — `status`, `status --json` et `doctor` inspectent les
   entités, cas d'usage, features, adapters et métadonnées réellement présents.
+- **Runtime projet** — `arclith-cli run api` synchronise avec `uv`, valide le
+  transport installé et lance le point d'entrée généré en avant-plan ; les modes
+  MCP, bus et multi-transport sont exposés selon les adapters présents.
 
 ### Changed
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -41,7 +41,14 @@ Le projet courant peut aussi être inspecté sans ouvrir le menu :
 arclith-cli status
 arclith-cli status --json
 arclith-cli doctor
+arclith-cli run api
 ```
+
+`run` retrouve la racine du projet, vérifie le transport installé, synchronise
+l'environnement avec `uv` et conserve le runtime en avant-plan. Les modes
+`mcp_http`, `mcp_sse`, `bus` et `all` sont proposés lorsque leurs adapters sont
+présents. Les logs et le code de sortie restent ceux du processus généré ;
+`Ctrl+C` l'arrête normalement.
 
 La documentation complète est disponible dans le
 [guide interactif](https://karned-rekipe.github.io/arclith/cli-guide/).

--- a/cli/arclith_cli/init_project.py
+++ b/cli/arclith_cli/init_project.py
@@ -157,7 +157,7 @@ arclith-cli expose-usecase create-todo --via fastapi --feature todos \\
   --path /v1/todos --method POST --status-code 201
 uv sync
 uv run python -m pytest
-MODE=api uv run python main.py
+arclith-cli run api
 ```
 
 Le parcours fonctionne immédiatement avec les seuls champs techniques de

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -31,6 +31,7 @@ from .guide import guide_command, run_interactive_guide, should_launch_guide
 from .init_project import init_project_cmd
 from .new_project import new_project_cmd as _new_project_cmd
 from .project_status_cli import doctor_command, status_command
+from .project_runtime_cli import run_command
 from .recipe import (
     adapter_secret_metadata,
     snapshot_project_files,
@@ -57,6 +58,7 @@ app.command(name="add-blueprint")(add_blueprint_command)
 app.command(name="guide")(guide_command)
 app.command(name="status")(status_command)
 app.command(name="doctor")(doctor_command)
+app.command(name="run")(run_command)
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")

--- a/cli/arclith_cli/project_runtime.py
+++ b/cli/arclith_cli/project_runtime.py
@@ -1,0 +1,134 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import yaml
+
+from arclith_cli.guide_models import ProjectOverview
+from arclith_cli.guide_status import find_project_root, inspect_project
+
+
+class ProjectRuntimeError(ValueError):
+    """Raised when a generated project cannot run the requested transport."""
+
+
+class RuntimeMode(StrEnum):
+    API = "api"
+    MCP_HTTP = "mcp_http"
+    MCP_SSE = "mcp_sse"
+    BUS = "bus"
+    ALL = "all"
+
+
+@dataclass(frozen=True)
+class RuntimeCommand:
+    root: Path
+    project_name: str
+    mode: RuntimeMode
+    argv: tuple[str, ...]
+    environment: tuple[tuple[str, str], ...]
+    endpoint: str | None
+
+    def display(self) -> str:
+        assignments = " ".join(f"{key}={value}" for key, value in self.environment)
+        command = " ".join(self.argv)
+        return f"{assignments} {command}".strip()
+
+    def process_environment(
+        self,
+        base: Mapping[str, str] = os.environ,
+    ) -> dict[str, str]:
+        environment = dict(base)
+        environment.update(self.environment)
+        return environment
+
+
+def available_runtime_modes(overview: ProjectOverview) -> tuple[RuntimeMode, ...]:
+    """Return runnable modes inferred from installed transport manifests."""
+    adapters = set(overview.adapters)
+    modes: list[RuntimeMode] = []
+    if "api/fastapi" in adapters:
+        modes.append(RuntimeMode.API)
+    if "mcp/fastmcp" in adapters:
+        modes.extend((RuntimeMode.MCP_HTTP, RuntimeMode.MCP_SSE))
+    if "command-bus/rabbitmq" in adapters:
+        modes.append(RuntimeMode.BUS)
+    if {"api/fastapi", "mcp/fastmcp"}.issubset(adapters):
+        modes.append(RuntimeMode.ALL)
+    return tuple(modes)
+
+
+def resolve_runtime_command(
+    directory: Path,
+    mode: RuntimeMode,
+) -> RuntimeCommand:
+    """Build the foreground command for one generated-project runtime."""
+    root = find_project_root(directory)
+    if root is None:
+        raise ProjectRuntimeError(
+            f"Projet Arclith introuvable depuis : {directory.absolute()}"
+        )
+    overview = inspect_project(root)
+    if mode not in available_runtime_modes(overview):
+        available = ", ".join(item.value for item in available_runtime_modes(overview))
+        suffix = available or "aucun transport exécutable"
+        raise ProjectRuntimeError(
+            f"Mode {mode.value!r} indisponible pour {overview.name}. "
+            f"Modes détectés : {suffix}."
+        )
+    if not (root / "main.py").is_file():
+        raise ProjectRuntimeError(f"Point d'entrée absent : {root / 'main.py'}")
+    if shutil.which("uv") is None:
+        raise ProjectRuntimeError(
+            "La commande 'uv' est requise pour synchroniser et lancer le projet."
+        )
+    return RuntimeCommand(
+        root=root,
+        project_name=overview.name,
+        mode=mode,
+        argv=("uv", "run", "python", "main.py"),
+        environment=(("MODE", mode.value),),
+        endpoint=_runtime_endpoint(root, mode),
+    )
+
+
+def run_foreground(command: RuntimeCommand) -> None:
+    """Run a project in the foreground and preserve its native terminal output."""
+    subprocess.run(
+        command.argv,
+        check=True,
+        cwd=command.root,
+        env=command.process_environment(),
+    )
+
+
+def _runtime_endpoint(root: Path, mode: RuntimeMode) -> str | None:
+    if mode in {RuntimeMode.API, RuntimeMode.ALL}:
+        return _http_endpoint(root / "config/adapters/inbound/fastapi.yaml")
+    if mode in {RuntimeMode.MCP_HTTP, RuntimeMode.MCP_SSE}:
+        return _http_endpoint(root / "config/adapters/inbound/fastmcp.yaml")
+    return None
+
+
+def _http_endpoint(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ProjectRuntimeError(
+            f"Configuration runtime invalide ({path}) : {exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise ProjectRuntimeError(f"Configuration runtime invalide : {path}")
+    host = raw.get("host")
+    port = raw.get("port")
+    if not isinstance(host, str) or not isinstance(port, int | str):
+        raise ProjectRuntimeError(f"Host ou port runtime invalide : {path}")
+    unspecified_hosts = {".".join(("0", "0", "0", "0")), "::"}
+    display_host = "127.0.0.1" if host in unspecified_hosts else host
+    return f"http://{display_host}:{port}"

--- a/cli/arclith_cli/project_runtime_cli.py
+++ b/cli/arclith_cli/project_runtime_cli.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import subprocess
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from arclith_cli.project_runtime import (
+    ProjectRuntimeError,
+    RuntimeMode,
+    resolve_runtime_command,
+    run_foreground,
+)
+
+console = Console()
+
+
+def run_command(
+    mode: Annotated[
+        RuntimeMode,
+        typer.Argument(help="Runtime à lancer : api, mcp_http, mcp_sse, bus ou all."),
+    ] = RuntimeMode.API,
+    directory: Annotated[
+        Path,
+        typer.Option("--dir", "-d", help="Racine ou sous-répertoire du projet."),
+    ] = Path("."),
+) -> None:
+    """Synchroniser puis lancer un transport du projet en avant-plan."""
+    try:
+        command = resolve_runtime_command(directory, mode)
+        console.print(
+            f"[bold cyan]▶ {command.project_name}[/bold cyan] "
+            f"[dim]({command.mode.value})[/dim]"
+        )
+        if command.endpoint is not None:
+            console.print(f"[green]↗ {command.endpoint}[/green]")
+        console.print(f"[dim]$ {command.display()}[/dim]")
+        console.print("[dim]Ctrl+C pour arrêter.[/dim]")
+        run_foreground(command)
+    except ProjectRuntimeError as exc:
+        console.print(f"[bold red]✗ {exc}[/bold red]")
+        raise typer.Exit(1) from exc
+    except subprocess.CalledProcessError as exc:
+        console.print(
+            f"[bold red]✗ Le runtime s'est arrêté avec le code {exc.returncode}.[/bold red]"
+        )
+        raise typer.Exit(exc.returncode) from exc
+    except KeyboardInterrupt as exc:
+        console.print("\n[yellow]■ Runtime arrêté.[/yellow]")
+        raise typer.Exit(130) from exc

--- a/cli/tests/test_project_runtime.py
+++ b/cli/tests/test_project_runtime.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+from typer.testing import CliRunner
+
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import (
+    NewProjectAnswers,
+    ProjectIntent,
+    ProjectOverview,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.main import app
+from arclith_cli.project_runtime import (
+    ProjectRuntimeError,
+    RuntimeCommand,
+    RuntimeMode,
+    available_runtime_modes,
+    resolve_runtime_command,
+    run_foreground,
+)
+
+runner = CliRunner()
+
+
+def _api_project(tmp_path: Path) -> Path:
+    plan = plan_new_project(
+        NewProjectAnswers(
+            parent_dir=tmp_path,
+            project_name="runtime-service",
+            intent=ProjectIntent.API_CRUD,
+            entity="Product",
+            usecase=None,
+            repository=RepositoryChoice.MEMORY,
+            transport_port=8765,
+            public_path="/v1/products",
+        )
+    )
+    return execute_project_plan(plan).root
+
+
+def test_available_runtime_modes_follow_installed_transports(tmp_path: Path) -> None:
+    overview = ProjectOverview(
+        root=tmp_path,
+        name="runtime-service",
+        package="runtime_service",
+        entities=(),
+        usecases=(),
+        features=(),
+        adapters=("api/fastapi", "mcp/fastmcp", "command-bus/rabbitmq"),
+        issues=(),
+    )
+
+    assert available_runtime_modes(overview) == (
+        RuntimeMode.API,
+        RuntimeMode.MCP_HTTP,
+        RuntimeMode.MCP_SSE,
+        RuntimeMode.BUS,
+        RuntimeMode.ALL,
+    )
+
+
+def test_resolve_runtime_command_uses_project_config(tmp_path: Path) -> None:
+    project = _api_project(tmp_path)
+
+    command = resolve_runtime_command(project / "src/runtime_service", RuntimeMode.API)
+
+    assert command.root == project
+    assert command.argv == ("uv", "run", "python", "main.py")
+    assert command.environment == (("MODE", "api"),)
+    assert command.endpoint == "http://127.0.0.1:8765"
+    assert command.display() == "MODE=api uv run python main.py"
+
+
+def test_resolve_runtime_command_rejects_missing_transport(tmp_path: Path) -> None:
+    project = _api_project(tmp_path)
+
+    with pytest.raises(ProjectRuntimeError, match="mcp_http.*indisponible"):
+        resolve_runtime_command(project, RuntimeMode.MCP_HTTP)
+
+
+def test_run_foreground_preserves_project_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    command = RuntimeCommand(
+        root=tmp_path,
+        project_name="runtime-service",
+        mode=RuntimeMode.API,
+        argv=("uv", "run", "python", "main.py"),
+        environment=(("MODE", "api"),),
+        endpoint="http://127.0.0.1:8000",
+    )
+
+    run_foreground(command)
+
+    assert captured["args"] == (command.argv,)
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["check"] is True
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["env"]["MODE"] == "api"
+
+
+def test_run_command_launches_api_from_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _api_project(tmp_path)
+    launched: list[RuntimeCommand] = []
+    monkeypatch.setattr(
+        "arclith_cli.project_runtime_cli.run_foreground",
+        launched.append,
+    )
+
+    result = runner.invoke(app, ["run", "api", "--dir", str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert len(launched) == 1
+    assert launched[0].mode == RuntimeMode.API
+    assert "runtime-service" in result.output
+    assert "http://127.0.0.1:8765" in result.output
+    assert "Ctrl+C" in result.output
+
+
+def test_run_command_propagates_runtime_exit_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _api_project(tmp_path)
+
+    def fail(_command: RuntimeCommand) -> None:
+        raise subprocess.CalledProcessError(7, ["uv"])
+
+    monkeypatch.setattr("arclith_cli.project_runtime_cli.run_foreground", fail)
+
+    result = runner.invoke(app, ["run", "api", "--dir", str(project)])
+
+    assert result.exit_code == 7
+    assert "code 7" in result.output

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -100,6 +100,36 @@ encore exactement le projet. La sortie JSON est adaptée aux scripts. `doctor`
 retourne un code non nul si le projet est introuvable ou si un manifeste ou la
 recette est absent ou illisible.
 
+## Lancer le projet
+
+La CLI peut aussi synchroniser l'environnement du projet et lancer un transport
+en avant-plan :
+
+```bash
+arclith-cli run api
+```
+
+La commande retrouve la racine depuis n'importe quel sous-répertoire, vérifie
+que l'adapter correspondant est réellement installé, puis exécute le point
+d'entrée généré avec `uv`. Le host, le port et le reload restent définis dans
+`config/adapters/inbound/fastapi.yaml`; `run` n'introduit pas de seconde
+configuration. L'URL locale est affichée avant le démarrage et `Ctrl+C` arrête
+le processus.
+
+Les autres modes du point d'entrée généré sont également disponibles lorsqu'ils
+ont leurs adapters :
+
+```bash
+arclith-cli run mcp_http
+arclith-cli run mcp_sse
+arclith-cli run bus
+arclith-cli run all
+```
+
+Le processus reste volontairement attaché au terminal : la CLI ne crée ni
+daemon caché, ni fichier PID global, ni runtime concurrent. Cette propriété
+garantit une propagation normale des logs, du code de sortie et des signaux.
+
 Pour retrouver toutes les options spécialisées, utilisez toujours :
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,6 +49,7 @@ arclith-cli add-adapter --capability repository --adapter memory --yes
 arclith-cli add-adapter --capability api --adapter fastapi --param port=8765 --yes
 arclith-cli expose-usecase create-todo --via fastapi --feature todos \
   --path /v1/todos --method POST --status-code 201
+arclith-cli run api
 ```
 
 `init` n'installe aucun transport. La commande `add-adapter` ci-dessus ajoute le
@@ -67,6 +68,10 @@ arclith-cli expose-feature todo --via fastapi --path /v1/todos
 Le profil crée le cœur applicatif ; `expose-feature` constitue la décision
 séparée qui publie ses cinq opérations sur l'adapter déjà installé. Consulter le
 [blueprint CRUD](blueprints/crud.md) pour le contrat HTTP et ses erreurs.
+
+`arclith-cli run api` exécute `uv run` dans la racine détectée et conserve le
+serveur en avant-plan jusqu'à `Ctrl+C`. Le port et le reload restent pilotés par
+la configuration FastAPI générée.
 
 Chaque commande mutante réussie enrichit `arclith.recipe.yaml`. Ce fichier
 versionné conserve les décisions de scaffolding sans remplacer Git et sans


### PR DESCRIPTION
## Pourquoi

Le guide pouvait construire et diagnostiquer un projet, mais il rendait encore la main à l’utilisateur pour démarrer son API ou ses autres transports.

## Quoi

- ajoute `arclith-cli run api` en avant-plan ;
- détecte la racine depuis un sous-répertoire et valide les adapters installés ;
- prend en charge `api`, `mcp_http`, `mcp_sse`, `bus` et `all` ;
- réutilise le `main.py` et la configuration générés via `uv run` ;
- affiche l’URL locale et propage logs, code de sortie et `Ctrl+C` ;
- documente le parcours et le recommande dans les nouveaux projets.

## Validation

- 392 tests CLI ;
- 2307 tests framework, 5 skipped, couverture 91,19 % ;
- Ruff, mypy (69 modules CLI), Bandit, Radon, pre-commit et MkDocs strict ;
- smoke réel : projet CRUD neuf, API sur le port 8876, OpenAPI accessible, arrêt Uvicorn propre par `Ctrl+C`.