### PR TITLE
feat(cli): add full-screen project cockpit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ### Added
 
+- **Cockpit plein écran** — l'appel `arclith-cli` et la commande explicite `tui`
+  ouvrent une interface Textual moderne pour créer ou ouvrir un projet, prévisualiser
+  son plan, suivre sa génération et inspecter son état réel.
+- **Contrôle runtime intégré** — le tableau de bord détecte les transports
+  installés, diffuse leurs logs et permet démarrage, arrêt et redémarrage sans
+  laisser de processus enfant après la fermeture.
 - **Guide projet persistant** — `arclith-cli` ouvre dans un vrai terminal un
-  menu contextuel pour créer un socle minimal, une API CRUD ou ciblée, un
+  cockpit contextuel pour créer un socle minimal, une API CRUD ou ciblée, un
   serveur MCP, un agent LangGraph ou un worker RabbitMQ, puis continuer à faire
   évoluer le projet sans relancer la CLI.
 - **Plans auditables et génération atomique** — chaque parcours affiche ses
@@ -19,6 +25,9 @@
 
 ### Changed
 
+- **Guide compact préservé** — `arclith-cli guide` conserve le parcours
+  Questionary et l'accès à toutes les mutations avancées du catalogue depuis le
+  cockpit.
 - **Compatibilité non interactive préservée** — sans TTY, dans une CI ou avec
   `TERM=dumb`, la commande racine continue d'afficher l'aide avec succès ; les
   commandes directes restent disponibles et le guide ne crée aucun adapter

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Framework Python 3.13 pour construire des microservices hexagonaux avec domaine,
 adapters, FastAPI, FastMCP, bus, canaux conversationnels, agents, configuration, observabilité et
 runtime Docker.
 
-Pour construire un projet pas à pas dans une session guidée, lancez
-`uvx --from arclith-cli arclith-cli` sans argument. Les commandes directes
-restent disponibles pour les scripts et la CI.
+Pour construire puis piloter un projet sans quitter le terminal, lancez
+`uvx --from arclith-cli arclith-cli` sans argument : le cockpit plein écran
+guide la création, inspecte le projet et démarre ses runtimes avec leurs logs.
+Les commandes directes restent disponibles pour les scripts et la CI.
 
 ```bash
 uvx --from arclith-cli arclith-cli init my-service --dir .
 cd my-service
 uv sync
-MODE=api uv run python main.py
+uvx --from arclith-cli arclith-cli run api
 curl -fsS http://127.0.0.1:9000/health
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,25 +11,29 @@ implicite.
 uv tool install "git+https://github.com/karned-rekipe/arclith.git#subdirectory=cli"
 ```
 
-## Guide interactif
+## Cockpit plein écran
 
-Exécuter `arclith-cli` sans argument dans un vrai terminal ouvre une session
-persistante. Le guide propose un résultat (socle minimal, API CRUD, API sur
+Exécuter `arclith-cli` sans argument dans un vrai terminal ouvre une TUI
+persistante. Le cockpit propose un résultat (socle minimal, API CRUD, API sur
 mesure, serveur MCP, agent LangGraph ou worker RabbitMQ), collecte uniquement
 les décisions nécessaires, affiche le plan et les commandes équivalentes, puis
 demande confirmation avant d'écrire :
 
 ```bash
 arclith-cli
-# ou explicitement
+# ou explicitement pour la TUI
+arclith-cli tui
+# interface Questionary compacte et catalogue avancé
 arclith-cli guide
 ```
 
-Après la création, le menu reste ouvert sur le projet afin d'ajouter une entité,
-un cas d'usage, un adapter ou une exposition sans relancer la CLI. Une création
-ou un replay complet utilise un staging atomique : la cible finale n'apparaît
-qu'après la réussite de toutes les étapes et une cible existante n'est jamais
-écrasée.
+Après la création, le cockpit ouvre le tableau de bord du projet. Il affiche les
+entités, use cases, features, adapters et diagnostics, puis permet de démarrer,
+arrêter ou redémarrer les transports disponibles avec leurs logs. Le bouton
+« Guide complet » rejoint l'interface compacte pour les mutations avancées du
+catalogue. Une création ou un replay complet utilise un staging atomique : la
+cible finale n'apparaît qu'après la réussite de toutes les étapes et une cible
+existante n'est jamais écrasée.
 
 Dans un pipe, un script, une CI ou avec `TERM=dumb`, l'appel sans argument reste
 non interactif : il affiche l'aide et termine avec succès. Toutes les commandes

--- a/cli/arclith_cli/main.py
+++ b/cli/arclith_cli/main.py
@@ -27,7 +27,7 @@ from .command_recording import record_success as _record_success
 from .core_scaffold import add_intent_interpreter_cmd, add_usecase_cmd
 from .export_config import export_config_cmd
 from .feature_projection_cli import expose_feature_command
-from .guide import guide_command, run_interactive_guide, should_launch_guide
+from .guide import guide_command, should_launch_guide
 from .init_project import init_project_cmd
 from .new_project import new_project_cmd as _new_project_cmd
 from .project_status_cli import doctor_command, status_command
@@ -38,6 +38,7 @@ from .recipe import (
 )
 from .recipe_cli import history_command, replay_command
 from .scaffold_interactive import resolve_usecase_entity_choice
+from .tui import run_tui, tui_command
 from .updater import run_update
 
 app = typer.Typer(
@@ -59,6 +60,7 @@ app.command(name="guide")(guide_command)
 app.command(name="status")(status_command)
 app.command(name="doctor")(doctor_command)
 app.command(name="run")(run_command)
+app.command(name="tui")(tui_command)
 
 _ENTITY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
@@ -66,10 +68,10 @@ _PROJECT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 
 @app.callback()
 def main(ctx: typer.Context) -> None:
-    """Lancer le guide dans un terminal, sinon afficher l'aide stable."""
+    """Lancer le cockpit dans un terminal, sinon afficher l'aide stable."""
     if ctx.invoked_subcommand is None:
         if should_launch_guide():
-            run_interactive_guide()
+            run_tui()
         else:
             typer.echo(ctx.get_help())
 

--- a/cli/arclith_cli/tui.py
+++ b/cli/arclith_cli/tui.py
@@ -1,0 +1,590 @@
+from pathlib import Path
+
+import typer
+from rich.markup import escape
+from rich.text import Text
+from textual import events, work
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    Label,
+    ProgressBar,
+    RichLog,
+    Select,
+    Static,
+)
+
+from arclith_cli.guide import run_interactive_guide
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    GuideStep,
+    ProjectIntent,
+    ProjectOverview,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.guide_status import find_project_root, inspect_project
+from arclith_cli.project_runtime import (
+    ProjectRuntimeError,
+    RuntimeCommand,
+    RuntimeMode,
+    available_runtime_modes,
+    resolve_runtime_command,
+)
+from arclith_cli.tui_models import ProjectDraft, render_plan
+from arclith_cli.tui_runtime import ManagedRuntime
+
+
+_INTENT_OPTIONS = (
+    ("API REST CRUD", ProjectIntent.API_CRUD.value),
+    ("API REST sur mesure", ProjectIntent.API_CUSTOM.value),
+    ("Serveur MCP", ProjectIntent.MCP.value),
+    ("Agent LangGraph", ProjectIntent.AGENT.value),
+    ("Worker RabbitMQ", ProjectIntent.WORKER.value),
+    ("Socle minimal", ProjectIntent.MINIMAL.value),
+)
+_REPOSITORY_OPTIONS = (
+    ("Mémoire — rapide et non persistant", RepositoryChoice.MEMORY.value),
+    ("MongoDB — documentaire asynchrone", RepositoryChoice.MONGODB.value),
+    ("PostgreSQL — JSONB et transactions", RepositoryChoice.POSTGRESQL.value),
+)
+_RUNTIME_LABELS = {
+    RuntimeMode.API: "API FastAPI",
+    RuntimeMode.MCP_HTTP: "MCP HTTP",
+    RuntimeMode.MCP_SSE: "MCP SSE",
+    RuntimeMode.BUS: "Worker RabbitMQ",
+    RuntimeMode.ALL: "API + MCP",
+}
+
+
+class WelcomeScreen(Screen[None]):
+    BINDINGS = [
+        ("n", "new_project", "Nouveau projet"),
+        ("g", "classic_guide", "Guide complet"),
+    ]
+
+    def __init__(self, start_dir: Path) -> None:
+        super().__init__()
+        self._start_dir = start_dir
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Vertical(id="welcome-shell"):
+            yield Static("◈", id="welcome-mark")
+            yield Label("ARCLITH", id="welcome-title")
+            yield Static(
+                "Construire, inspecter et exécuter un service hexagonal\n"
+                "sans quitter le terminal.",
+                id="welcome-copy",
+            )
+            yield Button("Nouveau projet", id="new-project", variant="primary")
+            yield Button("Guide complet", id="classic-guide")
+            yield Label("Ouvrir un projet existant", classes="field-label")
+            yield Input(value=str(self._start_dir), id="open-project-path")
+            yield Button("Ouvrir", id="open-project")
+            yield Static("", id="welcome-error", classes="error-message")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#new-project", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "new-project":
+            self.action_new_project()
+        elif event.button.id == "open-project":
+            self._open_project()
+        elif event.button.id == "classic-guide":
+            self.action_classic_guide()
+
+    def action_new_project(self) -> None:
+        self.app.push_screen(
+            ProjectWizardScreen(self._start_dir),
+            self._project_created,
+        )
+
+    def action_classic_guide(self) -> None:
+        self.app.exit(self._start_dir)
+
+    def _open_project(self) -> None:
+        raw_path = self.query_one("#open-project-path", Input).value.strip()
+        path = Path(raw_path).expanduser()
+        root = find_project_root(path)
+        if root is None:
+            self.query_one("#welcome-error", Static).update(
+                f"Projet Arclith introuvable depuis {escape(str(path.absolute()))}."
+            )
+            return
+        self.app.switch_screen(ProjectDashboardScreen(root))
+
+    def _project_created(self, root: Path | None) -> None:
+        if root is not None:
+            self.app.switch_screen(ProjectDashboardScreen(root))
+
+
+class ProjectWizardScreen(Screen[Path | None]):
+    BINDINGS = [("escape", "cancel", "Retour")]
+
+    def __init__(self, parent_dir: Path) -> None:
+        super().__init__()
+        self._parent_dir = parent_dir
+        self._busy = False
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="wizard-shell"):
+            with Vertical(id="wizard-sidebar"):
+                yield Label("NOUVEAU PROJET", classes="section-title")
+                yield Static("●  Intention", classes="wizard-step is-active")
+                yield Static("○  Domaine", classes="wizard-step")
+                yield Static("○  Stockage", classes="wizard-step")
+                yield Static("○  Transport", classes="wizard-step")
+                yield Static("○  Vérification", classes="wizard-step")
+                yield Static(
+                    "Le plan est calculé par le même moteur que les commandes directes.",
+                    id="wizard-note",
+                )
+            with VerticalScroll(id="wizard-form"):
+                yield Static("CRÉATION GUIDÉE", classes="eyebrow")
+                yield Label("Configurer le service", id="wizard-title")
+                yield Static(
+                    "Toutes les décisions restent modifiables avant l’écriture atomique.",
+                    classes="lead",
+                )
+                yield Label("Résultat attendu", classes="field-label")
+                yield Select(
+                    _INTENT_OPTIONS,
+                    value=ProjectIntent.API_CRUD.value,
+                    allow_blank=False,
+                    id="intent",
+                )
+                yield Label("Répertoire parent", classes="field-label")
+                yield Input(value=str(self._parent_dir), id="parent-dir")
+                yield Label("Nom du projet", classes="field-label")
+                yield Input(value="catalog-service", id="project-name")
+                with Vertical(id="entity-field", classes="form-field"):
+                    yield Label("Première entité", classes="field-label")
+                    yield Input(value="Product", id="entity")
+                with Vertical(id="usecase-field", classes="form-field"):
+                    yield Label("Premier cas d’usage", classes="field-label")
+                    yield Input(value="CreateProduct", id="usecase")
+                with Vertical(id="repository-field", classes="form-field"):
+                    yield Label("Repository explicite", classes="field-label")
+                    yield Select(
+                        _REPOSITORY_OPTIONS,
+                        value=RepositoryChoice.MEMORY.value,
+                        allow_blank=False,
+                        id="repository",
+                    )
+                with Vertical(id="port-field", classes="form-field"):
+                    yield Label("Port", classes="field-label")
+                    yield Input(value="8000", id="port", type="integer")
+                with Vertical(id="path-field", classes="form-field"):
+                    yield Label("Chemin HTTP", classes="field-label")
+                    yield Input(value="/v1/products", id="public-path")
+                yield Static("", id="wizard-error", classes="error-message")
+                with Horizontal(classes="action-row"):
+                    yield Button("Retour", id="cancel-project")
+                    yield Button(
+                        "Créer le projet", id="create-project", variant="primary"
+                    )
+                yield ProgressBar(total=1, show_eta=False, id="creation-progress")
+            with VerticalScroll(id="plan-panel"):
+                yield Label("PLAN DE GÉNÉRATION", classes="section-title")
+                yield Static("", id="plan-preview")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#creation-progress", ProgressBar).display = False
+        self._refresh_intent_fields()
+        self._refresh_plan()
+        self.query_one("#project-name", Input).focus()
+
+    def on_resize(self, event: events.Resize) -> None:
+        self.query_one("#wizard-sidebar", Vertical).display = event.size.width >= 100
+        self.query_one("#plan-panel", VerticalScroll).display = event.size.width >= 72
+
+    def on_input_changed(self, _event: Input.Changed) -> None:
+        self._refresh_plan()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if event.select.id == "intent":
+            self._refresh_intent_fields()
+        self._refresh_plan()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel-project":
+            self.action_cancel()
+        elif event.button.id == "create-project":
+            self._request_creation()
+
+    def action_cancel(self) -> None:
+        if self._busy:
+            self.notify(
+                "La génération atomique est en cours.",
+                severity="warning",
+            )
+            return
+        self.dismiss(None)
+
+    def _refresh_intent_fields(self) -> None:
+        intent = self._intent()
+        api = intent in {ProjectIntent.API_CRUD, ProjectIntent.API_CUSTOM}
+        self.query_one("#usecase-field", Vertical).display = intent not in {
+            ProjectIntent.MINIMAL,
+            ProjectIntent.API_CRUD,
+        }
+        self.query_one("#repository-field", Vertical).display = (
+            intent != ProjectIntent.MINIMAL
+        )
+        self.query_one("#port-field", Vertical).display = (
+            api or intent == ProjectIntent.MCP
+        )
+        self.query_one("#path-field", Vertical).display = api
+        if intent == ProjectIntent.MCP:
+            port = self.query_one("#port", Input)
+            if port.value == "8000":
+                port.value = "8001"
+        elif api:
+            port = self.query_one("#port", Input)
+            if port.value == "8001":
+                port.value = "8000"
+
+    def _refresh_plan(self) -> None:
+        if not self.is_mounted:
+            return
+        try:
+            preview = render_plan(self._draft().plan())
+        except (GuidePlanError, OSError, ValueError) as exc:
+            preview = f"[yellow]Plan incomplet[/yellow]\n\n{escape(str(exc))}"
+        self.query_one("#plan-preview", Static).update(preview)
+
+    def _request_creation(self) -> None:
+        try:
+            plan = self._draft().plan()
+        except (GuidePlanError, OSError, ValueError) as exc:
+            self.query_one("#wizard-error", Static).update(escape(str(exc)))
+            return
+        self.query_one("#wizard-error", Static).update("")
+        self._set_busy(True)
+        self._create_project(plan)
+
+    @work(thread=True, exclusive=True, group="project-creation")
+    def _create_project(self, plan: ProjectPlan) -> None:
+        try:
+            result = execute_project_plan(plan, on_step=self._on_creation_step)
+        except (GuidePlanError, OSError, SyntaxError, ValueError, typer.Exit) as exc:
+            message = str(exc) or "Une étape Arclith a été refusée."
+            self.app.call_from_thread(self._creation_failed, message)
+            return
+        self.app.call_from_thread(self._creation_succeeded, result.root)
+
+    def _on_creation_step(self, index: int, total: int, step: GuideStep) -> None:
+        self.app.call_from_thread(
+            self._update_creation_progress, index, total, step.title
+        )
+
+    def _update_creation_progress(self, index: int, total: int, title: str) -> None:
+        progress = self.query_one("#creation-progress", ProgressBar)
+        progress.update(total=total, progress=index - 1)
+        self.query_one("#wizard-error", Static).update(
+            f"[cyan]{index}/{total}[/cyan] {escape(title)}"
+        )
+
+    def _creation_failed(self, message: str) -> None:
+        self._set_busy(False)
+        self.query_one("#wizard-error", Static).update(f"[red]{escape(message)}[/red]")
+
+    def _creation_succeeded(self, root: Path) -> None:
+        progress = self.query_one("#creation-progress", ProgressBar)
+        progress.update(progress=progress.total)
+        self.notify(f"Projet créé : {root.name}", title="Arclith")
+        self.dismiss(root)
+
+    def _set_busy(self, busy: bool) -> None:
+        self._busy = busy
+        self.query_one("#create-project", Button).disabled = busy
+        self.query_one("#cancel-project", Button).disabled = busy
+        self.query_one("#creation-progress", ProgressBar).display = busy
+
+    def _draft(self) -> ProjectDraft:
+        return ProjectDraft(
+            parent_dir=self.query_one("#parent-dir", Input).value,
+            project_name=self.query_one("#project-name", Input).value,
+            intent=self._intent(),
+            entity=self.query_one("#entity", Input).value,
+            usecase=self.query_one("#usecase", Input).value,
+            repository=RepositoryChoice(
+                str(self.query_one("#repository", Select).value)
+            ),
+            port=self.query_one("#port", Input).value,
+            public_path=self.query_one("#public-path", Input).value,
+        )
+
+    def _intent(self) -> ProjectIntent:
+        return ProjectIntent(str(self.query_one("#intent", Select).value))
+
+
+class ProjectDashboardScreen(Screen[None]):
+    BINDINGS = [
+        ("r", "refresh_project", "Actualiser"),
+        ("s", "start_runtime", "Démarrer"),
+        ("x", "stop_runtime", "Arrêter"),
+        ("n", "new_project", "Nouveau"),
+        ("g", "classic_guide", "Guide complet"),
+        ("q", "request_quit", "Quitter"),
+    ]
+
+    def __init__(self, project_root: Path) -> None:
+        super().__init__()
+        self._project_root = project_root
+        self._overview: ProjectOverview | None = None
+        self._runtime = ManagedRuntime()
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="dashboard-shell"):
+            with Vertical(id="project-sidebar"):
+                yield Static("◈  ARCLITH", id="project-brand")
+                yield Button("Vue projet", id="nav-project", variant="primary")
+                yield Button("Nouveau projet", id="nav-new")
+                yield Button("Guide complet", id="nav-guide")
+                yield Button("Actualiser", id="nav-refresh")
+                yield Static("", id="project-location")
+            with VerticalScroll(id="project-content"):
+                yield Static("PROJET COURANT", classes="eyebrow")
+                yield Label("", id="project-title")
+                yield Static("", id="project-summary", classes="lead")
+                with Horizontal(id="project-metrics"):
+                    yield Static("", id="metric-entities", classes="metric")
+                    yield Static("", id="metric-usecases", classes="metric")
+                    yield Static("", id="metric-adapters", classes="metric")
+                yield Label("Runtime local", classes="content-title")
+                with Horizontal(id="runtime-toolbar"):
+                    yield Select([], prompt="Aucun transport", id="runtime-mode")
+                    yield Button("Démarrer", id="runtime-start", variant="success")
+                    yield Button("Redémarrer", id="runtime-restart")
+                    yield Button("Arrêter", id="runtime-stop", variant="error")
+                yield Static("Inactif", id="runtime-status")
+                yield RichLog(
+                    id="runtime-log",
+                    wrap=True,
+                    markup=True,
+                    max_lines=1000,
+                )
+            with VerticalScroll(id="project-plan"):
+                yield Label("ÉTAT DU PROJET", classes="section-title")
+                yield Static("", id="project-details")
+                yield Label("Diagnostic", classes="content-title")
+                yield Static("", id="project-doctor")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.call_after_refresh(self._refresh_project)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "nav-new":
+            self.action_new_project()
+        elif event.button.id == "nav-refresh":
+            self.action_refresh_project()
+        elif event.button.id == "nav-guide":
+            self.run_worker(self.action_classic_guide(), group="runtime-control")
+        elif event.button.id == "runtime-start":
+            self.action_start_runtime()
+        elif event.button.id == "runtime-restart":
+            self.run_worker(
+                self._restart_runtime(), exclusive=True, group="runtime-control"
+            )
+        elif event.button.id == "runtime-stop":
+            self.action_stop_runtime()
+
+    def action_refresh_project(self) -> None:
+        self._refresh_project()
+        self.notify("État du projet actualisé.", title="Arclith")
+
+    def action_new_project(self) -> None:
+        if self._runtime.is_running:
+            self.notify(
+                "Arrêtez le runtime avant de changer de projet.", severity="warning"
+            )
+            return
+        self.app.push_screen(
+            ProjectWizardScreen(self._project_root.parent),
+            self._project_created,
+        )
+
+    async def action_classic_guide(self) -> None:
+        await self._runtime.stop()
+        self.app.exit(self._project_root)
+
+    def action_start_runtime(self) -> None:
+        if self._runtime.is_running:
+            self.notify("Un runtime est déjà actif.", severity="warning")
+            return
+        try:
+            mode = RuntimeMode(str(self.query_one("#runtime-mode", Select).value))
+            command = resolve_runtime_command(self._project_root, mode)
+        except (ProjectRuntimeError, ValueError) as exc:
+            self._set_runtime_status(f"[red]{escape(str(exc))}[/red]", running=False)
+            return
+        log = self.query_one("#runtime-log", RichLog)
+        log.clear()
+        log.write(f"[cyan]$ {escape(command.display())}[/cyan]")
+        if command.endpoint is not None:
+            log.write(f"[green]↗ {escape(command.endpoint)}[/green]")
+        self._set_runtime_status(
+            f"[green]● Démarrage de {escape(_RUNTIME_LABELS[mode])}…[/green]",
+            running=True,
+        )
+        self._run_runtime(command)
+
+    def action_stop_runtime(self) -> None:
+        self.run_worker(self._stop_runtime(), exclusive=True, group="runtime-control")
+
+    async def action_request_quit(self) -> None:
+        await self._runtime.stop()
+        self.app.exit()
+
+    async def on_unmount(self) -> None:
+        await self._runtime.stop()
+
+    def on_resize(self, event: events.Resize) -> None:
+        self.query_one("#project-sidebar", Vertical).display = event.size.width >= 100
+        self.query_one("#project-plan", VerticalScroll).display = event.size.width >= 72
+
+    @work(exclusive=True, group="project-runtime")
+    async def _run_runtime(self, command: RuntimeCommand) -> None:
+        try:
+            return_code = await self._runtime.run(command, self._write_runtime_line)
+        except (OSError, RuntimeError) as exc:
+            self.query_one("#runtime-log", RichLog).write(
+                f"[red]{escape(str(exc))}[/red]"
+            )
+            self._set_runtime_status("[red]● Échec du runtime[/red]", running=False)
+            return
+        if return_code == 0:
+            status = "[green]● Runtime terminé[/green]"
+        elif return_code in {-2, 130}:
+            status = "[yellow]■ Runtime arrêté[/yellow]"
+        else:
+            status = f"[red]● Runtime terminé avec le code {return_code}[/red]"
+        self._set_runtime_status(status, running=False)
+
+    async def _stop_runtime(self) -> None:
+        if not self._runtime.is_running:
+            return
+        self.query_one("#runtime-log", RichLog).write(
+            "[yellow]■ Arrêt demandé…[/yellow]"
+        )
+        self._set_runtime_status("[yellow]■ Arrêt en cours…[/yellow]", running=True)
+        if await self._runtime.stop():
+            self._set_runtime_status("[yellow]■ Runtime arrêté[/yellow]", running=False)
+
+    async def _restart_runtime(self) -> None:
+        await self._runtime.stop()
+        self.action_start_runtime()
+
+    def _write_runtime_line(self, line: str) -> None:
+        self.query_one("#runtime-log", RichLog).write(Text.from_ansi(line))
+
+    def _set_runtime_status(self, content: str, *, running: bool) -> None:
+        self.query_one("#runtime-status", Static).update(content)
+        self.query_one("#runtime-start", Button).disabled = running
+        self.query_one("#runtime-stop", Button).disabled = not running
+        self.query_one("#runtime-restart", Button).disabled = not running
+
+    def _refresh_project(self) -> None:
+        self._overview = inspect_project(self._project_root)
+        overview = self._overview
+        self.query_one("#project-title", Label).update(escape(overview.name))
+        self.query_one("#project-summary", Static).update(
+            f"[dim]{escape(str(overview.root))}[/dim]\nPackage [cyan]{escape(overview.package)}[/cyan]"
+        )
+        self.query_one("#project-location", Static).update(
+            f"[dim]{escape(str(overview.root))}[/dim]"
+        )
+        self.query_one("#metric-entities", Static).update(
+            f"[b]{len(overview.entities)}[/b]\n[dim]Entités[/dim]"
+        )
+        self.query_one("#metric-usecases", Static).update(
+            f"[b]{len(overview.usecases)}[/b]\n[dim]Use cases[/dim]"
+        )
+        self.query_one("#metric-adapters", Static).update(
+            f"[b]{len(overview.adapters)}[/b]\n[dim]Adapters[/dim]"
+        )
+        self.query_one("#project-details", Static).update(
+            self._project_details(overview)
+        )
+        self.query_one("#project-doctor", Static).update(self._doctor_text(overview))
+        self._refresh_runtime_choices(overview)
+
+    def _refresh_runtime_choices(self, overview: ProjectOverview) -> None:
+        modes = available_runtime_modes(overview)
+        select = self.query_one("#runtime-mode", Select)
+        select.set_options([(_RUNTIME_LABELS[mode], mode.value) for mode in modes])
+        select.disabled = not modes
+        start = self.query_one("#runtime-start", Button)
+        start.disabled = not modes or self._runtime.is_running
+        if modes:
+            select.value = modes[0].value
+        self.query_one("#runtime-stop", Button).disabled = not self._runtime.is_running
+        self.query_one(
+            "#runtime-restart", Button
+        ).disabled = not self._runtime.is_running
+
+    @staticmethod
+    def _project_details(overview: ProjectOverview) -> str:
+        entities = ", ".join(overview.entities) or "—"
+        features = ", ".join(item.name for item in overview.features) or "—"
+        adapters = "\n".join(f"  • {item}" for item in overview.adapters) or "  —"
+        return (
+            f"[dim]Entités[/dim]\n{escape(entities)}\n\n"
+            f"[dim]Features[/dim]\n{escape(features)}\n\n"
+            f"[dim]Adapters[/dim]\n{escape(adapters)}"
+        )
+
+    @staticmethod
+    def _doctor_text(overview: ProjectOverview) -> str:
+        if not overview.issues:
+            return "[green]✓ Structure, manifestes et recette lisibles[/green]"
+        return "\n".join(
+            f"[yellow]• {escape(issue)}[/yellow]" for issue in overview.issues
+        )
+
+    def _project_created(self, root: Path | None) -> None:
+        if root is not None:
+            self.app.switch_screen(ProjectDashboardScreen(root))
+
+
+class ArclithTui(App[Path | None]):
+    CSS_PATH = "tui.tcss"
+    TITLE = "Arclith CLI"
+    SUB_TITLE = "Project cockpit"
+
+    def __init__(self, start_dir: Path) -> None:
+        super().__init__()
+        self._start_dir = start_dir
+
+    def on_mount(self) -> None:
+        root = find_project_root(self._start_dir)
+        if root is None:
+            self.push_screen(WelcomeScreen(self._start_dir))
+        else:
+            self.push_screen(ProjectDashboardScreen(root))
+
+
+def run_tui(start_dir: Path | None = None) -> None:
+    """Run the full-screen project cockpit in the current terminal."""
+    selected_dir = ArclithTui((start_dir or Path.cwd()).absolute()).run()
+    if selected_dir is not None:
+        run_interactive_guide(start_dir=selected_dir)
+
+
+def tui_command() -> None:
+    """Ouvrir le cockpit projet plein écran."""
+    run_tui()

--- a/cli/arclith_cli/tui.tcss
+++ b/cli/arclith_cli/tui.tcss
@@ -1,0 +1,297 @@
+$background: #090d12;
+$surface: #10161d;
+$surface-lighten-1: #151d26;
+$boost: #202936;
+$primary: #9383ff;
+$primary-lighten-1: #aa9dff;
+$primary-darken-1: #7563e8;
+$success: #55d8ae;
+$warning: #f0bc58;
+$error: #ff6b78;
+$text: #edf4fb;
+$text-muted: #8e9cab;
+$border: #27313d;
+
+Screen {
+    background: $background;
+    color: $text;
+}
+
+WelcomeScreen {
+    align-horizontal: center;
+}
+
+Header {
+    background: $surface;
+    color: $text;
+}
+
+Footer {
+    background: $surface-lighten-1;
+    color: $text-muted;
+}
+
+Button {
+    min-width: 16;
+    height: 3;
+    border: none;
+    background: $boost;
+    color: $text;
+}
+
+Button:hover {
+    background: $primary-darken-1;
+}
+
+Button.-primary {
+    background: $primary;
+    color: $background;
+}
+
+Button.-success {
+    background: $success;
+    color: $background;
+}
+
+Button.-error {
+    background: $error;
+    color: $background;
+}
+
+Input, Select {
+    height: 3;
+    border: tall $border;
+    background: $surface;
+    color: $text;
+}
+
+Input:focus, Select:focus {
+    border: tall $primary;
+}
+
+.section-title {
+    color: $text-muted;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+.eyebrow {
+    color: $primary-lighten-1;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+.lead {
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+.field-label {
+    color: $text-muted;
+    margin-top: 1;
+}
+
+.content-title {
+    margin-top: 1;
+    margin-bottom: 1;
+    text-style: bold;
+}
+
+.error-message {
+    min-height: 1;
+    color: $error;
+    margin-top: 1;
+}
+
+.action-row {
+    height: 4;
+    align-horizontal: right;
+    margin-top: 1;
+}
+
+.action-row Button {
+    margin-left: 1;
+}
+
+#welcome-shell {
+    width: 62;
+    height: auto;
+    max-height: 30;
+    margin: 4 0;
+    padding: 2 5;
+    background: $surface;
+    border: round $border;
+    align-horizontal: center;
+}
+
+#welcome-mark {
+    width: 7;
+    height: 3;
+    content-align: center middle;
+    background: $primary;
+    color: $background;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#welcome-title {
+    width: 100%;
+    text-align: center;
+    text-style: bold;
+}
+
+#welcome-copy {
+    width: 100%;
+    color: $text-muted;
+    text-align: center;
+    margin: 1 0 2 0;
+}
+
+#welcome-shell Input {
+    width: 100%;
+}
+
+#welcome-shell Button {
+    margin: 1 0;
+}
+
+#wizard-shell, #dashboard-shell {
+    height: 1fr;
+}
+
+#wizard-sidebar, #project-sidebar {
+    width: 25;
+    min-width: 22;
+    padding: 2 1;
+    background: $surface;
+    border-right: tall $border;
+}
+
+.wizard-step {
+    height: 3;
+    padding: 1;
+    color: $text-muted;
+}
+
+.wizard-step.is-active {
+    background: $boost;
+    color: $primary-lighten-1;
+    text-style: bold;
+}
+
+#wizard-note {
+    dock: bottom;
+    color: $text-muted;
+    padding: 1;
+}
+
+#wizard-form {
+    width: 1fr;
+    min-width: 42;
+    padding: 2 3;
+}
+
+#wizard-title, #project-title {
+    height: auto;
+    text-style: bold;
+    color: $text;
+}
+
+#wizard-title {
+    text-style: bold;
+}
+
+.form-field {
+    height: auto;
+}
+
+#plan-panel, #project-plan {
+    width: 40;
+    min-width: 32;
+    padding: 2;
+    background: $surface;
+    border-left: tall $border;
+}
+
+#plan-preview {
+    color: $text-muted;
+}
+
+#creation-progress {
+    margin-top: 1;
+}
+
+#project-brand {
+    height: 3;
+    padding: 1;
+    color: $primary-lighten-1;
+    text-style: bold;
+    margin-bottom: 2;
+}
+
+#project-sidebar Button {
+    width: 100%;
+    margin-bottom: 1;
+}
+
+#project-location {
+    dock: bottom;
+    padding: 1;
+    color: $text-muted;
+}
+
+#project-content {
+    width: 1fr;
+    min-width: 48;
+    padding: 2 3;
+}
+
+#project-summary {
+    height: auto;
+}
+
+#project-metrics {
+    height: 6;
+    margin: 1 0;
+}
+
+.metric {
+    width: 1fr;
+    height: 5;
+    padding: 1 2;
+    margin-right: 1;
+    background: $surface;
+    border: round $border;
+}
+
+#runtime-toolbar {
+    height: 4;
+}
+
+#runtime-mode {
+    width: 1fr;
+    margin-right: 1;
+}
+
+#runtime-toolbar Button {
+    margin-left: 1;
+}
+
+#runtime-status {
+    height: 2;
+    padding-left: 1;
+    color: $text-muted;
+}
+
+#runtime-log {
+    height: 1fr;
+    min-height: 12;
+    padding: 1;
+    background: $surface;
+    border: round $border;
+}
+
+#project-details, #project-doctor {
+    height: auto;
+    color: $text-muted;
+}

--- a/cli/arclith_cli/tui_models.py
+++ b/cli/arclith_cli/tui_models.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from rich.markup import escape
+
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    NewProjectAnswers,
+    ProjectIntent,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project, shell_command
+
+
+@dataclass(frozen=True)
+class ProjectDraft:
+    parent_dir: str
+    project_name: str
+    intent: ProjectIntent
+    entity: str
+    usecase: str
+    repository: RepositoryChoice
+    port: str
+    public_path: str
+
+    def plan(self) -> ProjectPlan:
+        """Validate the form state through the shared headless planner."""
+        minimal = self.intent == ProjectIntent.MINIMAL
+        api = self.intent in {ProjectIntent.API_CRUD, ProjectIntent.API_CUSTOM}
+        mcp = self.intent == ProjectIntent.MCP
+        return plan_new_project(
+            NewProjectAnswers(
+                parent_dir=Path(self.parent_dir).expanduser(),
+                project_name=self.project_name.strip(),
+                intent=self.intent,
+                entity=self.entity.strip() or None,
+                usecase=(
+                    self.usecase.strip()
+                    if not minimal and self.intent != ProjectIntent.API_CRUD
+                    else None
+                ),
+                repository=None if minimal else self.repository,
+                transport_port=self._port() if api or mcp else None,
+                public_path=self.public_path.strip() if api else None,
+            )
+        )
+
+    def _port(self) -> int:
+        value = self.port.strip()
+        if not value.isdecimal():
+            raise GuidePlanError("Le port doit être un entier entre 1 et 65535.")
+        return int(value)
+
+
+def render_plan(plan: ProjectPlan) -> str:
+    """Render a compact, auditable plan for the full-screen preview."""
+    step_label = "étape" if len(plan.steps) == 1 else "étapes"
+    lines = [
+        f"[b]{len(plan.steps)} {step_label}[/b] · aucune écriture effectuée",
+        "",
+    ]
+    lines.extend(
+        f"[dim]{index:>2}[/dim]  {escape(step.title)}\n"
+        f"    [cyan]{escape(shell_command(step))}[/cyan]"
+        for index, step in enumerate(plan.steps, start=1)
+    )
+    return "\n".join(lines)

--- a/cli/arclith_cli/tui_runtime.py
+++ b/cli/arclith_cli/tui_runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Callable
+from contextlib import suppress
 import os
 import signal
 
@@ -47,17 +48,13 @@ class ManagedRuntime:
         process = self._process
         if process is None or process.returncode is not None:
             return False
-        try:
+        with suppress(ProcessLookupError):
             self._interrupt(process)
-        except ProcessLookupError:
-            pass
         try:
             await asyncio.wait_for(process.wait(), timeout=timeout)
         except TimeoutError:
-            try:
+            with suppress(ProcessLookupError):
                 self._kill(process)
-            except ProcessLookupError:
-                pass
             await process.wait()
         if self._process is process:
             self._process = None

--- a/cli/arclith_cli/tui_runtime.py
+++ b/cli/arclith_cli/tui_runtime.py
@@ -1,0 +1,78 @@
+import asyncio
+from collections.abc import Callable
+import os
+import signal
+
+from arclith_cli.project_runtime import RuntimeCommand
+
+RuntimeLineSink = Callable[[str], None]
+
+
+class ManagedRuntime:
+    """Own exactly one child runtime and its complete process group."""
+
+    def __init__(self) -> None:
+        self._process: asyncio.subprocess.Process | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.returncode is None
+
+    async def run(self, command: RuntimeCommand, on_line: RuntimeLineSink) -> int:
+        """Start a runtime, stream merged output, and wait for its completion."""
+        if self.is_running:
+            raise RuntimeError("Un runtime Arclith est déjà actif.")
+        process = await asyncio.create_subprocess_exec(
+            *command.argv,
+            cwd=command.root,
+            env=command.process_environment(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=os.name == "posix",
+        )
+        self._process = process
+        assert process.stdout is not None
+        try:
+            while line := await process.stdout.readline():
+                on_line(line.decode(errors="replace").rstrip())
+            return await process.wait()
+        finally:
+            if self._process is process:
+                if process.returncode is None:
+                    await self.stop()
+                self._process = None
+
+    async def stop(self, *, timeout: float = 5.0) -> bool:
+        """Stop the owned process group and escalate only after a grace period."""
+        process = self._process
+        if process is None or process.returncode is not None:
+            return False
+        try:
+            self._interrupt(process)
+        except ProcessLookupError:
+            pass
+        try:
+            await asyncio.wait_for(process.wait(), timeout=timeout)
+        except TimeoutError:
+            try:
+                self._kill(process)
+            except ProcessLookupError:
+                pass
+            await process.wait()
+        if self._process is process:
+            self._process = None
+        return True
+
+    @staticmethod
+    def _interrupt(process: asyncio.subprocess.Process) -> None:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGINT)
+            return
+        process.terminate()
+
+    @staticmethod
+    def _kill(process: asyncio.subprocess.Process) -> None:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        process.kill()

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -15,10 +15,11 @@ authors = [
 keywords = ["arclith", "scaffold", "hexagonal-architecture", "cli", "ddd"]
 dependencies = [
     "typer>=0.15.0",
-    "rich>=13.0.0",
+    "rich>=14.2.0,<15.0.0",
     "httpx>=0.27.0",
     "arclith>=0.27.0",
     "questionary>=2.1.1,<3.0.0",
+    "textual>=8.2.8,<9.0.0",
 ]
 
 [tool.uv.sources]

--- a/cli/tests/test_tui.py
+++ b/cli/tests/test_tui.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button, Select, Static
+
+from arclith_cli.guide_executor import execute_project_plan
+from arclith_cli.guide_models import (
+    NewProjectAnswers,
+    ProjectIntent,
+    RepositoryChoice,
+)
+from arclith_cli.guide_planner import plan_new_project
+from arclith_cli.tui import (
+    ArclithTui,
+    ProjectDashboardScreen,
+    ProjectWizardScreen,
+    WelcomeScreen,
+)
+from arclith_cli.project_runtime import RuntimeCommand
+from arclith_cli.tui_runtime import ManagedRuntime, RuntimeLineSink
+
+
+def _api_project(tmp_path: Path) -> Path:
+    return execute_project_plan(
+        plan_new_project(
+            NewProjectAnswers(
+                parent_dir=tmp_path,
+                project_name="tui-service",
+                intent=ProjectIntent.API_CRUD,
+                entity="Product",
+                usecase=None,
+                repository=RepositoryChoice.MEMORY,
+                transport_port=8765,
+                public_path="/v1/products",
+            )
+        )
+    ).root
+
+
+@pytest.mark.asyncio
+async def test_tui_opens_welcome_then_project_wizard(tmp_path: Path) -> None:
+    app = ArclithTui(tmp_path)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, WelcomeScreen)
+
+        await pilot.press("n")
+        await pilot.pause()
+
+        assert isinstance(app.screen, ProjectWizardScreen)
+        preview = str(app.screen.query_one("#plan-preview", Static).render())
+        assert "5 étapes" in preview
+        assert "expose-feature" in preview
+
+
+@pytest.mark.asyncio
+async def test_wizard_creates_project_and_opens_dashboard(tmp_path: Path) -> None:
+    app = ArclithTui(tmp_path)
+
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+        wizard = app.screen
+        assert isinstance(wizard, ProjectWizardScreen)
+        wizard.query_one("#create-project", Button).press()
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if isinstance(app.screen, ProjectDashboardScreen):
+                break
+        await pilot.pause()
+
+        assert isinstance(app.screen, ProjectDashboardScreen)
+        assert (tmp_path / "catalog-service/arclith.recipe.yaml").is_file()
+        assert app.screen.query_one("#runtime-mode", Select).value == "api"
+
+
+@pytest.mark.asyncio
+async def test_wizard_cannot_close_during_atomic_generation(tmp_path: Path) -> None:
+    app = ArclithTui(tmp_path)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+        wizard = app.screen
+        assert isinstance(wizard, ProjectWizardScreen)
+        wizard._set_busy(True)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert app.screen is wizard
+
+
+@pytest.mark.asyncio
+async def test_dashboard_discovers_runtime_and_streams_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _api_project(tmp_path)
+
+    async def fake_run(
+        self: ManagedRuntime,
+        _command: RuntimeCommand,
+        on_line: RuntimeLineSink,
+    ) -> int:
+        del self, _command
+        on_line("Application startup complete")
+        return 0
+
+    monkeypatch.setattr(ManagedRuntime, "run", fake_run)
+    app = ArclithTui(project)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, ProjectDashboardScreen)
+
+        await pilot.press("s")
+        for _ in range(20):
+            await pilot.pause(0.05)
+            status = str(app.screen.query_one("#runtime-status", Static).render())
+            if "terminé" in status:
+                break
+
+        assert "Runtime terminé" in status
+
+
+@pytest.mark.asyncio
+async def test_dashboard_hides_secondary_panels_in_narrow_terminal(
+    tmp_path: Path,
+) -> None:
+    app = ArclithTui(_api_project(tmp_path))
+
+    async with app.run_test(size=(70, 30)) as pilot:
+        await pilot.pause()
+
+        assert app.screen.query_one("#project-sidebar").display is False
+        assert app.screen.query_one("#project-plan").display is False
+
+
+@pytest.mark.asyncio
+async def test_dashboard_restores_controls_after_runtime_stop(
+    tmp_path: Path,
+) -> None:
+    project = _api_project(tmp_path)
+    app = ArclithTui(project)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        dashboard = app.screen
+        assert isinstance(dashboard, ProjectDashboardScreen)
+        dashboard._runtime = _RuntimeStub()  # type: ignore[assignment]
+
+        await dashboard._stop_runtime()
+
+        assert dashboard.query_one("#runtime-start", Button).disabled is False
+        assert dashboard.query_one("#runtime-stop", Button).disabled is True
+        status = str(dashboard.query_one("#runtime-status", Static).render())
+        assert "Runtime arrêté" in status
+
+
+class _RuntimeStub:
+    is_running = True
+
+    async def stop(self) -> bool:
+        self.is_running = False
+        return True

--- a/cli/tests/test_tui_models.py
+++ b/cli/tests/test_tui_models.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pytest
+
+from arclith_cli.guide_models import (
+    GuidePlanError,
+    GuideStep,
+    ProjectIntent,
+    ProjectPlan,
+    RepositoryChoice,
+)
+from arclith_cli.tui_models import ProjectDraft, render_plan
+
+
+def _draft(
+    tmp_path: Path,
+    *,
+    project_name: str = "catalog-service",
+    intent: ProjectIntent = ProjectIntent.API_CRUD,
+    entity: str = "Product",
+    port: str = "8765",
+) -> ProjectDraft:
+    return ProjectDraft(
+        parent_dir=str(tmp_path),
+        project_name=project_name,
+        intent=intent,
+        entity=entity,
+        usecase="CreateProduct",
+        repository=RepositoryChoice.MEMORY,
+        port=port,
+        public_path="/v1/products",
+    )
+
+
+def test_project_draft_builds_api_plan(tmp_path: Path) -> None:
+    plan = _draft(tmp_path).plan()
+
+    assert plan.target_dir == tmp_path / "catalog-service"
+    assert [step.command for step in plan.steps] == [
+        "init",
+        "add-entity",
+        "add-adapter",
+        "add-adapter",
+        "expose-feature",
+    ]
+    assert plan.steps[3].args["params"] == {"port": "8765"}
+
+
+def test_project_draft_keeps_minimal_choices_optional(tmp_path: Path) -> None:
+    plan = _draft(
+        tmp_path,
+        intent=ProjectIntent.MINIMAL,
+        entity="",
+        port="not-used",
+    ).plan()
+
+    assert [step.command for step in plan.steps] == ["init"]
+
+
+def test_project_draft_validates_runtime_port(tmp_path: Path) -> None:
+    with pytest.raises(GuidePlanError, match="port doit être un entier"):
+        _draft(tmp_path, port="eight-thousand").plan()
+
+
+def test_render_plan_escapes_user_controlled_markup(tmp_path: Path) -> None:
+    plan = ProjectPlan(
+        target_dir=tmp_path / "catalog-service",
+        intent=ProjectIntent.MINIMAL,
+        steps=(
+            GuideStep(
+                title="Initialiser [service]",
+                command="init",
+                args={},
+                argv=("init", "catalog-service"),
+            ),
+        ),
+        creates_project=True,
+    )
+
+    rendered = render_plan(plan)
+
+    assert "\\[service]" in rendered
+    assert "1 étape" in rendered

--- a/cli/tests/test_tui_runtime.py
+++ b/cli/tests/test_tui_runtime.py
@@ -1,0 +1,52 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+from arclith_cli.project_runtime import RuntimeCommand, RuntimeMode
+from arclith_cli.tui_runtime import ManagedRuntime
+
+
+def _command(tmp_path: Path, code: str) -> RuntimeCommand:
+    return RuntimeCommand(
+        root=tmp_path,
+        project_name="runtime-service",
+        mode=RuntimeMode.API,
+        argv=(sys.executable, "-u", "-c", code),
+        environment=(("MODE", "api"),),
+        endpoint=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_managed_runtime_streams_output(tmp_path: Path) -> None:
+    runtime = ManagedRuntime()
+    lines: list[str] = []
+
+    return_code = await runtime.run(_command(tmp_path, "print('ready')"), lines.append)
+
+    assert return_code == 0
+    assert lines == ["ready"]
+    assert runtime.is_running is False
+
+
+@pytest.mark.asyncio
+async def test_managed_runtime_stops_its_process_group(tmp_path: Path) -> None:
+    runtime = ManagedRuntime()
+    task = asyncio.create_task(
+        runtime.run(
+            _command(tmp_path, "import time; print('ready'); time.sleep(30)"),
+            lambda _line: None,
+        )
+    )
+    for _ in range(100):
+        if runtime.is_running:
+            break
+        await asyncio.sleep(0.01)
+
+    assert runtime.is_running is True
+    assert await runtime.stop(timeout=1.0) is True
+    await asyncio.wait_for(task, timeout=2.0)
+    assert runtime.is_running is False
+    assert await runtime.stop() is False

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -202,6 +202,7 @@ dependencies = [
     { name = "httpx" },
     { name = "questionary" },
     { name = "rich" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
@@ -218,7 +219,8 @@ requires-dist = [
     { name = "arclith", editable = "../" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "questionary", specifier = ">=2.1.1,<3.0.0" },
-    { name = "rich", specifier = ">=13.0.0" },
+    { name = "rich", specifier = ">=14.2.0,<15.0.0" },
+    { name = "textual", specifier = ">=8.2.8,<9.0.0" },
     { name = "typer", specifier = ">=0.15.0" },
 ]
 
@@ -1346,6 +1348,15 @@ otel = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
 name = "logfire-api"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1390,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "mcp"
 version = "1.26.0"
@@ -1402,6 +1418,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -2357,6 +2385,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,25 +1,53 @@
-# Guide interactif Arclith CLI
+# Cockpit et guide interactif Arclith CLI
 
-Le guide interactif transforme la CLI en session persistante : vous choisissez
-le résultat attendu, Arclith construit un plan complet, affiche les commandes
-équivalentes, puis attend une confirmation unique avant d'écrire.
+Le cockpit plein écran transforme la CLI en espace de travail persistant : vous
+choisissez le résultat attendu, Arclith construit un plan complet, affiche les
+commandes équivalentes, génère le projet, puis permet de l'inspecter et de lancer
+ses transports sans quitter l'interface.
 
 ```bash
 arclith-cli
 ```
 
-Dans un vrai terminal, cette commande ouvre le guide. Dans un pipe, un script,
+Dans un vrai terminal, cette commande ouvre la TUI plein écran. Dans un pipe, un script,
 une CI ou un terminal déclaré `TERM=dumb`, elle conserve le comportement
 non-interactif historique et affiche l'aide avec un code de sortie `0`. Pour
-ouvrir explicitement le guide :
+ouvrir explicitement le cockpit :
+
+```bash
+arclith-cli tui
+```
+
+Le guide Questionary historique reste disponible comme interface de repli et
+pour le catalogue avancé complet :
 
 ```bash
 arclith-cli guide
 ```
 
+## Interface plein écran
+
+La TUI repose sur des écrans distincts et conserve le moteur de planification
+indépendant de l'interface :
+
+- un accueil pour créer ou ouvrir un projet ;
+- un formulaire adaptatif couvrant les six intentions Arclith ;
+- un aperçu permanent du plan et des commandes directes ;
+- une progression visible pendant la génération atomique ;
+- un tableau de bord fondé sur l'état réel du disque ;
+- un cockpit runtime avec sélection du transport, logs, démarrage, arrêt et
+  redémarrage ;
+- une disposition réduite automatiquement dans les terminaux étroits ;
+- navigation clavier, footer de raccourcis et palette de commandes Textual.
+
+Les raccourcis principaux du tableau de bord sont `s` pour démarrer, `x` pour
+arrêter, `r` pour actualiser, `n` pour un nouveau projet, `g` pour le guide
+avancé et `q` pour quitter. Un runtime actif est arrêté avant la fermeture de
+l'application afin de ne pas laisser de processus orphelin.
+
 ## Créer par intention
 
-Le premier écran ne demande pas de connaître les commandes Arclith. Il propose
+L'écran de création ne demande pas de connaître les commandes Arclith. Il propose
 six résultats :
 
 | Intention | Cœur généré | Décisions techniques explicites | Exposition |
@@ -51,9 +79,9 @@ Ces commandes restent utilisables indépendamment dans un script. Les paramètre
 secrets éventuellement saisis dans le parcours avancé sont masqués dans le plan
 et dans `arclith.recipe.yaml`.
 
-## Continuer dans le même menu
+## Continuer dans le tableau de bord
 
-Après la création, le guide reste ouvert sur le nouveau projet. Lancé depuis
+Après la création, le cockpit reste ouvert sur le nouveau projet. Lancé depuis
 n'importe quel sous-répertoire d'un projet Arclith, il retrouve automatiquement
 la racine et affiche :
 
@@ -63,7 +91,7 @@ la racine et affiche :
 - les adapters réellement installés ;
 - les anomalies de manifeste ou de recette.
 
-Le menu permet ensuite d'ajouter une entité, un cas d'usage ou n'importe quel
+Le guide avancé permet ensuite d'ajouter une entité, un cas d'usage ou n'importe quel
 adapter du catalogue, puis d'exposer un cas d'usage via FastAPI, FastMCP,
 LangGraph ou RabbitMQ. Une action impossible reste désactivée tant que ses
 prérequis ne sont pas présents.
@@ -102,8 +130,9 @@ recette est absent ou illisible.
 
 ## Lancer le projet
 
-La CLI peut aussi synchroniser l'environnement du projet et lancer un transport
-en avant-plan :
+Le tableau de bord sélectionne les transports réellement installés et permet de
+les démarrer, arrêter ou redémarrer tout en conservant leurs logs dans un panneau
+dédié. La même opération reste disponible hors TUI, en avant-plan :
 
 ```bash
 arclith-cli run api

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,16 +23,17 @@ uv tool install arclith-cli
 arclith-cli version
 ```
 
-Pour le parcours recommandé dans un terminal, lancer simplement :
+Pour le parcours recommandé dans un terminal, lancer simplement le cockpit plein
+écran :
 
 ```bash
 arclith-cli
 ```
 
-Le guide persistant demande le résultat attendu, montre le plan complet avant
-toute écriture et continue dans le nouveau projet. Il couvre le socle minimal,
-l'API REST CRUD ou ciblée, FastMCP, LangGraph et RabbitMQ, sans rendre implicite
-le choix du repository ou du transport. Voir le
+La TUI demande le résultat attendu, montre le plan complet avant toute écriture,
+continue dans le nouveau projet et permet d'y démarrer l'API avec ses logs. Elle
+couvre le socle minimal, l'API REST CRUD ou ciblée, FastMCP, LangGraph et
+RabbitMQ, sans rendre implicite le choix du repository ou du transport. Voir le
 [guide interactif Arclith CLI](cli-guide.md).
 
 Les commandes ci-dessous restent l'équivalent direct pour les scripts et la CI.


### PR DESCRIPTION
## Pourquoi

Le guide persistant de la PR #230 améliore le parcours, mais reste une succession de prompts. Le projet a maintenant besoin d'un espace de travail plein écran qui permette aussi de piloter le runtime introduit par la PR #231.

## Ce que cette PR apporte

- remplace l'appel interactif sans argument par un cockpit Textual plein écran ;
- conserve `arclith-cli guide` comme interface compacte et accès au catalogue avancé ;
- ajoute un accueil pour créer ou ouvrir un projet existant ;
- ajoute un formulaire adaptatif pour les six intentions Arclith ;
- réutilise le planificateur et l'exécuteur headless existants, avec aperçu des commandes et génération atomique ;
- ajoute un tableau de bord calculé depuis l'état réel du projet ;
- permet de démarrer, arrêter et redémarrer les modes API, MCP, bus et combiné disponibles ;
- diffuse stdout/stderr dans un journal ANSI sécurisé et arrête le groupe de processus à la fermeture ;
- adapte automatiquement la disposition aux terminaux étroits ;
- préserve le comportement non interactif pour les pipes, la CI et `TERM=dumb` ;
- documente le cockpit, ses raccourcis et la commande runtime directe.

## Architecture

- `tui_models.py` adapte les valeurs d'interface au contrat `NewProjectAnswers` existant ;
- `tui_runtime.py` possède le cycle de vie d'un unique processus enfant ;
- `tui.py` reste un adapter Textual qui compose ces services et l'inspection projet existante ;
- aucune logique de scaffolding ou de détection de transport n'est dupliquée dans les widgets.

## Validation

- `uv run --project cli pytest -q cli/tests` : 404 tests réussis ;
- `make coverage` : 2 319 tests réussis, 5 ignorés, couverture 91,19 % ;
- Ruff format/check, mypy (72 modules CLI et 228 modules framework), Bandit sur les nouveaux modules, Radon et `make precommit` : OK ;
- `mkdocs build --strict` : OK ;
- lock CLI figé, sdist et wheel construits ; `tui.tcss` est présent dans la wheel ;
- installation isolée : commandes `tui`, `run` et `guide` exposées ;
- parcours réel : ouverture du cockpit dans un projet CRUD généré, lancement de l'API sur le port 8876, lecture de l'OpenAPI et des routes Product, arrêt depuis le cockpit, absence de listener résiduel.

## Hors périmètre

- migration de chaque formulaire avancé du catalogue Questionary vers des écrans Textual dédiés ; ils restent accessibles sans régression via « Guide complet » ;
- release ou publication PyPI.
